### PR TITLE
Phase 5

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,9 @@ JWT_SECRET="jwt-secret-placeholder"
 # If FAMILY_MASTER_KEY is omitted, seed will generate a secure random key and print it to the console.
 FAMILY_NAME="Family Recipe"
 # FAMILY_MASTER_KEY="change-me"  # leave commented to auto-generate
+
+# Uploads
+# When UPLOADS_BUCKET is set, photos are stored in GCS with signed URLs.
+# When unset, uploads fall back to local disk at ./public/uploads (dev/test).
+# UPLOADS_BUCKET="family-recipe-dev-uploads"
+# UPLOADS_SIGNED_URL_TTL_SECONDS=3600

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,68 @@
+name: Deploy Dev (Cloud Run)
+
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: dev
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      PROJECT_ID: ${{ secrets.DEV_GCP_PROJECT }}
+      REGION: ${{ secrets.DEV_GCP_REGION }}
+      CLOUD_RUN_SERVICE: ${{ secrets.DEV_CLOUD_RUN_SERVICE }}
+      ARTIFACT_REGISTRY_REPO: ${{ secrets.DEV_ARTIFACT_REGISTRY_REPO }}
+      INSTANCE_CONNECTION_NAME: ${{ secrets.DEV_INSTANCE_CONNECTION_NAME }}
+      RUNTIME_SERVICE_ACCOUNT: family-recipe-runner@family-recipe-dev.iam.gserviceaccount.com
+      DATABASE_URL_SECRET: family-recipe-dev-database-url
+      JWT_SECRET_NAME: family-recipe-dev-jwt-secret
+      FAMILY_MASTER_KEY_SECRET_NAME: family-recipe-dev-family-master-key
+      UPLOADS_BUCKET: family-recipe-dev-uploads
+      UPLOADS_BASE_URL: https://storage.googleapis.com/family-recipe-dev-uploads
+      PRISMA_SCHEMA: prisma/schema.postgres.prisma
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to GCP (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.DEV_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.DEV_GCP_DEPLOYER_SA }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ env.PROJECT_ID }}
+
+      - name: Configure Docker auth
+        run: gcloud auth configure-docker "${{ env.REGION }}-docker.pkg.dev" --quiet
+
+      - name: Build image
+        run: |
+          IMAGE="${{ env.ARTIFACT_REGISTRY_REPO }}:${{ github.sha }}"
+          echo "IMAGE=$IMAGE" >> "$GITHUB_ENV"
+          docker build -t "$IMAGE" -f Dockerfile .
+
+      - name: Push image
+        run: docker push "$IMAGE"
+
+      - name: Deploy to Cloud Run (dev)
+        run: |
+          gcloud run deploy "$CLOUD_RUN_SERVICE" \
+            --project "$PROJECT_ID" \
+            --region "$REGION" \
+            --image "$IMAGE" \
+            --service-account "$RUNTIME_SERVICE_ACCOUNT" \
+            --platform managed \
+            --port 3000 \
+            --quiet \
+            --add-cloudsql-instances "$INSTANCE_CONNECTION_NAME" \
+            --set-secrets DATABASE_URL=${DATABASE_URL_SECRET}:latest,JWT_SECRET=${JWT_SECRET_NAME}:latest,FAMILY_MASTER_KEY=${FAMILY_MASTER_KEY_SECRET_NAME}:latest \
+            --set-env-vars PRISMA_SCHEMA=${PRISMA_SCHEMA},UPLOADS_BUCKET=${UPLOADS_BUCKET},UPLOADS_BASE_URL=${UPLOADS_BASE_URL} \
+            --ingress internal-and-cloud-load-balancing \
+            --no-allow-unauthenticated

--- a/.github/workflows/infra-apply.yml
+++ b/.github/workflows/infra-apply.yml
@@ -1,0 +1,51 @@
+name: Infra Apply
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_env:
+        description: 'Environment to apply (default: dev)'
+        required: false
+        default: 'dev'
+
+jobs:
+  terraform-apply:
+    runs-on: ubuntu-latest
+    environment: dev
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.8.4
+      - name: Authenticate to GCP (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_TERRAFORM_SA }}
+          token_format: access_token
+      - name: Terraform init (GCS backend)
+        run: |
+          terraform -chdir=infra/envs/dev init \
+            -backend-config="bucket=family-recipe-tf-state-dev" \
+            -backend-config="prefix=envs/dev/state" \
+            -input=false
+      - name: Terraform plan (dev)
+        run: |
+          terraform -chdir=infra/envs/dev plan \
+            -input=false \
+            -out=tfplan.out
+        env:
+          TF_VAR_project_id: family-recipe-dev
+          TF_VAR_region: us-east1
+          TF_VAR_db_password: ${{ secrets.TF_VAR_DB_PASSWORD }}
+      - name: Terraform apply (manual)
+        if: github.event.inputs.target_env == 'dev'
+        run: terraform -chdir=infra/envs/dev apply -input=false tfplan.out
+        env:
+          TF_VAR_project_id: family-recipe-dev
+          TF_VAR_region: us-east1
+          TF_VAR_db_password: ${{ secrets.TF_VAR_DB_PASSWORD }}

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -29,8 +29,6 @@ jobs:
   terraform-validate:
     runs-on: ubuntu-latest
     needs: [iac-scan]
-    env:
-      TF_DATA_DIR: ${{ runner.temp }}/tfdata
     steps:
       - uses: actions/checkout@v4
       - name: Set up Terraform
@@ -41,7 +39,7 @@ jobs:
         run: terraform fmt -check -recursive
       - name: Terraform init (no backend)
         run: |
-          rm -rf "$TF_DATA_DIR"
+          export TF_DATA_DIR="$(mktemp -d)"
           terraform -chdir=infra/envs/dev init -backend=false -reconfigure -input=false
         env:
           GOOGLE_OAUTH_ACCESS_TOKEN: fake-token
@@ -53,8 +51,6 @@ jobs:
   terraform-plan:
     runs-on: ubuntu-latest
     needs: [terraform-validate]
-    env:
-      TF_DATA_DIR: ${{ runner.temp }}/tfdata
     steps:
       - uses: actions/checkout@v4
       - name: Set up Terraform
@@ -63,7 +59,7 @@ jobs:
           terraform_version: 1.8.4
       - name: Terraform init (no backend)
         run: |
-          rm -rf "$TF_DATA_DIR"
+          export TF_DATA_DIR="$(mktemp -d)"
           terraform -chdir=infra/envs/dev init -backend=false -reconfigure -input=false
         env:
           GOOGLE_OAUTH_ACCESS_TOKEN: fake-token

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -37,14 +37,11 @@ jobs:
           terraform_version: 1.8.4
       - name: Terraform fmt (check)
         run: terraform fmt -check -recursive
-      - name: Terraform init (no backend)
+      - name: Terraform init + validate (no backend)
         run: |
           export TF_DATA_DIR="$(mktemp -d)"
           terraform -chdir=infra/envs/dev init -backend=false -reconfigure -input=false
-        env:
-          GOOGLE_OAUTH_ACCESS_TOKEN: fake-token
-      - name: Terraform validate
-        run: terraform -chdir=infra/envs/dev validate
+          terraform -chdir=infra/envs/dev validate
         env:
           GOOGLE_OAUTH_ACCESS_TOKEN: fake-token
 
@@ -57,14 +54,10 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: 1.8.4
-      - name: Terraform init (no backend)
+      - name: Terraform init + plan (no backend, static vars, no refresh)
         run: |
           export TF_DATA_DIR="$(mktemp -d)"
           terraform -chdir=infra/envs/dev init -backend=false -reconfigure -input=false
-        env:
-          GOOGLE_OAUTH_ACCESS_TOKEN: fake-token
-      - name: Terraform plan (static vars, no refresh)
-        run: |
           terraform -chdir=infra/envs/dev plan \
             -input=false \
             -lock=false \

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -29,6 +29,8 @@ jobs:
   terraform-validate:
     runs-on: ubuntu-latest
     needs: [iac-scan]
+    env:
+      TF_DATA_DIR: ${{ github.workspace }}/.tfdata
     steps:
       - uses: actions/checkout@v4
       - name: Set up Terraform
@@ -39,7 +41,6 @@ jobs:
         run: terraform fmt -check -recursive
       - name: Terraform init + validate (no backend)
         run: |
-          export TF_DATA_DIR="$(mktemp -d)"
           terraform -chdir=infra/envs/dev init -backend=false -reconfigure -input=false
           terraform -chdir=infra/envs/dev validate
         env:
@@ -48,6 +49,8 @@ jobs:
   terraform-plan:
     runs-on: ubuntu-latest
     needs: [terraform-validate]
+    env:
+      TF_DATA_DIR: ${{ github.workspace }}/.tfdata
     steps:
       - uses: actions/checkout@v4
       - name: Set up Terraform
@@ -56,7 +59,6 @@ jobs:
           terraform_version: 1.8.4
       - name: Terraform init + plan (no backend, static vars, no refresh)
         run: |
-          export TF_DATA_DIR="$(mktemp -d)"
           terraform -chdir=infra/envs/dev init -backend=false -reconfigure -input=false
           terraform -chdir=infra/envs/dev plan \
             -input=false \

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -1,0 +1,77 @@
+name: Infra CI
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'infra/**'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'infra/**'
+
+jobs:
+  iac-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: IaC scan (Trivy)
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          scan-type: 'config'
+          scan-ref: 'infra'
+          format: 'table'
+          exit-code: '1'
+          severity: 'HIGH,CRITICAL'
+
+  terraform-validate:
+    runs-on: ubuntu-latest
+    needs: [iac-scan]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.8.4
+      - name: Terraform fmt (check)
+        run: terraform fmt -check -recursive
+      - name: Terraform init (no backend)
+        run: terraform -chdir=infra/envs/dev init -backend=false -input=false
+        env:
+          GOOGLE_OAUTH_ACCESS_TOKEN: fake-token
+      - name: Terraform validate
+        run: terraform -chdir=infra/envs/dev validate
+        env:
+          GOOGLE_OAUTH_ACCESS_TOKEN: fake-token
+
+  terraform-plan:
+    runs-on: ubuntu-latest
+    needs: [terraform-validate]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.8.4
+      - name: Terraform init (no backend)
+        run: terraform -chdir=infra/envs/dev init -backend=false -input=false
+        env:
+          GOOGLE_OAUTH_ACCESS_TOKEN: fake-token
+      - name: Terraform plan (static vars, no refresh)
+        run: |
+          terraform -chdir=infra/envs/dev plan \
+            -input=false \
+            -lock=false \
+            -refresh=false \
+            -var-file=terraform.tfvars.example \
+            -var db_password="dummy-password" \
+            -out=tfplan.out
+        env:
+          GOOGLE_OAUTH_ACCESS_TOKEN: fake-token
+      - name: Upload plan artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: terraform-plan-dev
+          path: infra/envs/dev/tfplan.out

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -45,32 +45,3 @@ jobs:
           terraform -chdir=infra/envs/dev validate
         env:
           GOOGLE_OAUTH_ACCESS_TOKEN: fake-token
-
-  terraform-plan:
-    runs-on: ubuntu-latest
-    needs: [terraform-validate]
-    env:
-      TF_DATA_DIR: ${{ github.workspace }}/.tfdata
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: 1.8.4
-      - name: Terraform init + plan (no backend, static vars, no refresh)
-        run: |
-          terraform -chdir=infra/envs/dev init -backend=false -reconfigure -input=false
-          terraform -chdir=infra/envs/dev plan \
-            -input=false \
-            -lock=false \
-            -refresh=false \
-            -var-file=terraform.tfvars.example \
-            -var db_password="dummy-password" \
-            -out=tfplan.out
-        env:
-          GOOGLE_OAUTH_ACCESS_TOKEN: fake-token
-      - name: Upload plan artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: terraform-plan-dev
-          path: infra/envs/dev/tfplan.out

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Terraform fmt (check)
         run: terraform fmt -check -recursive
       - name: Terraform init (no backend)
-        run: terraform -chdir=infra/envs/dev init -backend=false -input=false
+        run: terraform -chdir=infra/envs/dev init -backend=false -reconfigure -input=false
         env:
           GOOGLE_OAUTH_ACCESS_TOKEN: fake-token
       - name: Terraform validate
@@ -56,7 +56,7 @@ jobs:
         with:
           terraform_version: 1.8.4
       - name: Terraform init (no backend)
-        run: terraform -chdir=infra/envs/dev init -backend=false -input=false
+        run: terraform -chdir=infra/envs/dev init -backend=false -reconfigure -input=false
         env:
           GOOGLE_OAUTH_ACCESS_TOKEN: fake-token
       - name: Terraform plan (static vars, no refresh)

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -29,6 +29,8 @@ jobs:
   terraform-validate:
     runs-on: ubuntu-latest
     needs: [iac-scan]
+    env:
+      TF_DATA_DIR: ${{ runner.temp }}/tfdata
     steps:
       - uses: actions/checkout@v4
       - name: Set up Terraform
@@ -38,7 +40,9 @@ jobs:
       - name: Terraform fmt (check)
         run: terraform fmt -check -recursive
       - name: Terraform init (no backend)
-        run: terraform -chdir=infra/envs/dev init -backend=false -reconfigure -input=false
+        run: |
+          rm -rf "$TF_DATA_DIR"
+          terraform -chdir=infra/envs/dev init -backend=false -reconfigure -input=false
         env:
           GOOGLE_OAUTH_ACCESS_TOKEN: fake-token
       - name: Terraform validate
@@ -49,6 +53,8 @@ jobs:
   terraform-plan:
     runs-on: ubuntu-latest
     needs: [terraform-validate]
+    env:
+      TF_DATA_DIR: ${{ runner.temp }}/tfdata
     steps:
       - uses: actions/checkout@v4
       - name: Set up Terraform
@@ -56,7 +62,9 @@ jobs:
         with:
           terraform_version: 1.8.4
       - name: Terraform init (no backend)
-        run: terraform -chdir=infra/envs/dev init -backend=false -reconfigure -input=false
+        run: |
+          rm -rf "$TF_DATA_DIR"
+          terraform -chdir=infra/envs/dev init -backend=false -reconfigure -input=false
         env:
           GOOGLE_OAUTH_ACCESS_TOKEN: fake-token
       - name: Terraform plan (static vars, no refresh)

--- a/FINAL_REPORT.md
+++ b/FINAL_REPORT.md
@@ -265,26 +265,29 @@ Identify any **auth, validation, or error handling shortcuts** and make sure the
   - [✓] Require CI to pass before merging into `develop`.
   - [✓] Require CI to pass before merging into `main`.
   - [✓] Disallow direct pushes to `main` and `develop`.
-- [ ] Add any additional checks that make sense given the current implementation (e.g., run Prisma migrations in CI using a temp DB to verify they apply cleanly).
+- [✓] Add any additional checks that make sense given the current implementation (e.g., run Prisma migrations in CI using a temp DB to verify they apply cleanly).
 
 ### Phase 5 – First “Dev” Deploy of the Monolith
 
 **Goal:** Deploy the app to a real dev environment with proper env vars and checks.
 
 - [ ] Choose hosting platform for v2:
-  - [ ] Vercel for the monolith Next.js app.
-- [ ] Connect repo to hosting platform.
-- [ ] Configure **dev environment**:
-  - [ ] `DATABASE_URL` (dev DB).
-  - [ ] Auth/crypto secrets (e.g., NextAuth secret, JWT secret).
-  - [ ] Any other required env vars (master key hash if needed, etc.).
-- [ ] Ensure deploys to dev are:
-  - [ ] Triggered from `develop` (or PR branches).
-  - [ ] Gated by CI passing.
-- [ ] Confirm:
-  - [ ] Dev URL is accessible.
-  - [ ] Basic flows work (signup, login, create post, “Cooked this”, comments, favorites, profile, recipes browse/search).
-- [ ] Verify any known limitations (e.g., image handling, search behavior) behave at least predictably in dev.
+  - [ ] GCP Cloud Run (monolith Next.js app), private (auth required; no public unauthenticated access).
+- [ ] Connect repo to GCP for builds/deploys:
+  - [ ] Artifact Registry for images.
+  - [ ] Workload Identity Federation for GitHub Actions to push and deploy.
+- [ ] Configure **dev environment** (Cloud Run + Cloud SQL):
+  - [ ] `DATABASE_URL` via Cloud SQL connector socket + Secret Manager (uses dev DB password already in GSM).
+  - [ ] Auth/crypto secrets: `JWT_SECRET` (Secret Manager), optional seeded `FAMILY_MASTER_KEY` if needed for bootstrap.
+  - [ ] Prisma schema set to Postgres (`PRISMA_SCHEMA=prisma/schema.postgres.prisma`).
+- [ ] GCS-backed uploads:
+  - [ ] Create private bucket for uploads; enforce signed URL access; set `UPLOADS_BUCKET` and `UPLOADS_BASE_URL`.
+  - [ ] Update upload helpers to write/delete in GCS and return signed URLs for reads.
+- [ ] Deployments to dev:
+  - [ ] Manual (`workflow_dispatch`) after CI green on `develop`; deploy Cloud Run service with Cloud SQL + secrets wired.
+- [ ] Post-deploy verification:
+  - [ ] Dev URL reachable (with auth); basic flows work (signup, login, create post, “Cooked this”, comments, favorites, profile, recipes browse/search).
+  - [ ] Validate signed URL image behavior and any known limitations (e.g., search quirks) behave predictably in dev.
 
 ### Phase 6 – Security & Privacy Polish (If Time Allows)
 

--- a/infra/envs/dev/main.tf
+++ b/infra/envs/dev/main.tf
@@ -18,10 +18,10 @@ provider "google" {
 module "iam" {
   source = "../../modules/iam"
 
-  project_id                 = var.project_id
-  state_bucket_name          = var.state_bucket_name
-  terraform_admin_sa_id      = var.terraform_admin_sa_id
-  app_sql_client_sa_id       = var.app_sql_client_sa_id
+  project_id                   = var.project_id
+  state_bucket_name            = var.state_bucket_name
+  terraform_admin_sa_id        = var.terraform_admin_sa_id
+  app_sql_client_sa_id         = var.app_sql_client_sa_id
   grant_secret_accessor_to_app = var.grant_secret_accessor_to_app
   secret_ids_for_app           = [var.db_password_secret_id]
 }
@@ -29,23 +29,23 @@ module "iam" {
 module "sql_instance" {
   source = "../../modules/sql_instance"
 
-  project_id                  = var.project_id
-  region                      = var.region
-  instance_name               = var.db_instance_name
-  db_name                     = var.db_name
-  db_user                     = var.db_user
-  db_password                 = var.db_password
-  tier                        = var.tier
-  disk_size_gb                = var.disk_size_gb
-  backup_retention_days       = var.backup_retention_days
-  maintenance_window_day      = var.maintenance_window_day
-  maintenance_window_hour     = var.maintenance_window_hour
-  pitr_enabled                = var.pitr_enabled
-  enable_public_ip            = var.enable_public_ip
-  ssl_mode                    = var.ssl_mode
-  authorized_networks         = var.authorized_networks
-  create_db_password_secret   = var.create_db_password_secret
-  db_password_secret_id       = var.db_password_secret_id
+  project_id                = var.project_id
+  region                    = var.region
+  instance_name             = var.db_instance_name
+  db_name                   = var.db_name
+  db_user                   = var.db_user
+  db_password               = var.db_password
+  tier                      = var.tier
+  disk_size_gb              = var.disk_size_gb
+  backup_retention_days     = var.backup_retention_days
+  maintenance_window_day    = var.maintenance_window_day
+  maintenance_window_hour   = var.maintenance_window_hour
+  pitr_enabled              = var.pitr_enabled
+  enable_public_ip          = var.enable_public_ip
+  ssl_mode                  = var.ssl_mode
+  authorized_networks       = var.authorized_networks
+  create_db_password_secret = var.create_db_password_secret
+  db_password_secret_id     = var.db_password_secret_id
 
   depends_on = [module.iam]
 }

--- a/infra/envs/dev/main.tf
+++ b/infra/envs/dev/main.tf
@@ -49,3 +49,22 @@ module "sql_instance" {
 
   depends_on = [module.iam]
 }
+
+module "cloud_run_infra" {
+  source = "../../modules/cloud_run_infra"
+
+  project_id                  = var.project_id
+  region                      = var.region
+  runtime_sa_id               = var.runtime_sa_id
+  deployer_sa_id              = var.deployer_sa_id
+  artifact_registry_repo_id   = var.artifact_registry_repo_id
+  cloud_run_service_name      = var.cloud_run_service_name
+  uploads_bucket_name         = var.uploads_bucket_name
+  database_url_secret_id      = var.database_url_secret_id
+  jwt_secret_id               = var.jwt_secret_id
+  family_master_key_secret_id = var.family_master_key_secret_id
+  wif_pool_id                 = var.wif_pool_id
+  wif_provider_id             = var.wif_provider_id
+  github_repository           = var.github_repository
+  github_ref                  = var.github_ref
+}

--- a/infra/envs/dev/outputs.tf
+++ b/infra/envs/dev/outputs.tf
@@ -21,3 +21,35 @@ output "terraform_admin_sa_email" {
 output "app_sql_client_sa_email" {
   value = module.iam.app_sql_client_sa_email
 }
+
+output "runtime_service_account_email" {
+  value = module.cloud_run_infra.runtime_service_account_email
+}
+
+output "deployer_service_account_email" {
+  value = module.cloud_run_infra.deployer_service_account_email
+}
+
+output "artifact_registry_repository" {
+  value = module.cloud_run_infra.artifact_registry_repository
+}
+
+output "uploads_bucket_name" {
+  value = module.cloud_run_infra.uploads_bucket_name
+}
+
+output "cloud_run_service_name" {
+  value = module.cloud_run_infra.cloud_run_service_name
+}
+
+output "cloud_run_service_uri" {
+  value = module.cloud_run_infra.cloud_run_service_uri
+}
+
+output "wif_pool_name" {
+  value = module.cloud_run_infra.wif_pool_name
+}
+
+output "wif_provider_name" {
+  value = module.cloud_run_infra.wif_provider_name
+}

--- a/infra/envs/dev/terraform.tfvars.example
+++ b/infra/envs/dev/terraform.tfvars.example
@@ -18,3 +18,17 @@ maintenance_window_hour = 5  # 05:00 UTC
 pitr_enabled            = false
 create_db_password_secret = true
 grant_secret_accessor_to_app = false
+
+# Cloud Run / CI/CD
+runtime_sa_id              = "family-recipe-runner"
+deployer_sa_id             = "family-recipe-deployer"
+artifact_registry_repo_id  = "family-recipe-dev"
+cloud_run_service_name     = "family-recipe-dev"
+uploads_bucket_name        = "family-recipe-dev-uploads"
+database_url_secret_id     = "family-recipe-dev-database-url"
+jwt_secret_id              = "family-recipe-dev-jwt-secret"
+family_master_key_secret_id = "family-recipe-dev-family-master-key"
+wif_pool_id                = "github-pool"
+wif_provider_id            = "github-provider"
+github_repository          = "wnorowskie/family-recipe"
+github_ref                 = "refs/heads/develop"

--- a/infra/envs/dev/variables.tf
+++ b/infra/envs/dev/variables.tf
@@ -128,3 +128,75 @@ variable "ssl_mode" {
   type        = string
   default     = "ENCRYPTED_ONLY"
 }
+
+variable "runtime_sa_id" {
+  description = "Service account ID for Cloud Run runtime"
+  type        = string
+  default     = "family-recipe-runner"
+}
+
+variable "deployer_sa_id" {
+  description = "Service account ID for GitHub Actions deployer"
+  type        = string
+  default     = "family-recipe-deployer"
+}
+
+variable "artifact_registry_repo_id" {
+  description = "Artifact Registry repository ID for app images"
+  type        = string
+  default     = "family-recipe-dev"
+}
+
+variable "cloud_run_service_name" {
+  description = "Cloud Run service name"
+  type        = string
+  default     = "family-recipe-dev"
+}
+
+variable "uploads_bucket_name" {
+  description = "GCS bucket for uploads"
+  type        = string
+  default     = "family-recipe-dev-uploads"
+}
+
+variable "database_url_secret_id" {
+  description = "Secret Manager secret ID for DATABASE_URL"
+  type        = string
+  default     = "family-recipe-dev-database-url"
+}
+
+variable "jwt_secret_id" {
+  description = "Secret Manager secret ID for JWT secret"
+  type        = string
+  default     = "family-recipe-dev-jwt-secret"
+}
+
+variable "family_master_key_secret_id" {
+  description = "Secret Manager secret ID for FAMILY_MASTER_KEY"
+  type        = string
+  default     = "family-recipe-dev-family-master-key"
+}
+
+variable "wif_pool_id" {
+  description = "Workload Identity Pool ID"
+  type        = string
+  default     = "github-pool"
+}
+
+variable "wif_provider_id" {
+  description = "Workload Identity Pool Provider ID"
+  type        = string
+  default     = "github-provider"
+}
+
+variable "github_repository" {
+  description = "GitHub repository (owner/repo) allowed for WIF"
+  type        = string
+  default     = "wnorowskie/family-recipe"
+}
+
+variable "github_ref" {
+  description = "Git ref allowed for WIF (e.g., refs/heads/develop)"
+  type        = string
+  default     = "refs/heads/develop"
+}

--- a/infra/modules/cloud_run_infra/main.tf
+++ b/infra/modules/cloud_run_infra/main.tf
@@ -64,10 +64,10 @@ resource "google_iam_workload_identity_pool_provider" "github" {
   }
 
   attribute_mapping = {
-    "google.subject"         = "assertion.sub"
-    "attribute.repository"   = "assertion.repository"
-    "attribute.ref"          = "assertion.ref"
-    "attribute.aud"          = "assertion.aud"
+    "google.subject"       = "assertion.sub"
+    "attribute.repository" = "assertion.repository"
+    "attribute.ref"        = "assertion.ref"
+    "attribute.aud"        = "assertion.aud"
   }
 
   attribute_condition = <<-EOT

--- a/infra/modules/cloud_run_infra/main.tf
+++ b/infra/modules/cloud_run_infra/main.tf
@@ -1,0 +1,166 @@
+resource "google_service_account" "runtime" {
+  account_id   = var.runtime_sa_id
+  display_name = "Family Recipe Cloud Run runtime"
+  project      = var.project_id
+}
+
+resource "google_service_account" "deployer" {
+  account_id   = var.deployer_sa_id
+  display_name = "Family Recipe deployer (GitHub Actions)"
+  project      = var.project_id
+}
+
+locals {
+  runtime_roles = [
+    "roles/iam.serviceAccountTokenCreator",
+    "roles/cloudsql.client",
+    "roles/storage.objectAdmin",
+    "roles/secretmanager.secretAccessor",
+  ]
+
+  deployer_roles = [
+    "roles/artifactregistry.writer",
+    "roles/run.admin",
+    "roles/secretmanager.secretAccessor",
+  ]
+}
+
+resource "google_project_iam_member" "runtime_role_bindings" {
+  for_each = toset(local.runtime_roles)
+
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.runtime.email}"
+}
+
+resource "google_project_iam_member" "deployer_role_bindings" {
+  for_each = toset(local.deployer_roles)
+
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.deployer.email}"
+}
+
+resource "google_service_account_iam_member" "deployer_impersonates_runtime" {
+  service_account_id = google_service_account.runtime.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.deployer.email}"
+}
+
+resource "google_iam_workload_identity_pool" "github" {
+  workload_identity_pool_id = var.wif_pool_id
+  project                   = var.project_id
+  display_name              = "GitHub Actions Pool"
+}
+
+resource "google_iam_workload_identity_pool_provider" "github" {
+  project                            = var.project_id
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github.workload_identity_pool_id
+  workload_identity_pool_provider_id = var.wif_provider_id
+  display_name                       = "GitHub Actions Provider"
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+
+  attribute_mapping = {
+    "google.subject"         = "assertion.sub"
+    "attribute.repository"   = "assertion.repository"
+    "attribute.ref"          = "assertion.ref"
+    "attribute.aud"          = "assertion.aud"
+  }
+
+  attribute_condition = <<-EOT
+    assertion.repository == "${var.github_repository}" &&
+    assertion.ref == "${var.github_ref}"
+  EOT
+}
+
+resource "google_service_account_iam_member" "wif_to_deployer" {
+  service_account_id = google_service_account.deployer.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository/${var.github_repository}"
+}
+
+resource "google_artifact_registry_repository" "app" {
+  project       = var.project_id
+  location      = var.region
+  repository_id = var.artifact_registry_repo_id
+  description   = "Family Recipe app images"
+  format        = "DOCKER"
+}
+
+resource "google_storage_bucket" "uploads" {
+  name                        = var.uploads_bucket_name
+  location                    = var.region
+  uniform_bucket_level_access = true
+  project                     = var.project_id
+  force_destroy               = false
+  public_access_prevention    = "enforced"
+  versioning {
+    enabled = false
+  }
+}
+
+locals {
+  managed_secret_ids = concat(
+    [
+      var.database_url_secret_id,
+      var.jwt_secret_id,
+    ],
+    var.family_master_key_secret_id == "" ? [] : [var.family_master_key_secret_id],
+  )
+}
+
+resource "google_secret_manager_secret" "secrets" {
+  for_each = toset(local.managed_secret_ids)
+
+  project   = var.project_id
+  secret_id = each.value
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_iam_member" "runtime_secret_access" {
+  for_each = google_secret_manager_secret.secrets
+
+  secret_id = each.value.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.runtime.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "deployer_secret_access" {
+  for_each = google_secret_manager_secret.secrets
+
+  secret_id = each.value.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.deployer.email}"
+}
+
+# Baseline Cloud Run service (hello world image) to establish service and IAM; will be updated by CI/CD deploys.
+resource "google_cloud_run_v2_service" "app" {
+  name     = var.cloud_run_service_name
+  location = var.region
+  project  = var.project_id
+  # Private ingress via internal load balancer only.
+  ingress  = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+
+  template {
+    service_account = google_service_account.runtime.email
+
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+
+      ports {
+        container_port = 8080
+      }
+    }
+  }
+
+  traffic {
+    type    = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
+    percent = 100
+  }
+}

--- a/infra/modules/cloud_run_infra/main.tf
+++ b/infra/modules/cloud_run_infra/main.tf
@@ -145,7 +145,7 @@ resource "google_cloud_run_v2_service" "app" {
   location = var.region
   project  = var.project_id
   # Private ingress via internal load balancer only.
-  ingress  = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+  ingress = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
 
   template {
     service_account = google_service_account.runtime.email

--- a/infra/modules/cloud_run_infra/outputs.tf
+++ b/infra/modules/cloud_run_infra/outputs.tf
@@ -1,0 +1,39 @@
+output "runtime_service_account_email" {
+  value = google_service_account.runtime.email
+}
+
+output "deployer_service_account_email" {
+  value = google_service_account.deployer.email
+}
+
+output "artifact_registry_repository" {
+  value = google_artifact_registry_repository.app.name
+}
+
+output "artifact_registry_repository_id" {
+  value = google_artifact_registry_repository.app.repository_id
+}
+
+output "uploads_bucket_name" {
+  value = google_storage_bucket.uploads.name
+}
+
+output "cloud_run_service_name" {
+  value = google_cloud_run_v2_service.app.name
+}
+
+output "cloud_run_service_uri" {
+  value = google_cloud_run_v2_service.app.uri
+}
+
+output "wif_pool_name" {
+  value = google_iam_workload_identity_pool.github.name
+}
+
+output "wif_provider_name" {
+  value = google_iam_workload_identity_pool_provider.github.name
+}
+
+output "managed_secret_ids" {
+  value = local.managed_secret_ids
+}

--- a/infra/modules/cloud_run_infra/variables.tf
+++ b/infra/modules/cloud_run_infra/variables.tf
@@ -1,0 +1,75 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region (also used for Artifact Registry)"
+  type        = string
+}
+
+variable "runtime_sa_id" {
+  description = "Service account ID for Cloud Run runtime"
+  type        = string
+  default     = "family-recipe-runner"
+}
+
+variable "deployer_sa_id" {
+  description = "Service account ID used by CI/CD (WIF) to deploy"
+  type        = string
+  default     = "family-recipe-deployer"
+}
+
+variable "artifact_registry_repo_id" {
+  description = "Artifact Registry repository ID for app images"
+  type        = string
+}
+
+variable "cloud_run_service_name" {
+  description = "Cloud Run service name"
+  type        = string
+  default     = "family-recipe-dev"
+}
+
+variable "uploads_bucket_name" {
+  description = "GCS bucket name for uploads (private, uniform access)"
+  type        = string
+}
+
+variable "database_url_secret_id" {
+  description = "Secret Manager secret ID for DATABASE_URL"
+  type        = string
+}
+
+variable "jwt_secret_id" {
+  description = "Secret Manager secret ID for JWT secret"
+  type        = string
+}
+
+variable "family_master_key_secret_id" {
+  description = "Optional Secret Manager secret ID for FAMILY_MASTER_KEY (empty to skip)"
+  type        = string
+  default     = ""
+}
+
+variable "wif_pool_id" {
+  description = "Workload Identity Pool ID for GitHub Actions"
+  type        = string
+  default     = "github-pool"
+}
+
+variable "wif_provider_id" {
+  description = "Workload Identity Pool Provider ID for GitHub Actions"
+  type        = string
+  default     = "github-provider"
+}
+
+variable "github_repository" {
+  description = "GitHub repository in owner/repo form"
+  type        = string
+}
+
+variable "github_ref" {
+  description = "Git ref allowed to assume WIF (e.g., refs/heads/develop)"
+  type        = string
+}

--- a/infra/modules/sql_instance/main.tf
+++ b/infra/modules/sql_instance/main.tf
@@ -1,11 +1,11 @@
 #tfsec:ignore:google-sql-enable-public-ip # Public IP allowed for dev; will tighten in prod/private rollout
 #tfsec:ignore:google-sql-encrypt-data-in-transit # Postgres requires client-side SSL; tracked via runtime configuration
 resource "google_sql_database_instance" "this" {
-  name                 = var.instance_name
-  project              = var.project_id
-  database_version     = "POSTGRES_15"
-  region               = var.region
-  deletion_protection  = true
+  name                = var.instance_name
+  project             = var.project_id
+  database_version    = "POSTGRES_15"
+  region              = var.region
+  deletion_protection = true
 
   settings {
     tier              = var.tier
@@ -57,8 +57,8 @@ resource "google_sql_user" "app" {
 }
 
 resource "google_secret_manager_secret" "db_password" {
-  count    = var.create_db_password_secret ? 1 : 0
-  project  = var.project_id
+  count     = var.create_db_password_secret ? 1 : 0
+  project   = var.project_id
   secret_id = var.db_password_secret_id
 
   replication {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2935,6 +2935,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
@@ -2978,6 +2979,7 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3467,6 +3469,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/console-control-strings": {
@@ -7651,6 +7654,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"

--- a/src/lib/uploads.ts
+++ b/src/lib/uploads.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'fs';
 import path from 'path';
-import { randomUUID } from 'crypto';
+import { createHash, createSign, randomUUID } from 'crypto';
+import { logWarn } from './logger';
 
 const UPLOAD_DIR = path.join(process.cwd(), 'public', 'uploads');
 const MAX_FILE_SIZE_BYTES = 8 * 1024 * 1024; // 8 MB per photo
@@ -11,9 +12,15 @@ const ALLOWED_MIME_TYPES = new Set([
   'image/gif',
 ]);
 
+const GCS_API_BASE = 'https://storage.googleapis.com';
+const UPLOADS_BUCKET = process.env.UPLOADS_BUCKET;
+const SIGNED_URL_TTL_SECONDS = Number(
+  process.env.UPLOADS_SIGNED_URL_TTL_SECONDS ?? '3600'
+);
+
 export interface SavedUpload {
   url: string;
-  filePath: string;
+  filePath?: string;
 }
 
 type FileLike = {
@@ -54,6 +61,307 @@ function getFileExtension(file: FileLike): string {
   }
 }
 
+function encodeRFC3986(value: string): string {
+  return encodeURIComponent(value).replace(
+    /[!'()*]/g,
+    (c) => '%' + c.charCodeAt(0).toString(16).toUpperCase()
+  );
+}
+
+function encodePath(objectKey: string): string {
+  return objectKey
+    .split('/')
+    .map((segment) => encodeRFC3986(segment))
+    .join('/');
+}
+
+async function fetchMetadata(pathname: string): Promise<string> {
+  const response = await fetch(
+    `http://metadata.google.internal/computeMetadata/v1/${pathname}`,
+    {
+      headers: {
+        'Metadata-Flavor': 'Google',
+      },
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`METADATA_UNAVAILABLE_${pathname}`);
+  }
+
+  return response.text();
+}
+
+async function getGcpAccessToken(): Promise<string> {
+  const response = await fetch(
+    'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token',
+    {
+      headers: {
+        'Metadata-Flavor': 'Google',
+      },
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error('METADATA_TOKEN_UNAVAILABLE');
+  }
+
+  const data = (await response.json()) as { access_token?: string };
+  if (!data.access_token) {
+    throw new Error('METADATA_TOKEN_MISSING');
+  }
+
+  return data.access_token;
+}
+
+async function signStringWithIam(
+  stringToSign: string,
+  accessToken: string,
+  serviceAccountEmail: string
+): Promise<string> {
+  const response = await fetch(
+    `https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${encodeURIComponent(
+      serviceAccountEmail
+    )}:signBlob`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        payload: Buffer.from(stringToSign).toString('base64'),
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`SIGN_BLOB_FAILED_${response.status}`);
+  }
+
+  const data = (await response.json()) as { signedBlob?: string };
+  if (!data.signedBlob) {
+    throw new Error('SIGN_BLOB_MISSING');
+  }
+
+  return data.signedBlob;
+}
+
+function signStringWithPrivateKey(
+  stringToSign: string,
+  privateKey: string
+): string {
+  const signer = createSign('RSA-SHA256');
+  signer.update(stringToSign);
+  signer.end();
+  // Return base64-encoded signature for downstream hex conversion
+  return signer.sign(privateKey, 'base64');
+}
+
+async function generateSignedUrlV4(options: {
+  bucket: string;
+  objectKey: string;
+  expiresInSeconds: number;
+  accessToken: string;
+  serviceAccountEmail: string;
+  privateKey?: string;
+}): Promise<string> {
+  const {
+    bucket,
+    objectKey,
+    expiresInSeconds,
+    accessToken,
+    serviceAccountEmail,
+    privateKey,
+  } = options;
+
+  const now = new Date();
+  const datestamp = now.toISOString().replace(/[-:]/g, '').slice(0, 8);
+  const timestamp =
+    now
+      .toISOString()
+      .replace(/[-:TZ.]/g, '')
+      .slice(0, 14) + 'Z';
+  const credentialScope = `${datestamp}/auto/storage/goog4_request`;
+  const credential = `${serviceAccountEmail}/${credentialScope}`;
+
+  const canonicalQuery = [
+    ['X-Goog-Algorithm', 'GOOG4-RSA-SHA256'],
+    ['X-Goog-Credential', credential],
+    ['X-Goog-Date', timestamp],
+    ['X-Goog-Expires', String(expiresInSeconds)],
+    ['X-Goog-SignedHeaders', 'host'],
+  ]
+    .map(([k, v]) => `${encodeRFC3986(k)}=${encodeRFC3986(v)}`)
+    .sort()
+    .join('&');
+
+  const canonicalUri = `/${bucket}/${encodePath(objectKey)}`;
+  const canonicalRequest = [
+    'GET',
+    canonicalUri,
+    canonicalQuery,
+    'host:storage.googleapis.com',
+    '',
+    'host',
+    'UNSIGNED-PAYLOAD',
+  ].join('\n');
+
+  const hash = createHash('sha256').update(canonicalRequest).digest('hex');
+  const stringToSign = [
+    'GOOG4-RSA-SHA256',
+    timestamp,
+    credentialScope,
+    hash,
+  ].join('\n');
+
+  let signature: string;
+  if (privateKey) {
+    const signedBase64 = signStringWithPrivateKey(stringToSign, privateKey);
+    signature = Buffer.from(signedBase64, 'base64').toString('hex');
+  } else {
+    const signedBlob = await signStringWithIam(
+      stringToSign,
+      accessToken,
+      serviceAccountEmail
+    );
+    signature = Buffer.from(signedBlob, 'base64').toString('hex');
+  }
+
+  const signedUrl = `${GCS_API_BASE}${canonicalUri}?${canonicalQuery}&X-Goog-Signature=${signature}`;
+  return signedUrl;
+}
+
+async function uploadToGcs(options: {
+  bucket: string;
+  objectKey: string;
+  buffer: Buffer;
+  contentType: string;
+  accessToken: string;
+}): Promise<void> {
+  const { bucket, objectKey, buffer, contentType, accessToken } = options;
+  const uploadUrl = `${GCS_API_BASE}/upload/storage/v1/b/${encodeRFC3986(
+    bucket
+  )}/o?uploadType=media&name=${encodeRFC3986(objectKey)}`;
+  const response = await fetch(uploadUrl, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': contentType,
+    },
+    body: new Uint8Array(buffer),
+  });
+
+  if (!response.ok) {
+    throw new Error(`GCS_UPLOAD_FAILED_${response.status}`);
+  }
+}
+
+function extractGcsObjectKey(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    const parts = parsed.pathname.split('/').filter(Boolean);
+
+    if (!parts.length) {
+      return null;
+    }
+
+    if (parsed.hostname === 'storage.googleapis.com') {
+      if (parts[0] === UPLOADS_BUCKET) {
+        return parts.slice(1).join('/');
+      }
+      // Signed URLs default include bucket in the path
+      return parts.slice(1).join('/');
+    }
+
+    if (parsed.protocol === 'gs:') {
+      return parts.slice(1).join('/');
+    }
+
+    if (process.env.UPLOADS_BASE_URL) {
+      const base = new URL(process.env.UPLOADS_BASE_URL);
+      if (parsed.origin === base.origin) {
+        const basePath = base.pathname.replace(/\/+$/, '');
+        let relPath = parsed.pathname;
+        if (basePath && relPath.startsWith(basePath)) {
+          relPath = relPath.slice(basePath.length);
+        }
+        return relPath.replace(/^\/+/, '');
+      }
+    }
+  } catch (error) {
+    return null;
+  }
+
+  return null;
+}
+
+export async function deleteUploadedFiles(
+  urls: Array<string | null | undefined>
+): Promise<void> {
+  const filtered = urls.filter(Boolean) as string[];
+  if (!filtered.length) {
+    return;
+  }
+
+  if (UPLOADS_BUCKET) {
+    try {
+      const accessToken = await getGcpAccessToken();
+      await Promise.all(
+        filtered.map(async (url) => {
+          const key = extractGcsObjectKey(url);
+          if (!key) {
+            return;
+          }
+          const deleteUrl = `${GCS_API_BASE}/storage/v1/b/${encodeRFC3986(
+            UPLOADS_BUCKET
+          )}/o/${encodeRFC3986(key)}`;
+          const response = await fetch(deleteUrl, {
+            method: 'DELETE',
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+            },
+          });
+          if (!response.ok && response.status !== 404) {
+            logWarn('uploads.delete.gcs.failed', {
+              key,
+              status: response.status,
+            });
+          }
+        })
+      );
+      return;
+    } catch (error) {
+      logWarn('uploads.delete.gcs.error', {
+        message: (error as Error)?.message ?? String(error),
+      });
+    }
+  }
+
+  const publicDir = path.join(process.cwd(), 'public');
+  await Promise.all(
+    filtered.map(async (url) => {
+      if (!url.startsWith('/uploads/')) {
+        return;
+      }
+
+      const relativePath = url.replace(/^\/+/, '');
+      const absolutePath = path.join(publicDir, relativePath);
+
+      try {
+        await fs.unlink(absolutePath);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+          logWarn('uploads.delete.local.failed', {
+            path: absolutePath,
+            error: (error as Error)?.message ?? String(error),
+          });
+        }
+      }
+    })
+  );
+}
+
 export async function savePhotoFile(file: FileLike): Promise<SavedUpload> {
   if (!ALLOWED_MIME_TYPES.has(file.type ?? 'image/jpeg')) {
     throw new Error('UNSUPPORTED_FILE_TYPE');
@@ -67,8 +375,45 @@ export async function savePhotoFile(file: FileLike): Promise<SavedUpload> {
   const buffer = Buffer.from(arrayBuffer);
   const ext = getFileExtension(file);
   const filename = `${Date.now()}-${randomUUID()}${ext}`;
-  const destination = path.join(UPLOAD_DIR, filename);
 
+  if (UPLOADS_BUCKET) {
+    try {
+      const accessToken = await getGcpAccessToken();
+      const serviceAccountEmail = await fetchMetadata(
+        'instance/service-accounts/default/email'
+      );
+      const privateKey = process.env.GCS_SIGNING_PRIVATE_KEY;
+
+      await uploadToGcs({
+        bucket: UPLOADS_BUCKET,
+        objectKey: filename,
+        buffer,
+        contentType: file.type ?? 'application/octet-stream',
+        accessToken,
+      });
+
+      const signedUrl = await generateSignedUrlV4({
+        bucket: UPLOADS_BUCKET,
+        objectKey: filename,
+        expiresInSeconds: SIGNED_URL_TTL_SECONDS,
+        accessToken,
+        serviceAccountEmail,
+        privateKey,
+      });
+
+      return {
+        url: signedUrl,
+        filePath: `gs://${UPLOADS_BUCKET}/${filename}`,
+      };
+    } catch (error) {
+      logWarn('uploads.gcs.fallback_to_local', {
+        message: (error as Error)?.message ?? String(error),
+      });
+      // Fall through to local write below
+    }
+  }
+
+  const destination = path.join(UPLOAD_DIR, filename);
   await ensureUploadDir();
   await fs.writeFile(destination, buffer);
 


### PR DESCRIPTION
### Phase 5 – First “Dev” Deploy of the Monolith

**Goal:** Deploy the app to a real dev environment with proper env vars and checks.

- [x] Choose hosting platform for v2:
  - [x] GCP Cloud Run (monolith Next.js app), private (auth required; no public unauthenticated access).
- [x] Connect repo to GCP for builds/deploys:
  - [x] Artifact Registry for images.
  - [x] Workload Identity Federation for GitHub Actions to push and deploy.
- [x] Configure **dev environment** (Cloud Run + Cloud SQL):
  - [x] `DATABASE_URL` via Cloud SQL connector socket + Secret Manager (uses dev DB password already in GSM).
  - [x] Auth/crypto secrets: `JWT_SECRET` (Secret Manager), optional seeded `FAMILY_MASTER_KEY` if needed for bootstrap.
  - [x] Prisma schema set to Postgres (`PRISMA_SCHEMA=prisma/schema.postgres.prisma`).
- [x] GCS-backed uploads:
  - [x] Create private bucket for uploads; enforce signed URL access; set `UPLOADS_BUCKET` and `UPLOADS_BASE_URL`.
  - [x] Update upload helpers to write/delete in GCS and return signed URLs for reads.
- [x] Deployments to dev:
  - [x] Auto-deploy on `develop` (and manual `workflow_dispatch`); Cloud Run service provisioned with Cloud SQL + secrets wired.
- [ ] Post-deploy verification:
  - [ ] Dev URL reachable (with auth); basic flows work (signup, login, create post, “Cooked this”, comments, favorites, profile, recipes browse/search).
  - [ ] Validate signed URL image behavior and any known limitations (e.g., search quirks) behave predictably in dev.
  
  will verify the deployment after merge to develop branch