### PR TITLE
refactor: timeline and tags and recipe search

### DIFF
--- a/__tests__/integration/api/timeline/timeline.test.ts
+++ b/__tests__/integration/api/timeline/timeline.test.ts
@@ -358,45 +358,6 @@ describe('GET /api/timeline', () => {
       expect(data.items[0].cooked.note).toBe('Turned out amazing!');
     });
 
-    it('returns timeline with post_edited activity', async () => {
-      mockGetTimelineFeed.mockResolvedValue({
-        items: [
-          {
-            id: 'edit-clh001-1234567890',
-            type: 'post_edited',
-            timestamp: new Date('2024-01-04T10:00:00.000Z'),
-            actor: {
-              id: 'user_1',
-              name: 'Alice',
-              avatarUrl: null,
-            },
-            post: {
-              id: 'clh001',
-              title: 'Chocolate Cake (Updated)',
-              mainPhotoUrl: '/uploads/cake.jpg',
-            },
-            edit: {
-              note: 'Updated baking time',
-            },
-          },
-        ],
-        hasMore: false,
-        nextOffset: 0,
-      });
-
-      const request = new NextRequest('http://localhost/api/timeline', {
-        method: 'GET',
-      });
-
-      const response = await GET(request);
-
-      expect(response.status).toBe(200);
-      const data = await parseResponseJSON(response);
-      expect(data.items).toHaveLength(1);
-      expect(data.items[0].type).toBe('post_edited');
-      expect(data.items[0].edit.note).toBe('Updated baking time');
-    });
-
     it('returns timeline with reaction_added activity', async () => {
       mockGetTimelineFeed.mockResolvedValue({
         items: [

--- a/__tests__/unit/lib/recipes.test.ts
+++ b/__tests__/unit/lib/recipes.test.ts
@@ -283,7 +283,7 @@ describe('Recipe Utilities', () => {
 
       const args = latestPostArgs();
       expect(args.where?.AND).toEqual([
-        { title: { contains: 'pasta' } },
+        { title: { contains: 'pasta', mode: 'insensitive' } },
         { authorId: { in: ['auth_1'] } },
         {
           OR: [

--- a/__tests__/unit/lib/recipes.test.ts
+++ b/__tests__/unit/lib/recipes.test.ts
@@ -86,7 +86,7 @@ describe('Recipe Utilities', () => {
 
       const args = latestPostArgs();
       expect(args?.where?.AND).toContainEqual({
-        title: { contains: 'cake' },
+        title: { contains: 'cake', mode: 'insensitive' },
       });
     });
 

--- a/__tests__/unit/lib/tags.test.ts
+++ b/__tests__/unit/lib/tags.test.ts
@@ -1,246 +1,39 @@
 /**
  * Unit Tests: Tag Utilities (src/lib/tags.ts)
- * 
- * Tests tag retrieval and grouping functionality.
- * 
+ *
+ * Tags are now hardcoded to match docs/TAGS.md.
  */
 
-import { getAllTags, TagRecord, TagGroup } from '@/lib/tags';
-
-// Mock Prisma
-jest.mock('@/lib/prisma', () => ({
-  prisma: {
-    tag: {
-      findMany: jest.fn(),
-    },
-  },
-}));
-
-import { prisma } from '@/lib/prisma';
-const mockFindMany = prisma.tag.findMany as jest.MockedFunction<typeof prisma.tag.findMany>;
+import { getAllTags, TagGroup, TagRecord } from '@/lib/tags';
 
 describe('Tag Utilities', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   describe('getAllTags()', () => {
-    it('should return empty object when no tags exist', async () => {
-      mockFindMany.mockResolvedValue([]);
-
+    it('returns the hardcoded tag groups', async () => {
       const result = await getAllTags();
 
-      expect(result).toEqual({});
-      expect(mockFindMany).toHaveBeenCalledWith({
-        orderBy: [{ type: 'asc' }, { name: 'asc' }],
-      });
-    });
-
-    it('should group tags by type', async () => {
-      const mockTags: TagRecord[] = [
-        { id: 'tag_1', name: 'vegetarian', type: 'dietary' },
-        { id: 'tag_2', name: 'vegan', type: 'dietary' },
-        { id: 'tag_3', name: 'quick', type: 'time' },
-        { id: 'tag_4', name: 'easy', type: 'difficulty' },
-      ];
-
-      mockFindMany.mockResolvedValue(mockTags as any);
-
-      const result = await getAllTags();
-
-      expect(result).toHaveProperty('dietary');
-      expect(result).toHaveProperty('time');
-      expect(result).toHaveProperty('difficulty');
-      expect(result.dietary).toHaveLength(2);
-      expect(result.time).toHaveLength(1);
-      expect(result.difficulty).toHaveLength(1);
-    });
-
-    it('should place tags with null type in "other" group', async () => {
-      const mockTags: TagRecord[] = [
-        { id: 'tag_1', name: 'favorite', type: null },
-        { id: 'tag_2', name: 'special', type: null },
-        { id: 'tag_3', name: 'vegan', type: 'dietary' },
-      ];
-
-      mockFindMany.mockResolvedValue(mockTags as any);
-
-      const result = await getAllTags();
-
-      expect(result).toHaveProperty('other');
-      expect(result.other).toHaveLength(2);
-      expect(result.other[0].name).toBe('favorite');
-      expect(result.other[1].name).toBe('special');
-    });
-
-    it('should handle tags with only null types', async () => {
-      const mockTags: TagRecord[] = [
-        { id: 'tag_1', name: 'untyped1', type: null },
-        { id: 'tag_2', name: 'untyped2', type: null },
-      ];
-
-      mockFindMany.mockResolvedValue(mockTags as any);
-
-      const result = await getAllTags();
-
-      expect(Object.keys(result)).toEqual(['other']);
-      expect(result.other).toHaveLength(2);
-    });
-
-    it('should return tags ordered by type then name', async () => {
-      const mockTags: TagRecord[] = [
-        { id: 'tag_1', name: 'apple', type: 'fruit' },
-        { id: 'tag_2', name: 'zucchini', type: 'vegetable' },
-        { id: 'tag_3', name: 'banana', type: 'fruit' },
-      ];
-
-      mockFindMany.mockResolvedValue(mockTags as any);
-
-      await getAllTags();
-
-      expect(mockFindMany).toHaveBeenCalledWith({
-        orderBy: [{ type: 'asc' }, { name: 'asc' }],
-      });
-    });
-
-    it('should handle mixed typed and untyped tags', async () => {
-      const mockTags: TagRecord[] = [
-        { id: 'tag_1', name: 'vegan', type: 'dietary' },
-        { id: 'tag_2', name: 'random', type: null },
-        { id: 'tag_3', name: 'quick', type: 'time' },
-        { id: 'tag_4', name: 'special', type: null },
-      ];
-
-      mockFindMany.mockResolvedValue(mockTags as any);
-
-      const result = await getAllTags();
-
-      expect(Object.keys(result).sort()).toEqual(['dietary', 'other', 'time'].sort());
-      expect(result.dietary).toHaveLength(1);
-      expect(result.time).toHaveLength(1);
-      expect(result.other).toHaveLength(2);
-    });
-
-    it('should preserve all tag properties', async () => {
-      const mockTags: TagRecord[] = [
-        { id: 'tag_123', name: 'gluten-free', type: 'dietary' },
-      ];
-
-      mockFindMany.mockResolvedValue(mockTags as any);
-
-      const result = await getAllTags();
-
-      expect(result.dietary[0]).toEqual({
-        id: 'tag_123',
-        name: 'gluten-free',
-        type: 'dietary',
-      });
-    });
-
-    it('should handle single tag', async () => {
-      const mockTags: TagRecord[] = [
-        { id: 'tag_1', name: 'healthy', type: 'lifestyle' },
-      ];
-
-      mockFindMany.mockResolvedValue(mockTags as any);
-
-      const result = await getAllTags();
-
-      expect(Object.keys(result)).toEqual(['lifestyle']);
-      expect(result.lifestyle).toHaveLength(1);
-      expect(result.lifestyle[0].name).toBe('healthy');
-    });
-
-    it('should handle multiple tags of same type', async () => {
-      const mockTags: TagRecord[] = [
-        { id: 'tag_1', name: 'vegetarian', type: 'dietary' },
-        { id: 'tag_2', name: 'vegan', type: 'dietary' },
-        { id: 'tag_3', name: 'gluten-free', type: 'dietary' },
-        { id: 'tag_4', name: 'dairy-free', type: 'dietary' },
-      ];
-
-      mockFindMany.mockResolvedValue(mockTags as any);
-
-      const result = await getAllTags();
-
-      expect(Object.keys(result)).toEqual(['dietary']);
-      expect(result.dietary).toHaveLength(4);
-      expect(result.dietary.map(t => t.name)).toEqual([
+      expect(Object.keys(result).sort()).toEqual(
+        ['diet-preference', 'allergen-safe'].sort()
+      );
+      expect(result['diet-preference'].map((tag) => tag.name)).toEqual([
         'vegetarian',
         'vegan',
-        'gluten-free',
+        'pescatarian',
+      ]);
+      expect(result['allergen-safe'].map((tag) => tag.name)).toEqual([
+        'nut-free',
         'dairy-free',
+        'gluten-free',
       ]);
     });
 
-    it('should handle many different tag types', async () => {
-      const mockTags: TagRecord[] = [
-        { id: 'tag_1', name: 'vegan', type: 'dietary' },
-        { id: 'tag_2', name: 'quick', type: 'time' },
-        { id: 'tag_3', name: 'easy', type: 'difficulty' },
-        { id: 'tag_4', name: 'italian', type: 'cuisine' },
-        { id: 'tag_5', name: 'comfort', type: 'mood' },
-      ];
-
-      mockFindMany.mockResolvedValue(mockTags as any);
-
+    it('provides stable ids and type values', async () => {
       const result = await getAllTags();
+      const sample = result['diet-preference'][0];
 
-      expect(Object.keys(result).sort()).toEqual([
-        'dietary',
-        'time',
-        'difficulty',
-        'cuisine',
-        'mood',
-      ].sort());
-      expect(Object.values(result).every(group => group.length === 1)).toBe(true);
-    });
-
-    it('should return TagGroup type structure', async () => {
-      const mockTags: TagRecord[] = [
-        { id: 'tag_1', name: 'test', type: 'type1' },
-      ];
-
-      mockFindMany.mockResolvedValue(mockTags as any);
-
-      const result = await getAllTags();
-
-      // Verify it matches TagGroup type structure
-      expect(typeof result).toBe('object');
-      expect(result).not.toBeNull();
-      expect(Array.isArray(result)).toBe(false);
-      
-      // Each value should be an array of TagRecords
-      for (const group of Object.values(result)) {
-        expect(Array.isArray(group)).toBe(true);
-        for (const tag of group) {
-          expect(tag).toHaveProperty('id');
-          expect(tag).toHaveProperty('name');
-          expect(tag).toHaveProperty('type');
-        }
-      }
-    });
-
-    it('should handle Prisma query errors gracefully', async () => {
-      mockFindMany.mockRejectedValue(new Error('Database error'));
-
-      await expect(getAllTags()).rejects.toThrow('Database error');
-    });
-
-    it('should call Prisma with correct ordering parameters', async () => {
-      mockFindMany.mockResolvedValue([]);
-
-      await getAllTags();
-
-      expect(mockFindMany).toHaveBeenCalledTimes(1);
-      expect(mockFindMany).toHaveBeenCalledWith(
-        expect.objectContaining({
-          orderBy: expect.arrayContaining([
-            { type: 'asc' },
-            { name: 'asc' },
-          ]),
-        })
-      );
+      expect(sample).toHaveProperty('id');
+      expect(sample).toHaveProperty('name');
+      expect(sample).toHaveProperty('type', 'diet-preference');
+      expect(sample.id).toBe(`diet-preference:${sample.name}`);
     });
   });
 
@@ -269,160 +62,12 @@ describe('Tag Utilities', () => {
 
     it('should export TagGroup type', () => {
       const tagGroup: TagGroup = {
-        dietary: [
-          { id: 'tag_1', name: 'vegan', type: 'dietary' },
-        ],
-        time: [
-          { id: 'tag_2', name: 'quick', type: 'time' },
-        ],
+        dietary: [{ id: 'tag_1', name: 'vegan', type: 'dietary' }],
+        time: [{ id: 'tag_2', name: 'quick', type: 'time' }],
       };
 
       expect(tagGroup).toHaveProperty('dietary');
       expect(tagGroup).toHaveProperty('time');
-    });
-  });
-
-  describe('Integration Scenarios', () => {
-    it('should support typical recipe tagging workflow', async () => {
-      const mockTags: TagRecord[] = [
-        { id: 'tag_1', name: 'vegetarian', type: 'dietary' },
-        { id: 'tag_2', name: 'gluten-free', type: 'dietary' },
-        { id: 'tag_3', name: 'under-30-min', type: 'time' },
-        { id: 'tag_4', name: 'easy', type: 'difficulty' },
-        { id: 'tag_5', name: 'italian', type: 'cuisine' },
-      ];
-
-      mockFindMany.mockResolvedValue(mockTags as any);
-
-      const result = await getAllTags();
-
-      // Verify we can access tags by category for UI display
-      expect(result.dietary).toBeDefined();
-      expect(result.time).toBeDefined();
-      expect(result.difficulty).toBeDefined();
-      expect(result.cuisine).toBeDefined();
-
-      // Verify dietary tags are grouped together
-      const dietaryTagNames = result.dietary.map(t => t.name);
-      expect(dietaryTagNames).toContain('vegetarian');
-      expect(dietaryTagNames).toContain('gluten-free');
-    });
-
-    it('should support tag selection in recipe forms', async () => {
-      const mockTags: TagRecord[] = [
-        { id: 'tag_1', name: 'vegan', type: 'dietary' },
-        { id: 'tag_2', name: 'quick', type: 'time' },
-      ];
-
-      mockFindMany.mockResolvedValue(mockTags as any);
-
-      const result = await getAllTags();
-
-      // Simulate rendering tag options grouped by type
-      const tagOptions = Object.entries(result).flatMap(([type, tags]) =>
-        tags.map(tag => ({
-          value: tag.id,
-          label: tag.name,
-          group: type,
-        }))
-      );
-
-      expect(tagOptions.length).toBe(2);
-      expect(tagOptions[0]).toMatchObject({
-        value: expect.any(String),
-        label: expect.any(String),
-        group: expect.any(String),
-      });
-    });
-
-    it('should handle empty database gracefully for new installations', async () => {
-      mockFindMany.mockResolvedValue([]);
-
-      const result = await getAllTags();
-
-      expect(result).toEqual({});
-      expect(Object.keys(result)).toHaveLength(0);
-    });
-
-    it('should support filtering recipes by tag groups', async () => {
-      const mockTags: TagRecord[] = [
-        { id: 'tag_1', name: 'vegan', type: 'dietary' },
-        { id: 'tag_2', name: 'vegetarian', type: 'dietary' },
-        { id: 'tag_3', name: 'quick', type: 'time' },
-      ];
-
-      mockFindMany.mockResolvedValue(mockTags as any);
-
-      const result = await getAllTags();
-
-      // Get all dietary restriction tags for filtering UI
-      const dietaryTags = result.dietary || [];
-      expect(dietaryTags.length).toBe(2);
-      
-      // Get all time-based tags
-      const timeTags = result.time || [];
-      expect(timeTags.length).toBe(1);
-    });
-  });
-
-  describe('Edge Cases', () => {
-    it('should handle tags with special characters in names', async () => {
-      const mockTags: TagRecord[] = [
-        { id: 'tag_1', name: 'gluten-free', type: 'dietary' },
-        { id: 'tag_2', name: 'kid-friendly', type: 'audience' },
-        { id: 'tag_3', name: '< 30 min', type: 'time' },
-      ];
-
-      mockFindMany.mockResolvedValue(mockTags as any);
-
-      const result = await getAllTags();
-
-      expect(result.dietary[0].name).toBe('gluten-free');
-      expect(result.audience[0].name).toBe('kid-friendly');
-      expect(result.time[0].name).toBe('< 30 min');
-    });
-
-    it('should handle tags with empty string type as other', async () => {
-      const mockTags: TagRecord[] = [
-        { id: 'tag_1', name: 'misc', type: '' as any },
-      ];
-
-      mockFindMany.mockResolvedValue(mockTags as any);
-
-      const result = await getAllTags();
-
-      // Empty string should be treated as a valid type, not mapped to "other"
-      expect(result['']).toBeDefined();
-    });
-
-    it('should handle very long tag names', async () => {
-      const longName = 'a'.repeat(200);
-      const mockTags: TagRecord[] = [
-        { id: 'tag_1', name: longName, type: 'test' },
-      ];
-
-      mockFindMany.mockResolvedValue(mockTags as any);
-
-      const result = await getAllTags();
-
-      expect(result.test[0].name).toBe(longName);
-      expect(result.test[0].name.length).toBe(200);
-    });
-
-    it('should maintain insertion order within groups', async () => {
-      const mockTags: TagRecord[] = [
-        { id: 'tag_1', name: 'first', type: 'order' },
-        { id: 'tag_2', name: 'second', type: 'order' },
-        { id: 'tag_3', name: 'third', type: 'order' },
-      ];
-
-      mockFindMany.mockResolvedValue(mockTags as any);
-
-      const result = await getAllTags();
-
-      expect(result.order[0].name).toBe('first');
-      expect(result.order[1].name).toBe('second');
-      expect(result.order[2].name).toBe('third');
     });
   });
 });

--- a/__tests__/unit/lib/timeline-data.test.ts
+++ b/__tests__/unit/lib/timeline-data.test.ts
@@ -428,181 +428,6 @@ describe('Timeline Data Aggregation', () => {
     });
   });
 
-  describe('getTimelineFeed - Edit Events', () => {
-    it('returns post_edited events', async () => {
-      const createdAt = new Date('2024-01-01T10:00:00.000Z');
-      const editedAt = new Date('2024-01-01T14:00:00.000Z');
-
-      const mockEditedPost = withPostStorage({
-        id: 'post_1',
-        title: 'Chocolate Cake (Updated)',
-        mainPhotoUrl: '/cake.jpg',
-        createdAt,
-        lastEditAt: editedAt,
-        lastEditNote: 'Updated baking time',
-        editor: {
-          id: 'user_5',
-          name: 'Eve',
-          avatarUrl: null,
-        },
-        author: {
-          id: 'user_1',
-          name: 'Alice',
-          avatarUrl: null,
-        },
-      });
-
-      prismaMock.post.findMany
-        .mockResolvedValueOnce([])
-        .mockResolvedValue([mockEditedPost] as any);
-      prismaMock.comment.findMany.mockResolvedValue([]);
-      prismaMock.reaction.findMany.mockResolvedValue([]);
-      prismaMock.cookedEvent.findMany.mockResolvedValue([]);
-
-      const result = await getTimelineFeed({ familySpaceId: 'family_1' });
-
-      expect(result.items).toHaveLength(1);
-      expect(result.items[0]).toEqual({
-        id: `edit-post_1-${editedAt.getTime()}`,
-        type: 'post_edited',
-        timestamp: editedAt,
-        actor: {
-          id: 'user_5',
-          name: 'Eve',
-          avatarUrl: null,
-        },
-        post: {
-          id: 'post_1',
-          title: 'Chocolate Cake (Updated)',
-          mainPhotoUrl: '/cake.jpg',
-        },
-        edit: {
-          note: 'Updated baking time',
-        },
-      });
-    });
-
-    it('uses author as actor when editor is null', async () => {
-      const createdAt = new Date('2024-01-01T10:00:00.000Z');
-      const editedAt = new Date('2024-01-01T14:00:00.000Z');
-
-      const mockEditedPost = withPostStorage({
-        id: 'post_1',
-        title: 'Recipe',
-        mainPhotoUrl: null,
-        createdAt,
-        lastEditAt: editedAt,
-        lastEditNote: null,
-        editor: null,
-        author: {
-          id: 'user_1',
-          name: 'Alice',
-          avatarUrl: null,
-        },
-      });
-
-      prismaMock.post.findMany
-        .mockResolvedValueOnce([])
-        .mockResolvedValue([mockEditedPost] as any);
-      prismaMock.comment.findMany.mockResolvedValue([]);
-      prismaMock.reaction.findMany.mockResolvedValue([]);
-      prismaMock.cookedEvent.findMany.mockResolvedValue([]);
-
-      const result = await getTimelineFeed({ familySpaceId: 'family_1' });
-
-      expect(result.items[0].actor).toEqual({
-        id: 'user_1',
-        name: 'Alice',
-        avatarUrl: null,
-      });
-    });
-
-    it('skips edit events when lastEditAt is null', async () => {
-      const mockPost = withPostStorage({
-        id: 'post_1',
-        title: 'Recipe',
-        mainPhotoUrl: null,
-        createdAt: new Date('2024-01-01T10:00:00.000Z'),
-        lastEditAt: null,
-        lastEditNote: null,
-        editor: null,
-        author: {
-          id: 'user_1',
-          name: 'Alice',
-          avatarUrl: null,
-        },
-      });
-
-      prismaMock.post.findMany
-        .mockResolvedValueOnce([])
-        .mockResolvedValue([mockPost] as any);
-      prismaMock.comment.findMany.mockResolvedValue([]);
-      prismaMock.reaction.findMany.mockResolvedValue([]);
-      prismaMock.cookedEvent.findMany.mockResolvedValue([]);
-
-      const result = await getTimelineFeed({ familySpaceId: 'family_1' });
-
-      expect(result.items).toHaveLength(0);
-    });
-
-    it('skips edit events when lastEditAt equals createdAt', async () => {
-      const timestamp = new Date('2024-01-01T10:00:00.000Z');
-
-      const mockPost = withPostStorage({
-        id: 'post_1',
-        title: 'Recipe',
-        mainPhotoUrl: null,
-        createdAt: timestamp,
-        lastEditAt: timestamp,
-        lastEditNote: null,
-        editor: null,
-        author: {
-          id: 'user_1',
-          name: 'Alice',
-          avatarUrl: null,
-        },
-      });
-
-      prismaMock.post.findMany
-        .mockResolvedValueOnce([])
-        .mockResolvedValue([mockPost] as any);
-      prismaMock.comment.findMany.mockResolvedValue([]);
-      prismaMock.reaction.findMany.mockResolvedValue([]);
-      prismaMock.cookedEvent.findMany.mockResolvedValue([]);
-
-      const result = await getTimelineFeed({ familySpaceId: 'family_1' });
-
-      expect(result.items).toHaveLength(0);
-    });
-
-    it('skips edit events when both editor and author are null', async () => {
-      const createdAt = new Date('2024-01-01T10:00:00.000Z');
-      const editedAt = new Date('2024-01-01T14:00:00.000Z');
-
-      const mockPost = withPostStorage({
-        id: 'post_1',
-        title: 'Recipe',
-        mainPhotoUrl: null,
-        createdAt,
-        lastEditAt: editedAt,
-        lastEditNote: null,
-        editor: null,
-        author: null,
-      });
-
-      prismaMock.post.findMany
-        .mockResolvedValueOnce([])
-        .mockResolvedValue([mockPost] as any);
-      prismaMock.comment.findMany.mockResolvedValue([]);
-      prismaMock.reaction.findMany.mockResolvedValue([]);
-      prismaMock.cookedEvent.findMany.mockResolvedValue([]);
-
-      const result = await getTimelineFeed({ familySpaceId: 'family_1' });
-
-      expect(result.items).toHaveLength(0);
-    });
-  });
-
   describe('getTimelineFeed - Sorting', () => {
     it('sorts all events by timestamp descending', async () => {
       const mockPost = withPostStorage({
@@ -884,7 +709,7 @@ describe('Timeline Data Aggregation', () => {
       expect(result.items.every((item) => item.post.id)).toBe(true);
     });
 
-    it('queries posts for both creation and edit events', async () => {
+    it('queries posts for creation events', async () => {
       prismaMock.post.findMany.mockResolvedValue([]);
       prismaMock.comment.findMany.mockResolvedValue([]);
       prismaMock.reaction.findMany.mockResolvedValue([]);
@@ -892,8 +717,7 @@ describe('Timeline Data Aggregation', () => {
 
       await getTimelineFeed({ familySpaceId: 'family_1' });
 
-      // Should be called twice: once for post_created, once for edit events
-      expect(prismaMock.post.findMany).toHaveBeenCalledTimes(2);
+      expect(prismaMock.post.findMany).toHaveBeenCalledTimes(1);
     });
 
     it('handles familySpaceId filtering correctly', async () => {

--- a/__tests__/unit/lib/timeline.test.ts
+++ b/__tests__/unit/lib/timeline.test.ts
@@ -39,7 +39,9 @@ describe('Timeline Utilities', () => {
       const result = formatRelativeTime(date);
 
       expect(result).toBe('5 minutes ago');
-      expect(mockFormatDistanceToNow).toHaveBeenCalledWith(date, { addSuffix: true });
+      expect(mockFormatDistanceToNow).toHaveBeenCalledWith(date, {
+        addSuffix: true,
+      });
     });
 
     it('formats a date from hours ago', () => {
@@ -49,7 +51,9 @@ describe('Timeline Utilities', () => {
       const result = formatRelativeTime(date);
 
       expect(result).toBe('2 hours ago');
-      expect(mockFormatDistanceToNow).toHaveBeenCalledWith(date, { addSuffix: true });
+      expect(mockFormatDistanceToNow).toHaveBeenCalledWith(date, {
+        addSuffix: true,
+      });
     });
 
     it('formats a date from days ago', () => {
@@ -59,7 +63,9 @@ describe('Timeline Utilities', () => {
       const result = formatRelativeTime(date);
 
       expect(result).toBe('7 days ago');
-      expect(mockFormatDistanceToNow).toHaveBeenCalledWith(date, { addSuffix: true });
+      expect(mockFormatDistanceToNow).toHaveBeenCalledWith(date, {
+        addSuffix: true,
+      });
     });
 
     it('formats a date from months ago', () => {
@@ -69,7 +75,9 @@ describe('Timeline Utilities', () => {
       const result = formatRelativeTime(date);
 
       expect(result).toBe('3 months ago');
-      expect(mockFormatDistanceToNow).toHaveBeenCalledWith(date, { addSuffix: true });
+      expect(mockFormatDistanceToNow).toHaveBeenCalledWith(date, {
+        addSuffix: true,
+      });
     });
 
     it('formats a date from years ago', () => {
@@ -79,7 +87,9 @@ describe('Timeline Utilities', () => {
       const result = formatRelativeTime(date);
 
       expect(result).toBe('about 2 years ago');
-      expect(mockFormatDistanceToNow).toHaveBeenCalledWith(date, { addSuffix: true });
+      expect(mockFormatDistanceToNow).toHaveBeenCalledWith(date, {
+        addSuffix: true,
+      });
     });
 
     it('handles just now', () => {
@@ -89,7 +99,9 @@ describe('Timeline Utilities', () => {
       const result = formatRelativeTime(date);
 
       expect(result).toBe('less than a minute ago');
-      expect(mockFormatDistanceToNow).toHaveBeenCalledWith(date, { addSuffix: true });
+      expect(mockFormatDistanceToNow).toHaveBeenCalledWith(date, {
+        addSuffix: true,
+      });
     });
 
     it('passes options correctly to date-fns', () => {
@@ -98,7 +110,9 @@ describe('Timeline Utilities', () => {
 
       formatRelativeTime(date);
 
-      expect(mockFormatDistanceToNow).toHaveBeenCalledWith(date, { addSuffix: true });
+      expect(mockFormatDistanceToNow).toHaveBeenCalledWith(date, {
+        addSuffix: true,
+      });
     });
   });
 
@@ -123,11 +137,6 @@ describe('Timeline Utilities', () => {
       expect(result).toBe('cooked');
     });
 
-    it('returns "updated" for post_edited', () => {
-      const result = getActionText('post_edited');
-      expect(result).toBe('updated');
-    });
-
     it('returns "shared" for unknown type (default case)', () => {
       const result = getActionText('unknown_type' as TimelineItemType);
       expect(result).toBe('shared');
@@ -139,7 +148,6 @@ describe('Timeline Utilities', () => {
         'comment_added',
         'reaction_added',
         'cooked_logged',
-        'post_edited',
       ];
 
       types.forEach((type) => {

--- a/docs/TAGS.md
+++ b/docs/TAGS.md
@@ -7,34 +7,3 @@ Allergen-safe:
 • nut-free
 • dairy-free
 • gluten-free
-
-Heat:
-• mild
-• medium-spicy
-• spicy
-• extra-spicy
-
-Flavor notes:
-• sweet
-• savory
-• tangy
-• smoky
-• herby
-• garlicky
-• umami
-• rich
-• fresh (e.g., lots of herbs/veg)
-
-Cusine:
-• american
-• italian
-• mexican
-• mediterranean
-• greek
-• indian
-• chinese
-• japanese
-• thai
-• middle-eastern
-• latin-american
-• fusion

--- a/src/components/timeline/TimelineCard.tsx
+++ b/src/components/timeline/TimelineCard.tsx
@@ -32,8 +32,6 @@ function getMetadata(item: TimelineItem): string | null {
         return `${item.cooked.rating} ★`;
       }
       return null;
-    case 'post_edited':
-      return null;
     default:
       return null;
   }
@@ -51,18 +49,7 @@ function renderExtra(item: TimelineItem) {
       if (!item.cooked?.note) {
         return null;
       }
-      return (
-        <p className="text-sm text-gray-600">“{item.cooked.note}”</p>
-      );
-    case 'post_edited':
-      if (!item.edit?.note) {
-        return null;
-      }
-      return (
-        <div className="rounded-2xl bg-amber-50 p-3 text-sm text-amber-900">
-          “{item.edit.note}”
-        </div>
-      );
+      return <p className="text-sm text-gray-600">“{item.cooked.note}”</p>;
     default:
       return null;
   }

--- a/src/lib/recipes.ts
+++ b/src/lib/recipes.ts
@@ -116,6 +116,7 @@ export async function getRecipes(
       andFilters.push({
         title: {
           contains: searchValue,
+          mode: 'insensitive',
         },
       });
     }

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -1,5 +1,3 @@
-import { prisma } from '@/lib/prisma';
-
 export interface TagRecord {
   id: string;
   name: string;
@@ -8,18 +6,24 @@ export interface TagRecord {
 
 export type TagGroup = Record<string, TagRecord[]>;
 
-export async function getAllTags(): Promise<TagGroup> {
-  const tags = await prisma.tag.findMany({
-    orderBy: [{ type: 'asc' }, { name: 'asc' }],
-  });
+const TAG_GROUP_DEFINITIONS: Array<{ type: string; names: string[] }> = [
+  {
+    type: 'diet-preference',
+    names: ['vegetarian', 'vegan', 'pescatarian'],
+  },
+  {
+    type: 'allergen-safe',
+    names: ['nut-free', 'dairy-free', 'gluten-free'],
+  },
+];
 
-  const tagArray = tags as TagRecord[];
-  return tagArray.reduce((groups: TagGroup, tag: TagRecord) => {
-    const key = tag.type ?? 'other';
-    if (!groups[key]) {
-      groups[key] = [];
-    }
-    groups[key].push(tag);
+export async function getAllTags(): Promise<TagGroup> {
+  return TAG_GROUP_DEFINITIONS.reduce((groups: TagGroup, group) => {
+    groups[group.type] = group.names.map((name) => ({
+      id: `${group.type}:${name}`,
+      name,
+      type: group.type,
+    }));
     return groups;
   }, {} as TagGroup);
 }

--- a/src/lib/timeline.ts
+++ b/src/lib/timeline.ts
@@ -4,8 +4,7 @@ export type TimelineItemType =
   | 'post_created'
   | 'comment_added'
   | 'reaction_added'
-  | 'cooked_logged'
-  | 'post_edited';
+  | 'cooked_logged';
 
 export interface TimelineActor {
   id: string;
@@ -62,23 +61,11 @@ export interface CookedLoggedItem {
   };
 }
 
-export interface PostEditedItem {
-  id: string;
-  type: 'post_edited';
-  timestamp: Date;
-  actor: TimelineActor;
-  post: TimelinePostSummary;
-  edit: {
-    note: string | null;
-  };
-}
-
 export type TimelineItem =
   | PostCreatedItem
   | CommentAddedItem
   | ReactionAddedItem
-  | CookedLoggedItem
-  | PostEditedItem;
+  | CookedLoggedItem;
 
 export function formatRelativeTime(date: Date): string {
   return formatDistanceToNow(date, { addSuffix: true });
@@ -94,8 +81,6 @@ export function getActionText(type: TimelineItemType): string {
       return 'reacted to';
     case 'cooked_logged':
       return 'cooked';
-    case 'post_edited':
-      return 'updated';
     default:
       return 'shared';
   }


### PR DESCRIPTION
 Remove post_edited events and related logic from timeline h…andling

- Removed handling of post_edited events from the timeline data aggregation logic.
- Updated timeline-related tests to reflect the removal of post_edited events.
- Adjusted the timeline card component to no longer display edit notes.
- Modified the recipes search functionality to include case-insensitive title matching.
- Refactored tag retrieval to use hardcoded tag groups instead of database queries.
- Cleaned up the timeline utility functions and types to remove references to post_edited.