### PR TITLE
Phase 3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@ DATABASE_URL="file:./dev.db"
 # DATABASE_URL="postgresql://postgres:postgres@localhost:5432/family_recipe"
 # PRISMA_SCHEMA="prisma/schema.postgres.prisma"
 
+# For Cloud SQL dev (via Cloud SQL Auth Proxy):
+# DATABASE_URL="postgresql://family_app:DB_PASSWORD@127.0.0.1:5432/family_recipe_dev?sslmode=disable"
+# PRISMA_SCHEMA="prisma/schema.postgres.prisma"
+
 # JWT Secret
 # IMPORTANT: Generate a strong, random secret for production
 # Example: openssl rand -base64 32

--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,15 @@ Desktop.ini
 logs
 *.log
 
+# Terraform
+**/.terraform/*
+**/.terraform.lock.hcl
+**/terraform.tfstate
+**/terraform.tfstate.*
+**/*.tfvars
+**/*.tfvars.json
+tfplan.bin
+
 # Temporary files
 *.tmp
 *.temp

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Open [http://localhost:3000](http://localhost:3000).
 
 To run the monolith + Postgres in containers:
 
-1) Build and start:
+1. Build and start:
 
 ```
 docker compose up --build
@@ -107,13 +107,13 @@ docker compose up --build
 - Uploaded images persist via the bind mount `./public/uploads:/app/public/uploads`.
 - Migrations run on container start via `prisma migrate deploy --schema prisma/schema.postgres.prisma`.
 
-2) Re-run migrations manually (if needed):
+2. Re-run migrations manually (if needed):
 
 ```
 docker compose run --rm app npx prisma migrate deploy --schema prisma/schema.postgres.prisma
 ```
 
-3) Seed data (optional):
+3. Seed data (optional):
 
 ```
 docker compose exec app npm run db:seed
@@ -122,7 +122,7 @@ docker compose exec app npm run db:seed
 ### Local Development Options
 
 - **SQLite (default):** Use the `.env` defaults and `npm run dev`.
-- **Local Postgres without Docker:** Set `DATABASE_URL` to your Postgres URL and `PRISMA_SCHEMA=prisma/schema.postgres.prisma`, then run:
+- **Local Postgres without Docker:** Set `DATABASE_URL` to the Postgres URL and `PRISMA_SCHEMA=prisma/schema.postgres.prisma`, then run:
 
 ```
 npx prisma generate --schema prisma/schema.postgres.prisma
@@ -131,6 +131,34 @@ npm run dev
 ```
 
 Prisma migrations are generated for Postgres; stick to `prisma db push` for SQLite workflows.
+
+### Connecting to Cloud SQL (dev)
+
+- Run Cloud SQL Auth Proxy:
+
+```
+cloud-sql-proxy family-recipe-dev:us-east1:family-recipe-dev --port 5432
+```
+
+- Set `DATABASE_URL` using the Secret Manager password:
+
+```
+DATABASE_URL="postgresql://family_app:DB_PASSWORD@127.0.0.1:5432/family_recipe_dev?sslmode=disable"
+PRISMA_SCHEMA=prisma/schema.postgres.prisma
+```
+
+- Apply migrations and seed:
+
+```
+DATABASE_URL="postgresql://family_app:DB_PASSWORD@127.0.0.1:5432/family_recipe_dev?sslmode=disable" \
+PRISMA_SCHEMA=prisma/schema.postgres.prisma \
+npx prisma migrate deploy --schema prisma/schema.postgres.prisma
+
+DATABASE_URL="postgresql://family_app:DB_PASSWORD@127.0.0.1:5432/family_recipe_dev?sslmode=disable" \
+PRISMA_SCHEMA=prisma/schema.postgres.prisma \
+FAMILY_NAME="Family Recipe" FAMILY_MASTER_KEY="actual-master-key" \
+npm run db:seed
+```
 
 ---
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,57 @@
+# Infrastructure (dev) – GCP Cloud SQL
+
+This folder contains Terraform config for the **dev** environment only (`family-recipe-dev`). Prod will be handled separately (Phase 7). Structure:
+
+- `envs/dev/` – environment wiring and backend config
+- `modules/iam/` – service accounts + IAM bindings
+- `modules/sql_instance/` – Cloud SQL instance/db/user (+ optional Secret Manager secret)
+
+## Prereqs (one-time manual)
+
+1. GCP project: `family-recipe-dev`
+2. APIs enabled: Cloud SQL Admin, Service Networking, IAM, Secret Manager, Cloud Logging/Monitoring (Cloud Run + VPC Access later if needed).
+3. Remote state bucket: `family-recipe-tf-state-dev` (with versioning).
+4. Bootstrap credentials: used my user creds to run the initial apply. Terraform will create:
+
+## How to run Terraform (dev)
+
+```bash
+cd infra/envs/dev
+export GOOGLE_PROJECT=family-recipe-dev
+export TF_VAR_project_id=family-recipe-dev
+export TF_VAR_region=us-east1
+# Set DB user/password via tfvars or env; do not commit secrets.
+# Example: export TF_VAR_db_user=family_app; export TF_VAR_db_password='...'
+
+terraform init \
+  -backend-config="bucket=family-recipe-tf-state-dev" \
+  -backend-config="prefix=envs/dev/state"
+
+terraform plan
+terraform apply
+```
+
+## Outputs of interest
+
+- `instance_connection_name` – for Cloud SQL Proxy / Cloud Run connector.
+- `public_ip_address` – reachable via proxy or IP allowlist (dev only).
+- `database_name`, `database_user` – use with the secret-stored password to build `DATABASE_URL`.
+- Service accounts: terraform admin + app SQL client emails.
+- Secret Manager: `family-recipe-dev-db-password` (secret only; add a secret version manually to avoid storing the value in Terraform state).
+
+## Connecting (Cloud SQL Auth Proxy)
+
+```bash
+cloud-sql-proxy $(terraform output -raw instance_connection_name) --port 5432
+DATABASE_URL="postgresql://${DB_USER}:${DB_PASSWORD}@127.0.0.1:5432/family_recipe_dev?sslmode=disable"
+npx prisma migrate deploy --schema prisma/schema.postgres.prisma --url "$DATABASE_URL"
+PRISMA_SCHEMA=prisma/schema.postgres.prisma \
+FAMILY_NAME="Family Recipe" FAMILY_MASTER_KEY="actual-master-key" \
+npm run db:seed
+```
+
+## Notes
+
+- Backups: enabled, 7-day retention; maintenance window: Sunday 05:00 UTC.
+- Public IP only for now (simpler for local/Vercel). Private IP + VPC connector can be added later if moving to Cloud Run.
+- Secrets (DB password, optional family master key) should live in Secret Manager or local tfvars (not committed). I initially had to create a place holder in local tfvars, and then I updated the secret value manually in Secret Manager to avoid storing it in Terraform state. Now it is set to be ignored so that any future changes won't be stored in state.

--- a/infra/envs/dev/main.tf
+++ b/infra/envs/dev/main.tf
@@ -1,0 +1,48 @@
+terraform {
+  required_version = ">= 1.5.0"
+  backend "gcs" {}
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+module "iam" {
+  source = "../../modules/iam"
+
+  project_id                 = var.project_id
+  state_bucket_name          = var.state_bucket_name
+  terraform_admin_sa_id      = var.terraform_admin_sa_id
+  app_sql_client_sa_id       = var.app_sql_client_sa_id
+  grant_secret_accessor_to_app = var.grant_secret_accessor_to_app
+  secret_ids_for_app           = [var.db_password_secret_id]
+}
+
+module "sql_instance" {
+  source = "../../modules/sql_instance"
+
+  project_id                  = var.project_id
+  region                      = var.region
+  instance_name               = var.db_instance_name
+  db_name                     = var.db_name
+  db_user                     = var.db_user
+  db_password                 = var.db_password
+  tier                        = var.tier
+  disk_size_gb                = var.disk_size_gb
+  backup_retention_days       = var.backup_retention_days
+  maintenance_window_day      = var.maintenance_window_day
+  maintenance_window_hour     = var.maintenance_window_hour
+  pitr_enabled                = var.pitr_enabled
+  create_db_password_secret   = var.create_db_password_secret
+  db_password_secret_id       = var.db_password_secret_id
+
+  depends_on = [module.iam]
+}

--- a/infra/envs/dev/outputs.tf
+++ b/infra/envs/dev/outputs.tf
@@ -1,0 +1,23 @@
+output "instance_connection_name" {
+  value = module.sql_instance.instance_connection_name
+}
+
+output "public_ip_address" {
+  value = module.sql_instance.public_ip_address
+}
+
+output "database_name" {
+  value = module.sql_instance.database_name
+}
+
+output "database_user" {
+  value = module.sql_instance.database_user
+}
+
+output "terraform_admin_sa_email" {
+  value = module.iam.terraform_admin_sa_email
+}
+
+output "app_sql_client_sa_email" {
+  value = module.iam.app_sql_client_sa_email
+}

--- a/infra/envs/dev/terraform.tfvars.example
+++ b/infra/envs/dev/terraform.tfvars.example
@@ -1,0 +1,20 @@
+# Example values for dev environment. Do NOT commit real secrets.
+
+project_id              = "family-recipe-dev"
+region                  = "us-east1"
+state_bucket_name       = "family-recipe-tf-state-dev"
+terraform_admin_sa_id   = "terraform-admin"
+app_sql_client_sa_id    = "app-sql-client"
+db_instance_name        = "family-recipe-dev"
+db_name                 = "family_recipe_dev"
+db_user                 = "family_app"
+db_password             = "REPLACE_ME" # store real value outside git; consider using Secret Manager and adding versions manually
+db_password_secret_id   = "family-recipe-dev-db-password"
+tier                    = "db-custom-1-3840"
+disk_size_gb            = 20
+backup_retention_days   = 7
+maintenance_window_day  = 7  # Sunday (GCP expects 1-7; Sunday=7)
+maintenance_window_hour = 5  # 05:00 UTC
+pitr_enabled            = false
+create_db_password_secret = true
+grant_secret_accessor_to_app = false

--- a/infra/envs/dev/variables.tf
+++ b/infra/envs/dev/variables.tf
@@ -1,0 +1,106 @@
+variable "project_id" {
+  description = "GCP project ID for dev"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "us-east1"
+}
+
+variable "state_bucket_name" {
+  description = "GCS bucket for Terraform state"
+  type        = string
+  default     = "family-recipe-tf-state-dev"
+}
+
+variable "terraform_admin_sa_id" {
+  description = "Service account ID for Terraform admin"
+  type        = string
+  default     = "terraform-admin"
+}
+
+variable "app_sql_client_sa_id" {
+  description = "Service account ID for app Cloud SQL client"
+  type        = string
+  default     = "app-sql-client"
+}
+
+variable "db_instance_name" {
+  description = "Cloud SQL instance name"
+  type        = string
+  default     = "family-recipe-dev"
+}
+
+variable "db_name" {
+  description = "Database name"
+  type        = string
+  default     = "family_recipe_dev"
+}
+
+variable "db_user" {
+  description = "Application database user"
+  type        = string
+  default     = "family_app"
+}
+
+variable "db_password" {
+  description = "Application database password (sensitive)"
+  type        = string
+  sensitive   = true
+}
+
+variable "db_password_secret_id" {
+  description = "Secret Manager secret ID for DB password (secret resource only; add versions manually)"
+  type        = string
+  default     = "family-recipe-dev-db-password"
+}
+
+variable "tier" {
+  description = "Machine tier for Cloud SQL"
+  type        = string
+  default     = "db-custom-1-3840"
+}
+
+variable "disk_size_gb" {
+  description = "Disk size in GB"
+  type        = number
+  default     = 20
+}
+
+variable "backup_retention_days" {
+  description = "Automated backup retention (days)"
+  type        = number
+  default     = 7
+}
+
+variable "maintenance_window_day" {
+  description = "Maintenance window day (0 = Sunday, 1 = Monday, ...)"
+  type        = number
+  default     = 7
+}
+
+variable "maintenance_window_hour" {
+  description = "Maintenance window hour (0-23, UTC)"
+  type        = number
+  default     = 5
+}
+
+variable "pitr_enabled" {
+  description = "Enable point-in-time recovery (PITR)"
+  type        = bool
+  default     = false
+}
+
+variable "create_db_password_secret" {
+  description = "Create Secret Manager secret for DB password (no version)"
+  type        = bool
+  default     = true
+}
+
+variable "grant_secret_accessor_to_app" {
+  description = "Grant Secret Manager Secret Accessor to app SQL client SA for specified secrets"
+  type        = bool
+  default     = false
+}

--- a/infra/modules/iam/main.tf
+++ b/infra/modules/iam/main.tf
@@ -1,0 +1,48 @@
+resource "google_service_account" "terraform_admin" {
+  account_id   = var.terraform_admin_sa_id
+  display_name = "Terraform admin"
+  project      = var.project_id
+}
+
+resource "google_service_account" "app_sql_client" {
+  account_id   = var.app_sql_client_sa_id
+  display_name = "App Cloud SQL client"
+  project      = var.project_id
+}
+
+locals {
+  terraform_admin_roles = [
+    "roles/cloudsql.admin",
+    "roles/iam.serviceAccountAdmin",
+    "roles/secretmanager.admin",
+  ]
+}
+
+resource "google_project_iam_member" "terraform_admin_roles" {
+  for_each = toset(local.terraform_admin_roles)
+
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.terraform_admin.email}"
+}
+
+resource "google_project_iam_member" "app_sql_client_roles" {
+  project = var.project_id
+  role    = "roles/cloudsql.client"
+  member  = "serviceAccount:${google_service_account.app_sql_client.email}"
+}
+
+resource "google_storage_bucket_iam_member" "terraform_state_admin" {
+  count  = var.state_bucket_name != "" ? 1 : 0
+  bucket = var.state_bucket_name
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${google_service_account.terraform_admin.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "app_secret_accessor" {
+  for_each = var.grant_secret_accessor_to_app ? toset(var.secret_ids_for_app) : []
+
+  secret_id = each.value
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.app_sql_client.email}"
+}

--- a/infra/modules/iam/outputs.tf
+++ b/infra/modules/iam/outputs.tf
@@ -1,0 +1,7 @@
+output "terraform_admin_sa_email" {
+  value = google_service_account.terraform_admin.email
+}
+
+output "app_sql_client_sa_email" {
+  value = google_service_account.app_sql_client.email
+}

--- a/infra/modules/iam/variables.tf
+++ b/infra/modules/iam/variables.tf
@@ -1,0 +1,32 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "state_bucket_name" {
+  description = "GCS bucket for Terraform state (for granting storage admin to terraform SA)"
+  type        = string
+  default     = ""
+}
+
+variable "terraform_admin_sa_id" {
+  description = "Service account ID for Terraform admin"
+  type        = string
+}
+
+variable "app_sql_client_sa_id" {
+  description = "Service account ID for app Cloud SQL client"
+  type        = string
+}
+
+variable "grant_secret_accessor_to_app" {
+  description = "Whether to grant Secret Manager Secret Accessor to app SA for provided secrets"
+  type        = bool
+  default     = false
+}
+
+variable "secret_ids_for_app" {
+  description = "List of Secret Manager secret IDs to grant accessor to app SA"
+  type        = list(string)
+  default     = []
+}

--- a/infra/modules/sql_instance/main.tf
+++ b/infra/modules/sql_instance/main.tf
@@ -1,0 +1,56 @@
+resource "google_sql_database_instance" "this" {
+  name                 = var.instance_name
+  project              = var.project_id
+  database_version     = "POSTGRES_15"
+  region               = var.region
+  deletion_protection  = true
+
+  settings {
+    tier              = var.tier
+    disk_size         = var.disk_size_gb
+    disk_autoresize   = true
+    availability_type = "ZONAL"
+
+    ip_configuration {
+      ipv4_enabled = true
+    }
+
+    backup_configuration {
+      enabled                        = true
+      start_time                     = "05:00"
+      transaction_log_retention_days = var.backup_retention_days
+      point_in_time_recovery_enabled = var.pitr_enabled
+    }
+
+    maintenance_window {
+      day          = var.maintenance_window_day
+      hour         = var.maintenance_window_hour
+      update_track = "stable"
+    }
+  }
+}
+
+resource "google_sql_database" "db" {
+  name     = var.db_name
+  instance = google_sql_database_instance.this.name
+}
+
+resource "google_sql_user" "app" {
+  name     = var.db_user
+  instance = google_sql_database_instance.this.name
+  password = var.db_password
+
+  lifecycle {
+    ignore_changes = [password]
+  }
+}
+
+resource "google_secret_manager_secret" "db_password" {
+  count    = var.create_db_password_secret ? 1 : 0
+  project  = var.project_id
+  secret_id = var.db_password_secret_id
+
+  replication {
+    auto {}
+  }
+}

--- a/infra/modules/sql_instance/outputs.tf
+++ b/infra/modules/sql_instance/outputs.tf
@@ -1,0 +1,15 @@
+output "instance_connection_name" {
+  value = google_sql_database_instance.this.connection_name
+}
+
+output "public_ip_address" {
+  value = google_sql_database_instance.this.public_ip_address
+}
+
+output "database_name" {
+  value = google_sql_database.db.name
+}
+
+output "database_user" {
+  value = google_sql_user.app.name
+}

--- a/infra/modules/sql_instance/variables.tf
+++ b/infra/modules/sql_instance/variables.tf
@@ -1,0 +1,73 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+}
+
+variable "instance_name" {
+  description = "Cloud SQL instance name"
+  type        = string
+}
+
+variable "db_name" {
+  description = "Database name"
+  type        = string
+}
+
+variable "db_user" {
+  description = "Database user"
+  type        = string
+}
+
+variable "db_password" {
+  description = "Database password (sensitive)"
+  type        = string
+  sensitive   = true
+}
+
+variable "db_password_secret_id" {
+  description = "Secret Manager secret ID for DB password (secret only; add versions manually)"
+  type        = string
+  default     = "family-recipe-dev-db-password"
+}
+
+variable "create_db_password_secret" {
+  description = "Create Secret Manager secret for DB password (no version)"
+  type        = bool
+  default     = true
+}
+
+variable "tier" {
+  description = "Machine tier for Cloud SQL"
+  type        = string
+}
+
+variable "disk_size_gb" {
+  description = "Disk size in GB"
+  type        = number
+}
+
+variable "backup_retention_days" {
+  description = "Automated backup retention (days)"
+  type        = number
+}
+
+variable "maintenance_window_day" {
+  description = "Maintenance window day (0 = Sunday, 1 = Monday, ...)"
+  type        = number
+}
+
+variable "maintenance_window_hour" {
+  description = "Maintenance window hour (0-23, UTC)"
+  type        = number
+}
+
+variable "pitr_enabled" {
+  description = "Enable point-in-time recovery (PITR)"
+  type        = bool
+  default     = false
+}

--- a/prisma/migrations/20251205094500_add_core_indexes/migration.sql
+++ b/prisma/migrations/20251205094500_add_core_indexes/migration.sql
@@ -1,0 +1,23 @@
+-- Additional indexes for common query patterns
+
+CREATE INDEX "idx_posts_family_created" ON "posts"("family_space_id", "created_at");
+CREATE INDEX "idx_posts_author" ON "posts"("author_id");
+
+CREATE INDEX "idx_comments_post_created" ON "comments"("post_id", "created_at");
+
+CREATE INDEX "idx_reactions_target" ON "reactions"("target_type", "target_id");
+CREATE INDEX "idx_reactions_post" ON "reactions"("post_id");
+CREATE INDEX "idx_reactions_comment" ON "reactions"("comment_id");
+
+CREATE INDEX "idx_favorites_user" ON "favorites"("user_id");
+CREATE INDEX "idx_favorites_post" ON "favorites"("post_id");
+
+CREATE INDEX "idx_cooked_events_post" ON "cooked_events"("post_id");
+CREATE INDEX "idx_cooked_events_user" ON "cooked_events"("user_id");
+
+CREATE INDEX "idx_post_photos_post" ON "post_photos"("post_id");
+
+CREATE INDEX "idx_post_tags_post" ON "post_tags"("post_id");
+CREATE INDEX "idx_post_tags_tag" ON "post_tags"("tag_id");
+
+CREATE INDEX "idx_family_memberships_family" ON "family_memberships"("family_space_id");

--- a/prisma/schema.postgres.prisma
+++ b/prisma/schema.postgres.prisma
@@ -60,6 +60,7 @@ model FamilyMembership {
 
   @@unique([familySpaceId, userId])
   @@map("family_memberships")
+  @@index([familySpaceId])
 }
 
 // Post represents both quick posts and full recipe posts
@@ -90,6 +91,8 @@ model Post {
   favorites         Favorite[]
 
   @@map("posts")
+  @@index([familySpaceId, createdAt])
+  @@index([authorId])
 }
 
 // PostPhoto stores additional photos attached to a post
@@ -104,6 +107,7 @@ model PostPhoto {
   post        Post     @relation(fields: [postId], references: [id], onDelete: Cascade)
 
   @@map("post_photos")
+  @@index([postId])
 }
 
 // RecipeDetails stores optional recipe-specific information
@@ -152,6 +156,8 @@ model PostTag {
 
   @@unique([postId, tagId])
   @@map("post_tags")
+  @@index([postId])
+  @@index([tagId])
 }
 
 // Comment represents flat comments on posts
@@ -171,6 +177,7 @@ model Comment {
   reactions Reaction[] @relation("CommentReactions")
 
   @@map("comments")
+  @@index([postId, createdAt])
 }
 
 // Reaction represents emoji-based reactions on posts and comments
@@ -191,6 +198,9 @@ model Reaction {
 
   @@unique([targetType, targetId, userId, emoji])
   @@map("reactions")
+  @@index([targetType, targetId])
+  @@index([postId])
+  @@index([commentId])
 }
 
 // CookedEvent represents "Cooked this!" check-ins
@@ -207,6 +217,8 @@ model CookedEvent {
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@map("cooked_events")
+  @@index([postId])
+  @@index([userId])
 }
 
 // Favorite represents user's private bookmarks
@@ -222,4 +234,6 @@ model Favorite {
 
   @@unique([userId, postId])
   @@map("favorites")
+  @@index([userId])
+  @@index([postId])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -60,6 +60,7 @@ model FamilyMembership {
 
   @@unique([familySpaceId, userId])
   @@map("family_memberships")
+  @@index([familySpaceId])
 }
 
 // Post represents both quick posts and full recipe posts
@@ -90,6 +91,8 @@ model Post {
   favorites         Favorite[]
 
   @@map("posts")
+  @@index([familySpaceId, createdAt])
+  @@index([authorId])
 }
 
 // PostPhoto stores additional photos attached to a post
@@ -104,6 +107,7 @@ model PostPhoto {
   post        Post     @relation(fields: [postId], references: [id], onDelete: Cascade)
 
   @@map("post_photos")
+  @@index([postId])
 }
 
 // RecipeDetails stores optional recipe-specific information
@@ -152,6 +156,8 @@ model PostTag {
 
   @@unique([postId, tagId])
   @@map("post_tags")
+  @@index([postId])
+  @@index([tagId])
 }
 
 // Comment represents flat comments on posts
@@ -171,6 +177,7 @@ model Comment {
   reactions Reaction[] @relation("CommentReactions")
 
   @@map("comments")
+  @@index([postId, createdAt])
 }
 
 // Reaction represents emoji-based reactions on posts and comments
@@ -191,6 +198,9 @@ model Reaction {
 
   @@unique([targetType, targetId, userId, emoji])
   @@map("reactions")
+  @@index([targetType, targetId])
+  @@index([postId])
+  @@index([commentId])
 }
 
 // CookedEvent represents "Cooked this!" check-ins
@@ -207,6 +217,8 @@ model CookedEvent {
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@map("cooked_events")
+  @@index([postId])
+  @@index([userId])
 }
 
 // Favorite represents user's private bookmarks
@@ -222,4 +234,6 @@ model Favorite {
 
   @@unique([userId, postId])
   @@map("favorites")
+  @@index([userId])
+  @@index([postId])
 }


### PR DESCRIPTION
Phase 3 – External Database & Data Discipline

**Goal:** Use a real managed Postgres instance with proper migrations and backups.

- [✓] Choose a managed Postgres provider for v2 (GCP Cloud SQL).
- [✓] Create:
  - [✓] Dev database (Cloud SQL Postgres).
  - [ ] (Prod database moved to Phase 7).
- [✓] Configure `DATABASE_URL` values for:
  - [✓] Local dev (Cloud SQL via proxy).
  - [✓] Dev environment.
  - [ ] (Prod environment moved to Phase 7).
- [✓] Run Prisma migrations against the **dev database** (`prisma migrate deploy`).
- [✓] Add a **seed script** (or reuse existing) to:
  - [✓] Create initial `FamilySpace`.
  - [✓] Store hashed family master key.
  - [✓] Create owner user or a way to bootstrap one.
- [✓] Ensure any **schema changes** (e.g., additional indexes, enum refinements) are captured in migrations.
- [✓] Identify any data fields currently unused in V1 and decide whether to keep, remove, or fully wire them.