### PR TITLE
chore: commit CLAUDE.md guides and .github templates (#29)

### DIFF
--- a/.github/GITHUB_GUIDE.md
+++ b/.github/GITHUB_GUIDE.md
@@ -1,0 +1,148 @@
+# GitHub Usage Guide
+
+How we use GitHub Issues, branches, commits, and PRs on family-recipe.
+
+## Environments and release flow
+
+- `main` — **production**. Only updated via release PRs from `develop`.
+- `develop` — **dev environment**. All feature work lands here first.
+- Feature branches are cut from `develop` and merged back into `develop`.
+- To release, open a PR from `develop` → `main`. Only the repo owner cuts these.
+
+---
+
+## Principles
+
+- Non-trivial work has a GitHub issue before it starts — trivial fixes (typos, one-line bugs) can skip the issue
+- PRs exist even for solo work — they are a review checkpoint
+- Commits reference the issue number when one exists
+
+---
+
+## Issues
+
+### Ticket format
+
+Tickets use the templates in [ISSUE_TEMPLATE/](ISSUE_TEMPLATE/) — one per type (`feature`, `chore`, `research`). The template applies the `type:` label automatically via frontmatter. See [TICKET_FORMAT.md](TICKET_FORMAT.md) for the rationale behind each section.
+
+### When to create one
+
+Before starting any feature, bug, research spike, or non-trivial chore. If you are about to write more than a few lines of code and there is no issue for it, create one first.
+
+### Labels
+
+The only required namespace is `type:`, which the issue templates apply automatically:
+
+| Namespace | Labels                                   |
+| --------- | ---------------------------------------- |
+| `type:`   | `feature` · `bug` · `chore` · `research` |
+
+Add extra labels freely (e.g. area or priority tags) when they help filter issues later — no strict taxonomy is enforced.
+
+---
+
+## Branches
+
+### Naming convention
+
+```
+{type}/{issue-number}/short-description
+```
+
+Where `type` matches the ticket type: `feature`, `fix`, `chore`, or `research`. If there's no issue (trivial fix), omit the number: `fix/typo-in-readme`.
+
+Examples:
+
+```
+feature/12/cooked-event-reactions
+fix/18/recipe-importer-timeout
+chore/7/upgrade-next-15
+research/3/gcs-vs-r2-uploads
+```
+
+Always branch from `develop`. Never commit directly to `main` or `develop`.
+
+---
+
+## Commits
+
+### Format
+
+```
+{type}: {description} (#{issue-number})
+```
+
+The `(#N)` suffix is optional when there is no issue.
+
+Types:
+| Type | Use for |
+|------|---------|
+| `feat` | New feature code |
+| `fix` | Bug fix |
+| `chore` | Config, tooling, setup |
+| `refactor` | Code restructure, no behavior change |
+| `test` | Tests only |
+| `docs` | Documentation only |
+| `research` | Research spike findings |
+
+Examples (from this repo's history):
+
+```
+feat: add validation for recipe ingredient name and origin length
+fix: test for case sensitivity update
+refactor: Remove post_edited events and related logic from timeline handling
+```
+
+Keep commit subjects under 72 characters. Add a body for non-obvious context.
+
+---
+
+## Pull Requests
+
+All work merges via PR — no direct pushes to `main` or `develop`.
+
+### Workflow
+
+1. Create a branch from `develop` using the naming convention above
+2. Do the work, committing with issue references where applicable
+3. Open a PR targeting `develop` — title matches the issue title
+4. Body uses the template in [pull_request_template.md](pull_request_template.md)
+5. Review the diff yourself before merging
+6. Squash merge into `develop` to keep history clean
+7. Delete the branch after merge
+8. When ready to release, open a PR from `develop` → `main`. Release PRs use **merge commits**, not squash, so individual features stay visible in `main` history
+
+### PR title format
+
+```
+{type}: {issue title} (#{N})
+```
+
+Example: `feat: cooked-event reactions (#12)`
+
+### CI gates on every PR
+
+`.github/workflows/ci.yml` runs typecheck, lint, tests, docker build, trivy scan, prisma validate, `npm audit`, dependency-review, semgrep, IaC scan, and gitleaks. Separate workflows run for [apps/api/](../apps/api/) and [apps/recipe-url-importer/](../apps/recipe-url-importer/). All must pass before merging.
+
+---
+
+## Research Spikes
+
+Research issues are complete when:
+
+1. A written summary is committed to `docs/research/{topic}.md`
+2. The doc answers the questions listed in the issue
+3. The issue is closed with a comment linking to the committed doc
+
+Research docs are reference material for implementation decisions — keep them concise and decision-oriented.
+
+---
+
+## Creating issues mid-development
+
+When work surfaces something that needs tracking:
+
+1. Create the issue before context-switching to it
+2. Pick the right template so the `type:` label is applied
+3. Link it from the originating PR or commit
+4. Reference it in future commits that address it

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,19 @@
+---
+name: Chore
+about: Setup, configuration, infrastructure, or maintenance work
+labels: 'type: chore'
+---
+
+**Ticket Description:**
+[What needs to be set up or done and why it is needed]
+
+**Tasks:**
+
+- [ ]
+- [ ]
+- [ ]
+
+**Testing:**
+
+-
+-

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,21 @@
+---
+name: Feature
+about: A new user-facing feature or capability
+labels: 'type: feature'
+---
+
+**Ticket Description:**
+As a [role]
+I want to [action]
+So that [outcome]
+
+**Acceptance Criteria:**
+
+-
+-
+-
+
+**Testing:**
+
+-
+-

--- a/.github/ISSUE_TEMPLATE/research.md
+++ b/.github/ISSUE_TEMPLATE/research.md
@@ -1,0 +1,22 @@
+---
+name: Research Spike
+about: A time-boxed investigation to answer specific questions before implementation
+labels: 'type: research'
+---
+
+**Ticket Description:**
+[What we are researching and why it matters to the project]
+
+**Questions to Answer:**
+
+-
+-
+-
+
+**Output:**
+A written summary committed to `docs/research/<topic>.md`
+
+**Testing:**
+
+- Research doc answers all listed questions with specific recommendations
+- Unblocks implementation tickets: #

--- a/.github/TICKET_FORMAT.md
+++ b/.github/TICKET_FORMAT.md
@@ -1,0 +1,78 @@
+# Ticket Format Guide
+
+All tickets follow one of three formats depending on type. Apply the correct format based on the `type:` label.
+
+---
+
+## Feature Tickets (`type: feature`)
+
+```markdown
+**Ticket Description:**
+As a [role]
+I want to [action]
+So that [outcome]
+
+**Acceptance Criteria:**
+
+- [observable outcome 1]
+- [observable outcome 2]
+- [observable outcome 3]
+
+**Testing:**
+
+- [what to verify and how]
+- [edge case to exercise]
+- [expected failure behavior]
+```
+
+---
+
+## Research Spike Tickets (`type: research`)
+
+```markdown
+**Ticket Description:**
+[What we are researching and why it matters to the project]
+
+**Questions to Answer:**
+
+- [specific question 1]
+- [specific question 2]
+- [specific question 3]
+
+**Output:**
+[What gets committed when this ticket is closed — e.g., a doc at docs/research/topic.md]
+
+**Testing:**
+
+- [how we know the research was sufficient]
+- [which implementation tickets this should unblock]
+```
+
+---
+
+## Chore Tickets (`type: chore`)
+
+```markdown
+**Ticket Description:**
+[What needs to be set up or done and why it is needed]
+
+**Tasks:**
+
+- [ ] [concrete step 1]
+- [ ] [concrete step 2]
+- [ ] [concrete step 3]
+
+**Testing:**
+
+- [how to verify it is working correctly]
+- [smoke test or observable outcome]
+```
+
+---
+
+## Notes
+
+- Acceptance Criteria describe **observable outcomes**, not implementation steps
+- Testing describes **how to validate** the ticket is complete, not how to implement it
+- Research outputs are always committed to `docs/research/` and linked in the closing comment
+- Chore tasks use checkboxes so progress is visible directly in the ticket

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Summary
+
+-
+-
+
+## Closes
+
+Closes #
+
+## Test notes
+
+- How to verify this works locally
+- Edge cases exercised

--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ __pycache__/
 
 # Husky (git hooks will be installed locally)
 .husky/_
+
+# CLAUDE
+/.claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,16 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Session Startup Checklist
+
+Before doing any work, a new Claude session should:
+
+1. **Check what's in flight** — look at the [Family Recipe Project board](https://github.com/users/wnorowskie/projects/4) for issues marked `In Progress`. Do not start work that overlaps with an open in-progress ticket.
+2. **Check the current branch** — run `git branch` and `git status`. If already on a feature branch, read the associated issue before continuing.
+3. **Check recent history** — run `git log --oneline -10` to understand what was last completed.
+4. **Confirm the issue exists** — every piece of work must have a GitHub issue. Create one before starting if it doesn't exist.
+5. **Follow the conventions** — branch naming, commit format, and PR workflow are in [.github/GITHUB_GUIDE.md](.github/GITHUB_GUIDE.md). Ticket format is in [.github/TICKET_FORMAT.md](.github/TICKET_FORMAT.md).
+
 ## Project
 
 Private family-only web app for sharing recipes and cooking activity. Single `FamilySpace` model with members joining via a hashed master key. Currently in **testing with real family users**, so prefer minimal, non-breaking changes and protect existing data flows.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,92 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+Private family-only web app for sharing recipes and cooking activity. Single `FamilySpace` model with members joining via a hashed master key. Currently in **testing with real family users**, so prefer minimal, non-breaking changes and protect existing data flows.
+
+The product/domain truth lives in [docs/PRODUCT_SPEC.md](docs/PRODUCT_SPEC.md), [docs/USER_STORIES.md](docs/USER_STORIES.md), and [docs/TECHNICAL_SPEC.md](docs/TECHNICAL_SPEC.md). The most up-to-date narrative is [docs/V1_DETAILED_SUMMARY.md](docs/V1_DETAILED_SUMMARY.md).
+
+## Commands
+
+```bash
+# Dev / build
+npm run dev                  # Next.js dev server on :3000
+npm run build                # Production build
+npm run type-check           # tsc --noEmit (also runs in pre-commit)
+npm run lint                 # next lint
+npm run lint:fix             # auto-fix
+npm run format               # prettier write
+
+# Tests (Jest, see jest.config.js)
+npm test                     # all tests
+npm run test:unit            # __tests__/unit only
+npm run test:integration     # __tests__/integration only
+npm run test:watch
+npm run test:coverage        # enforces 75% global threshold
+npx jest path/to/file.test.ts                  # single file
+npx jest -t "should reject unauthenticated"    # filter by name
+
+# Database (defaults to SQLite via prisma/schema.prisma)
+npm run db:generate          # prisma generate
+npm run db:push              # prisma db push (SQLite workflow — no migrations)
+npm run db:seed              # tsx prisma/seed.ts; PRINTS the family master key
+npm run db:studio
+```
+
+When working against Postgres locally, set `PRISMA_SCHEMA=prisma/schema.postgres.prisma` and pass `--schema $PRISMA_SCHEMA` to prisma commands. See [prisma/CLAUDE.md](prisma/CLAUDE.md).
+
+## Architecture (the things that span files)
+
+**Three concurrent runtimes share one database.** Code lives in three places that must stay schema-consistent:
+
+1. **Next.js monolith** ([src/](src/)) — App Router UI + REST-ish API under [src/app/api/](src/app/api/). Today this is the production backend.
+2. **FastAPI service** ([apps/api/](apps/api/)) — Python re-implementation of the same auth/session/JSON contract. Mid-migration target per [docs/API_BACKEND_MIGRATION_PLAN.md](docs/API_BACKEND_MIGRATION_PLAN.md). When changing an endpoint in `src/app/api/`, check whether the equivalent router in `apps/api/src/routers/` needs the same change.
+3. **Recipe URL Importer** ([apps/recipe-url-importer/](apps/recipe-url-importer/)) — standalone Python service called by the Next backend (see [apps/recipe-url-importer/SPEC.md](apps/recipe-url-importer/SPEC.md)). Does not touch the database.
+
+**Three Prisma schemas** describe the same domain for different deploy targets — [prisma/CLAUDE.md](prisma/CLAUDE.md) explains when to edit which.
+
+**Auth flow.** Credentials login → bcrypt verify → JWT signed with `jose` ([src/lib/jwt.ts](src/lib/jwt.ts)) → HTTP-only `session` cookie. [src/middleware.ts](src/middleware.ts) gates the `(app)` route group; API routes use `withAuth`/`withRole` wrappers from [src/lib/apiAuth.ts](src/lib/apiAuth.ts). See [src/app/api/CLAUDE.md](src/app/api/CLAUDE.md) for the handler pattern.
+
+**Family scoping is implicit.** Every authenticated handler receives `user.familySpaceId`. All Post/Comment/Reaction/etc. queries must filter by it — there is no row-level enforcement in Prisma, so a missing filter leaks data across families. (V1 only has one family, but the schema is multi-tenant-ready and tests assume the filter is present.)
+
+**Photo storage is environment-dependent.** [src/lib/uploads.ts](src/lib/uploads.ts) writes to `public/uploads` locally and to GCS when `UPLOADS_BUCKET` is set. URLs returned to clients are signed and time-limited in the GCS path; the DB stores opaque `storageKey` values, never URLs. Resolve URLs only at response time via `getSignedUploadUrl` / `createSignedUrlResolver`.
+
+**Timeline is computed, not stored.** [src/lib/timeline-data.ts](src/lib/timeline-data.ts) unions posts, comments, post-reactions, cooked events, and post edits per request. There is no `TimelineEvent` table — don't add one without discussing trade-offs.
+
+**Rate limiting is in-process.** [src/lib/rateLimit.ts](src/lib/rateLimit.ts) uses LRU caches keyed by user or IP. Globally mocked in [jest.setup.js](jest.setup.js); production deployments behind multiple instances would not share state (acceptable for current single-instance Cloud Run setup).
+
+**Subdirectory guides** — read before editing in these areas:
+
+- [src/app/api/CLAUDE.md](src/app/api/CLAUDE.md) — route handler conventions
+- [src/lib/CLAUDE.md](src/lib/CLAUDE.md) — what each lib/ module is for
+- [prisma/CLAUDE.md](prisma/CLAUDE.md) — schema variants and migration rules
+- [**tests**/CLAUDE.md](__tests__/CLAUDE.md) — global mocks and helper conventions
+- [apps/api/CLAUDE.md](apps/api/CLAUDE.md) — FastAPI mirror service
+- [apps/recipe-url-importer/CLAUDE.md](apps/recipe-url-importer/CLAUDE.md) — importer service
+
+## Conventions worth knowing
+
+- **TypeScript strict mode** is on. The pre-commit hook ([.husky/pre-commit](.husky/pre-commit)) runs `type-check` then `lint-staged` — failing types block the commit.
+- **Path alias**: `@/*` → `src/*` (also configured in jest's `moduleNameMapper`).
+- **Validation**: every API input goes through a Zod schema in [src/lib/validation.ts](src/lib/validation.ts). Add new schemas there, don't inline them in route handlers.
+- **Error responses**: use the helpers in [src/lib/apiErrors.ts](src/lib/apiErrors.ts) (`validationError`, `notFoundError`, etc.) — never construct `NextResponse.json({ error: ... })` ad-hoc.
+- **Logger**: use `logError`/`logWarn` from [src/lib/logger.ts](src/lib/logger.ts). Tests silence `console.*` by default; set `ALLOW_TEST_LOGS=true` to see output.
+- **`bcrypt` vs `bcryptjs`**: prod uses native `bcrypt`; jest aliases it to `bcryptjs` (see [jest.config.js](jest.config.js)) so tests don't need native compilation. Don't import `bcryptjs` directly in app code.
+- **Server vs client components**: default to server components for data fetching; mark `'use client'` only for interactive forms/state. Server components reuse `getCurrentUser` by passing a `NextRequest`-shaped object.
+
+## Branches and releases
+
+- `main` = **production**. `develop` = **dev environment**.
+- Feature branches **branch from `develop`** and merge back into `develop` via PR — never target `main` directly.
+- Releases happen by opening a PR from `develop` → `main`. Only the repo owner cuts these.
+- When asked to "open a PR", the base branch is `develop` unless the user explicitly says it's a release.
+
+## CI gates
+
+[.github/workflows/ci.yml](.github/workflows/ci.yml) runs typecheck → lint → test → docker build → trivy scan, plus prisma validate (postgres schema), `npm audit`, dependency-review, semgrep, IaC scan, and gitleaks. Separate workflows cover [api-ci.yml](.github/workflows/api-ci.yml) and [recipe-url-importer-ci.yml](.github/workflows/recipe-url-importer-ci.yml). Deploy workflows target GCP Cloud Run.
+
+## What's out of scope (don't add unless asked)
+
+Multi-family/multi-tenant features, public sharing, OCR, threaded comments, meal planning, grocery lists. Per the product spec, V1 is intentionally a single private family space.

--- a/__tests__/CLAUDE.md
+++ b/__tests__/CLAUDE.md
@@ -1,0 +1,53 @@
+# CLAUDE.md — `__tests__/`
+
+Jest tests for the Next.js monolith. See [README.md](README.md) for the directory tour and [jest.config.js](../jest.config.js) for the runner config. Python tests for FastAPI live in [apps/api/tests/](../apps/api/tests/) and the importer in [apps/recipe-url-importer/tests/](../apps/recipe-url-importer/tests/) — those use pytest, not jest.
+
+## Layout
+
+- `unit/lib/` — pure-function tests for [src/lib/](../src/lib/) modules
+- `unit/api/` — handler logic with the prisma mock
+- `integration/api/` — endpoint-level tests using [helpers/](integration/helpers/) (request builders + Prisma mock setup)
+- `helpers/glob-default.js` — CommonJS shim required by jest's coverage reporter (the runtime uses ESM `glob` v11)
+
+## Global mocks (in [jest.setup.js](../jest.setup.js))
+
+Three things are mocked **for every test** before any test code runs — your test gets these by default and must override them when it needs real behavior:
+
+1. **`@/lib/prisma`** — every model is replaced with `{}`. Tests must stub the specific methods they exercise (e.g., `prisma.user.findUnique = jest.fn().mockResolvedValue(...)`). Use `jest-mock-extended` or the helpers in [integration/helpers/mock-prisma.ts](integration/helpers/mock-prisma.ts) for bulk setup.
+2. **`@/lib/rateLimit`** — every limiter's `check` returns `{ allowed: true }` and `applyRateLimit` returns `null`. To test rate-limit behavior, re-mock the specific limiter inside the test.
+3. **`console.*`** — silenced. Set `ALLOW_TEST_LOGS=true` env var to see output while debugging.
+
+`bcrypt` is aliased to `bcryptjs` via `moduleNameMapper` so tests don't need native binaries. Use `bcrypt` in your imports — never `bcryptjs` directly.
+
+## Writing a new test
+
+```ts
+import { POST } from '@/app/api/posts/route';
+import { prisma } from '@/lib/prisma';
+import { buildAuthedRequest } from '../helpers';
+
+describe('POST /api/posts', () => {
+  beforeEach(() => {
+    (prisma.post as any).create = jest.fn().mockResolvedValue({ id: 'p1' });
+  });
+
+  it('rejects unauthenticated', async () => {
+    const res = await POST(buildAuthedRequest({ session: null }));
+    expect(res.status).toBe(401);
+  });
+});
+```
+
+The integration helpers expose `buildAuthedRequest`, fixture users, and a Prisma mock builder — prefer them over rolling your own setup.
+
+## Coverage
+
+`npm run test:coverage` enforces a 75% global threshold (branches/functions/lines/statements) per [jest.config.js](../jest.config.js). Coverage scope is `src/lib/**` and `src/app/api/**` — UI components are excluded. Routes' `route.ts` files are excluded from collection because they're tested via integration tests.
+
+If a unit test needs `path/to/route.ts` coverage, add an integration test instead of changing the collection rules.
+
+## Don't
+
+- Don't hit a real database. Tests run in `node` env without prisma migrations applied.
+- Don't import `next/server` types in unit tests for pure helpers — keep unit tests free of Next runtime.
+- Don't `console.log` to debug; either temporarily set `ALLOW_TEST_LOGS=true` or use the jest debugger.

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -1,0 +1,36 @@
+# CLAUDE.md — `apps/api/`
+
+FastAPI re-implementation of the Next.js JSON API. Setup, run, and test commands live in [README.md](README.md).
+
+## Why this exists
+
+The Next.js route handlers in [src/app/api/](../../src/app/api/) are the **current** production backend. This service is the **migration target** — when complete, the Next frontend will call FastAPI via `NEXT_PUBLIC_API_BASE_URL` and the Next API routes will be removed. See [docs/API_BACKEND_MIGRATION_PLAN.md](../../docs/API_BACKEND_MIGRATION_PLAN.md).
+
+## Stay in sync with Next
+
+When you change an endpoint here, check whether the equivalent in `src/app/api/` needs the same change (and vice-versa). The two services share:
+
+- The same Prisma schema ([prisma/schema.postgres.prisma](../../prisma/schema.postgres.prisma))
+- The same database
+- The same JWT format and `session` cookie semantics
+- The same request/response shapes (the migration plan is explicit that the contract should not change during the cutover, except for the planned `/v1/` prefix and access/refresh-token split)
+
+The Python Prisma client is generated from the postgres schema:
+
+```bash
+npx prisma generate --schema ../../prisma/schema.postgres.prisma --generator clientPy
+```
+
+## Module layout
+
+- [src/main.py](src/main.py) — FastAPI app, includes routers, manages prisma connect/disconnect lifespan
+- [src/routers/](src/routers/) — one file per resource, mirrors [src/app/api/](../../src/app/api/) structure
+- [src/dependencies.py](src/dependencies.py) — auth dependency injectors (the FastAPI equivalent of `withAuth`)
+- [src/permissions.py](src/permissions.py) — mirrors [src/lib/permissions.ts](../../src/lib/permissions.ts)
+- [src/security.py](src/security.py) — JWT verify, password hashing
+- [src/schemas/](src/schemas/) — Pydantic request/response models (mirrors `validation.ts` + `apiErrors.ts`)
+- [src/uploads.py](src/uploads.py) — signed URL resolution for GCS
+
+## Testing
+
+`pytest tests/unit/` for unit tests, `pytest tests/integration/` for integration. CI runs both plus ruff, mypy, trivy, pip-audit, semgrep, gitleaks ([.github/workflows/api-ci.yml](../../.github/workflows/api-ci.yml)).

--- a/apps/recipe-url-importer/CLAUDE.md
+++ b/apps/recipe-url-importer/CLAUDE.md
@@ -1,0 +1,23 @@
+# CLAUDE.md — `apps/recipe-url-importer/`
+
+Standalone Python service that fetches a public recipe URL and returns a normalized `RecipeDraft`. Setup and run commands live in [README.md](README.md). Behavior contract — request/response shape, confidence scoring, security requirements (SSRF, timeouts, max bytes), error codes — is in [SPEC.md](SPEC.md). **Treat SPEC.md as the source of truth** before changing parser, fetch, or response logic.
+
+## Boundaries
+
+- **No database access.** This service only reads URLs from the public internet. Don't import Prisma here; don't add DB-backed features.
+- **Called by the Next backend**, not the browser directly. The client lives in [src/lib/recipeImporter.ts](../../src/lib/recipeImporter.ts). Authentication in production is via Cloud Run OIDC (only the main API service account is invoker).
+- **Stateless aside from caching.** The optional response cache and per-IP / per-domain rate limits are in-process — fine for a single Cloud Run instance, would need redis if scaled.
+
+## Module layout
+
+- [src/recipe_url_importer/app.py](src/recipe_url_importer/app.py) — FastAPI app + `POST /v1/parse`
+- [src/recipe_url_importer/fetch/](src/recipe_url_importer/fetch/) — HTTP fetch with size/timeout caps and SSRF guards
+- [src/recipe_url_importer/parse/](src/recipe_url_importer/parse/) — JSON-LD / microdata / heuristic recipe extraction
+- [src/recipe_url_importer/security/](src/recipe_url_importer/security/) — URL validation, SSRF protection
+- [src/recipe_url_importer/cache/](src/recipe_url_importer/cache/) — response cache keyed by URL
+- [src/recipe_url_importer/rate_limit/](src/recipe_url_importer/rate_limit/) — IP + domain throttling
+- [src/recipe_url_importer/config.py](src/recipe_url_importer/config.py) — `IMPORTER_*` env vars
+
+## Tests
+
+`PYTHONPATH=src pytest`. CI is [.github/workflows/recipe-url-importer-ci.yml](../../.github/workflows/recipe-url-importer-ci.yml).

--- a/docs/API_BACKEND_MIGRATION_PLAN.md
+++ b/docs/API_BACKEND_MIGRATION_PLAN.md
@@ -1,0 +1,732 @@
+# Frontend ↔ FastAPI Migration Plan
+
+## Objective
+
+Migrate the Next.js frontend to use the FastAPI service as the primary backend while maintaining stability during the transition. The end state is a token‑based auth system (access + refresh tokens), standardized API contracts, and no reliance on Next.js API route handlers for application data.
+
+## Scope
+
+- Frontend (Next.js) in src
+- Backend (FastAPI) in apps/api
+- Auth and session model
+- API contract alignment (endpoints, payloads, responses)
+- Observability and rollout safety
+
+## Principles
+
+- **Best practice auth**: short‑lived access tokens + refresh token rotation
+- **Secure storage**: access token in memory; refresh token in httpOnly cookie (same‑site or cross‑site as required)
+- **Compatibility**: keep current cookie‑based guards until token flow is fully deployed
+- **Incremental migration**: prioritize high‑traffic flows first, deprecate Next API routes last
+
+## Current State Summary
+
+- Frontend fetches same‑origin `/api/*` routes in Next.
+- Next route handlers implement auth, sessions, and data logic.
+- FastAPI has core routes for auth, posts, profile, tags, timeline, etc., but is missing some endpoints used by the frontend.
+- Next middleware and server components read session cookies directly.
+
+## Target Architecture
+
+- Frontend calls FastAPI via a shared API client using `NEXT_PUBLIC_API_BASE_URL`.
+- Auth uses:
+  - **Access token** (JWT, 5–15 min TTL) returned on login
+  - **Refresh token** stored in httpOnly cookie (30–90 days, rotation on refresh)
+- Next middleware and server components use token presence (or a lightweight backend call) instead of reading Next session cookies.
+- Next API routes are removed or replaced by thin proxies only where needed.
+
+---
+
+## API Contract & Endpoint Mapping
+
+### API Versioning
+
+- **Target prefix**: all FastAPI endpoints are **/v1/**.
+- **Transition aliasing**: keep unprefixed routes as aliases during rollout.
+  - Example: `/v1/auth/login` and `/auth/login` both resolve to the same handler.
+- **Mapping table below** assumes **/v1/** for all target endpoints.
+- **Deprecation**: unprefixed routes sunset after rollout (announce + remove).
+
+### Common Conventions
+
+- **Base URL**: `${NEXT_PUBLIC_API_BASE_URL}/v1` (defaults to same-origin in local dev)
+- **Auth header**: `Authorization: Bearer <access_token>`
+- **Refresh cookie**: `refresh_token` (httpOnly)
+- **Error shape** (all non-2xx):
+  ```json
+  { "error": { "code": "STRING", "message": "STRING" } }
+  ```
+
+### Error Code Registry & Retry Semantics
+
+- **VALIDATION_ERROR (400)**: do not retry; fix payload
+- **BAD_REQUEST (400)**: do not retry; fix request
+- **UNAUTHORIZED (401)**: refresh once; if still 401, force logout
+- **FORBIDDEN (403)**: do not retry; show access denied
+- **NOT_FOUND (404)**: do not retry
+- **CONFLICT (409)**: do not retry; surface message
+- **RATE_LIMITED (429)**: retry after `Retry-After` (exponential backoff)
+- **INTERNAL_ERROR (500)**: retry once; if still failing, surface error
+
+### Pagination, Sorting, Filters (List Endpoints)
+
+- **Default**: `limit=20`, `offset=0`
+- **Max limit**: `100`
+- **Sort order** (default): newest first (`createdAt desc`)
+- **List endpoints**:
+  - `/v1/posts`: `limit`, `offset`, `authorId?`, `tag?`, `search?`, `hasRecipe?`
+  - `/v1/timeline`: `limit`, `offset`
+  - `/v1/notifications` (TBD): `limit`, `offset`, `unreadOnly?`
+  - `/v1/recipes`: `limit`, `offset`, `tag?`, `course?`, `search?`
+  - `/v1/feedback` (admin, TBD): `limit`, `offset`, `status?`, `rating?`
+
+### Request/Response Schema References (FastAPI)
+
+- **LoginRequest**: `{ emailOrUsername, password, rememberMe }`
+- **SignupRequest**: `{ name, emailOrUsername, password, familyMasterKey, rememberMe }`
+- **AuthResponse**: `{ user }`
+- **CreatePostRequest**: `{ title, caption?, recipe? }`
+- **UpdatePostRequest**: `{ title?, caption?, recipe?, changeNote? }`
+- **CreateCommentRequest**: `{ text }`
+- **ReactionRequest**: `{ targetType, targetId, emoji }`
+- **CookedRequest**: `{ rating?, note? }`
+
+### Canonical Schema Source
+
+- **Source of truth**: FastAPI OpenAPI schema.
+- **Runtime endpoint**: `/v1/openapi.json` (served by FastAPI).
+- **CI snapshot**: add a generated file `apps/api/openapi.json` on each CI build.
+- **Frontend contract tests**: validate requests against the OpenAPI snapshot.
+
+### Endpoint Mapping Table (All `/api/*` calls)
+
+> **Legend:**
+>
+> - **Next Route**: current Next.js API route
+> - **FastAPI**: target endpoint
+> - **Success**: status + response body
+> - **Errors**: status + error codes (shape above)
+
+#### Auth (all targets under `/v1`)
+
+- **POST /api/auth/login** → **POST /v1/auth/login**
+  - Request: `LoginRequest`
+  - Success: `200 { accessToken, user }` (AuthResponse + accessToken)
+  - Errors: `400 VALIDATION_ERROR`, `401 INVALID_CREDENTIALS`
+
+- **POST /api/auth/signup** → **POST /v1/auth/signup**
+  - Request: `SignupRequest`
+  - Success: `200 { accessToken, user }`
+  - Errors: `400 VALIDATION_ERROR`, `409 CONFLICT`
+
+- **POST /api/auth/reset** → **POST /v1/auth/reset` (TBD)`**
+  - Request: `{ emailOrUsername }`
+  - Success: `204 No Content`
+  - Errors: `400 VALIDATION_ERROR`, `404 NOT_FOUND`
+
+- **POST /api/auth/reset/confirm` (new)`** → **POST /v1/auth/reset/confirm` (TBD)`**
+  - Request: `{ token, newPassword }`
+  - Success: `204 No Content`
+  - Errors: `400 VALIDATION_ERROR`, `401 INVALID_TOKEN`, `410 TOKEN_EXPIRED`, `404 NOT_FOUND`
+
+- **POST /api/auth/logout** → **POST /v1/auth/logout**
+  - Request: none
+  - Success: `204 No Content`
+  - Errors: `401 UNAUTHORIZED`
+
+- **GET /api/auth/me** → **GET /v1/auth/me**
+  - Request: auth header required
+  - Success: `200 { user }`
+  - Errors: `401 UNAUTHORIZED`
+
+#### Health
+
+- **GET /api/health** → **GET /v1/health**
+  - Success: `200 { status: "ok" }`
+
+#### Posts
+
+- **GET /api/posts** → **GET /v1/posts**
+  - Query: `limit`, `offset`, filters
+  - Success: `200 { items: Post[], total }`
+  - Errors: `401 UNAUTHORIZED`
+
+- **POST /api/posts** → **POST /v1/posts**
+  - Request: `CreatePostRequest` + optional media upload
+  - Success: `201 { post }`
+  - Errors: `400 VALIDATION_ERROR`, `401 UNAUTHORIZED`
+
+- **GET /api/posts/{postId}** → **GET /v1/posts/{postId}**
+  - Success: `200 { post }`
+  - Errors: `401 UNAUTHORIZED`, `404 NOT_FOUND`
+
+- **PATCH /api/posts/{postId}** → **PATCH /v1/posts/{postId}**
+  - Request: `UpdatePostRequest`
+  - Success: `200 { post }`
+  - Errors: `400 VALIDATION_ERROR`, `401 UNAUTHORIZED`, `404 NOT_FOUND`
+
+- **DELETE /api/posts/{postId}** → **DELETE /v1/posts/{postId}**
+  - Success: `204 No Content`
+  - Errors: `401 UNAUTHORIZED`, `404 NOT_FOUND`
+
+- **POST /api/posts/{postId}/comments** → **POST /v1/posts/{postId}/comments**
+  - Request: `CreateCommentRequest`
+  - Success: `201 { comment }`
+  - Errors: `400 VALIDATION_ERROR`, `401 UNAUTHORIZED`, `404 NOT_FOUND`
+
+- **POST /api/posts/{postId}/favorite** → **POST /v1/posts/{postId}/favorite**
+  - Request: none
+  - Success: `200 { favorited: true }`
+  - Errors: `401 UNAUTHORIZED`, `404 NOT_FOUND`
+
+- **DELETE /api/posts/{postId}/favorite** → **DELETE /v1/posts/{postId}/favorite**
+  - Success: `200 { favorited: false }`
+  - Errors: `401 UNAUTHORIZED`, `404 NOT_FOUND`
+
+- **POST /api/posts/{postId}/cooked** → **POST /v1/posts/{postId}/cooked**
+  - Request: `CookedRequest`
+  - Success: `200 { cooked: true }`
+  - Errors: `400 VALIDATION_ERROR`, `401 UNAUTHORIZED`, `404 NOT_FOUND`
+
+- **DELETE /api/posts/{postId}/cooked** → **DELETE /v1/posts/{postId}/cooked**
+  - Success: `200 { cooked: false }`
+  - Errors: `401 UNAUTHORIZED`, `404 NOT_FOUND`
+
+#### Comments
+
+- **DELETE /api/comments/{commentId}** → **DELETE /v1/comments/{commentId}**
+  - Success: `204 No Content`
+  - Errors: `401 UNAUTHORIZED`, `404 NOT_FOUND`
+
+#### Reactions
+
+- **POST /api/reactions** → **POST /v1/reactions**
+  - Request: `ReactionRequest`
+  - Success: `200 { reacted: true }`
+  - Errors: `400 VALIDATION_ERROR`, `401 UNAUTHORIZED`
+
+#### Timeline
+
+- **GET /api/timeline** → **GET /v1/timeline**
+  - Query: `limit`, `offset`
+  - Success: `200 { items: TimelineItem[], total }`
+  - Errors: `401 UNAUTHORIZED`
+
+#### Recipes
+
+- **GET /api/recipes** → **GET /v1/recipes**
+  - Query: `limit`, `offset`, filters
+  - Success: `200 { items: Recipe[], total }`
+  - Errors: `401 UNAUTHORIZED`
+
+- **POST /api/recipes/import` (TBD)`** → **POST /v1/recipes/import` (TBD)`**
+  - Request: `{ url, mapping? }`
+  - Success: `201 { recipe }`
+  - Errors: `400 VALIDATION_ERROR`, `401 UNAUTHORIZED`
+
+#### Tags
+
+- **GET /api/tags** → **GET /v1/tags**
+  - Success: `200 { items: Tag[] }`
+  - Errors: `401 UNAUTHORIZED`
+
+#### Profile / Me
+
+- **GET /api/profile/posts** → **GET /v1/profile/posts**
+  - Success: `200 { items: Post[], total }`
+  - Errors: `401 UNAUTHORIZED`
+
+- **GET /api/profile/cooked** → **GET /v1/profile/cooked**
+  - Success: `200 { items: Post[], total }`
+  - Errors: `401 UNAUTHORIZED`
+
+- **GET /api/me/profile** → **GET /v1/me/profile**
+  - Success: `200 { user }`
+  - Errors: `401 UNAUTHORIZED`
+
+- **PATCH /api/me/profile** → **PATCH /v1/me/profile**
+  - Request: `{ name?, avatarUrl? }`
+  - Success: `200 { user }`
+  - Errors: `400 VALIDATION_ERROR`, `401 UNAUTHORIZED`
+
+- **POST /api/me/password** → **POST /v1/me/password**
+  - Request: `{ currentPassword, nextPassword }`
+  - Success: `204 No Content`
+  - Errors: `400 VALIDATION_ERROR`, `401 UNAUTHORIZED`
+
+- **GET /api/me/favorites** → **GET /v1/me/favorites**
+  - Success: `200 { items: Post[], total }`
+  - Errors: `401 UNAUTHORIZED`
+
+- **DELETE /api/me/delete` (TBD)`** → **DELETE /v1/me/delete` (TBD)`**
+  - Success: `204 No Content`
+  - Errors: `401 UNAUTHORIZED`
+
+#### Family
+
+- **GET /api/family/members** → **GET /v1/family/members**
+  - Success: `200 { items: User[] }`
+  - Errors: `401 UNAUTHORIZED`
+
+- **DELETE /api/family/members/{userId}** → **DELETE /v1/family/members/{userId}**
+  - Success: `204 No Content`
+  - Errors: `401 UNAUTHORIZED`, `403 FORBIDDEN`
+
+#### Notifications
+
+- **GET /api/notifications` (TBD)`** → **GET /v1/notifications` (TBD)`**
+  - Success: `200 { items: Notification[], unreadCount }`
+  - Errors: `401 UNAUTHORIZED`
+
+- **POST /api/notifications/mark-read` (TBD)`** → **POST /v1/notifications/mark-read` (TBD)`**
+  - Request: `{ notificationIds }`
+  - Success: `204 No Content`
+  - Errors: `400 VALIDATION_ERROR`, `401 UNAUTHORIZED`
+
+- **GET /api/notifications/unread-count` (TBD)`** → **GET /v1/notifications/unread-count` (TBD)`**
+  - Success: `200 { unreadCount }`
+  - Errors: `401 UNAUTHORIZED`
+
+#### Feedback
+
+- **POST /api/feedback` (TBD)`** → **POST /v1/feedback` (TBD)`**
+  - Request: `{ message, rating?, metadata? }`
+  - Success: `201 { feedback }`
+  - Errors: `400 VALIDATION_ERROR`, `401 UNAUTHORIZED`
+
+- **GET /api/feedback` (TBD, admin)`** → **GET /v1/feedback` (TBD, admin)`**
+  - Success: `200 { items: Feedback[], total }`
+  - Errors: `401 UNAUTHORIZED`, `403 FORBIDDEN`
+
+---
+
+## Upload Handling
+
+### Multipart Endpoints
+
+- **POST /v1/posts**
+  - **Content-Type**: `multipart/form-data`
+  - **Fields**:
+    - `payload` (stringified JSON) → `CreatePostRequest`
+    - `media` (file[], optional)
+  - **Limits**:
+    - max files: 10
+    - max file size: 10MB each
+    - total request size: 50MB
+
+- **PATCH /v1/posts/{postId}**
+  - **Content-Type**: `multipart/form-data`
+  - **Fields**:
+    - `payload` (stringified JSON) → `UpdatePostRequest`
+    - `media` (file[], optional)
+
+- **PATCH /v1/me/profile**
+  - **Content-Type**: `multipart/form-data`
+  - **Fields**:
+    - `payload` (stringified JSON) → `{ name? }`
+    - `avatar` (file, optional)
+  - **Limits**:
+    - max file size: 5MB
+
+### Upload Validation & Processing
+
+- **Allowed mime types**: `image/jpeg`, `image/png`, `image/webp`
+- **Image processing**: resize max 2048px on longest edge; strip EXIF
+- **Storage**: object storage bucket (S3/GCS) with signed URL access
+- **Malware scanning**: optional ClamAV or managed scanning on upload (async)
+
+### Non‑Multipart Uploads
+
+- **POST /v1/recipes/import** (TBD)
+  - Standard JSON payload `{ url, mapping? }` (no file upload)
+  - Success: `201 { recipe }`
+  - Errors: `400 VALIDATION_ERROR`, `401 UNAUTHORIZED`
+
+### Idempotency & Retries
+
+- **Write requests** accept `X-Request-Id` for idempotency.
+- Backend stores request ID for 24 hours; duplicate IDs return the original response.
+- Applies to: create post, comment, reaction, favorite/cooked, feedback.
+
+---
+
+## Auth & Security Specifics
+
+### CORS Policy
+
+- **Allowed origins**: explicit allow‑list per environment (no `*` with credentials)
+- **Allowed methods**: `GET, POST, PATCH, PUT, DELETE, OPTIONS`
+- **Allowed headers**: `Authorization, Content-Type, X-CSRF-Token, X-Request-Id`
+- **Credentials**: enabled for refresh cookie flow
+
+### Rate Limits & Abuse Protections
+
+- **Auth login**: 10 requests / 5 minutes / IP → `429 TOO_MANY_REQUESTS`
+- **Auth signup**: 5 requests / 10 minutes / IP → `429 TOO_MANY_REQUESTS`
+- **Auth reset request**: 3 requests / 30 minutes / IP + per account → `429 TOO_MANY_REQUESTS`
+- **Auth reset confirm**: 5 requests / 30 minutes / IP → `429 TOO_MANY_REQUESTS`
+- **Refresh**: 30 requests / 10 minutes / session → `429 TOO_MANY_REQUESTS`
+- **Feedback**: 20 requests / hour / user → `429 TOO_MANY_REQUESTS`
+- **Response**: `429 { error: { code: "RATE_LIMITED", message } }` + `Retry-After` header
+
+### CSRF Strategy for Refresh
+
+- **Double-submit token**: refresh cookie is httpOnly; a second non‑httpOnly `csrf_token` cookie is set.
+- `/v1/auth/refresh` requires `X-CSRF-Token` header matching the `csrf_token` cookie.
+- Reject if `Origin`/`Referer` does not match allowed origins.
+
+### CSRF Cookie Lifecycle
+
+- **Set**: on successful login/signup and on each refresh (rotate `csrf_token`).
+- **Rotate**: every refresh to prevent fixation.
+- **Clear**: on logout and when refresh token is revoked/expired.
+
+### Cookie Domain/Flags by Environment
+
+- **Local dev**: `Domain=localhost`, `Secure=false`, `SameSite=Lax` (or `None` with HTTPS dev cert if cross‑origin)
+- **Staging**: `Domain=.staging.example.com`, `Secure=true`, `SameSite=None`
+- **Production**: `Domain=.example.com`, `Secure=true`, `SameSite=None`
+
+### Token Claims (Access Token)
+
+- Required: `sub` (userId), `familySpaceId`, `role`, `iss`, `iat`, `exp`, `aud`, `jti`
+- Optional: `name`, `avatarUrl` for UI‑friendly claims
+
+### Rotation & Reuse Detection
+
+- Store refresh token hash + `jti` in DB.
+- On refresh, rotate token and invalidate previous `jti`.
+- If a previously used `jti` appears, revoke all active refresh tokens for that user (session compromise signal).
+
+### rememberMe Behavior
+
+- **rememberMe=false** → refresh token TTL 7 days
+- **rememberMe=true** → refresh token TTL 30 days
+- **Rotation**: always rotate on refresh, regardless of rememberMe
+
+### Token Signing & Key Rotation
+
+- **Key storage**: managed secret store (e.g., AWS Secrets Manager / GCP Secret Manager)
+- **Signing**: current `kid` used to sign access tokens
+- **Rotation cadence**: every 90 days (or on incident)
+- **Validation**: keep previous keys active for 2× access token TTL to allow overlap
+
+### Password Reset Flow
+
+1. **Request reset**: `POST /v1/auth/reset` with `{ emailOrUsername }` → 204
+2. **Email sent**: contains single‑use token and link to frontend reset page
+3. **Confirm reset**: `POST /v1/auth/reset/confirm` with `{ token, newPassword }`
+4. **Token TTL**: 30 minutes; tokens are one‑time use
+5. **Rate limits**: per IP + per account
+
+### Logout Invalidation Semantics
+
+- Clear refresh cookie on client.
+- Revoke refresh token in DB immediately.
+- Access tokens expire naturally; optional deny‑list for high‑risk admin actions.
+
+---
+
+## Migration Mechanics
+
+### Middleware & Server Components
+
+- **During dual‑mode**: keep existing cookie checks in Next middleware.
+- **Target**: middleware checks for refresh cookie presence and/or calls a lightweight `/v1/auth/me` with a server‑side access token.
+
+### Frontend Token Storage
+
+- **Access token**: in‑memory only, stored in a dedicated auth store (e.g., `src/lib/auth/tokenStore`).
+- **Refresh token**: httpOnly cookie managed by the backend.
+- **On reload**: client bootstraps by calling `/v1/auth/refresh` to mint a new access token.
+- **Hydration**: server components can prefetch `/v1/auth/me` and pass user data as props to avoid flash.
+
+### SSR Requests with Access Tokens
+
+- **Server components**: call `/v1/auth/refresh` using refresh cookie (server‑side only) to mint a short‑lived access token, then call `/v1/auth/me` or data endpoints.
+- **Client components**: use in‑memory access token with automatic refresh on 401.
+- **Edge runtime**: avoid decoding tokens in edge if crypto/JWT limitations exist; prefer `/v1/auth/me`.
+
+### Edge/Runtime Constraints
+
+- **Next middleware** runs on **Edge** by default.
+- **Edge limitation**: avoid JWT decode and crypto libs in middleware; only check refresh cookie presence and redirect.
+- **Node runtime** (server components / API routes) may call `/v1/auth/refresh` to obtain access tokens.
+
+---
+
+## Rollout Plan
+
+### Feature Flags
+
+- `USE_FASTAPI_AUTH`
+- `USE_FASTAPI_DATA`
+- `USE_REFRESH_TOKEN_FLOW`
+
+### Feature Flag Enforcement Source
+
+- **Backend source**: environment‑backed config (`FASTAPI_FEATURE_FLAGS`) loaded on startup and reloaded on interval (e.g., 60s).
+- **Frontend source**: same config service/flag system used by backend.
+- **Sync**: flags published from the config system; backend polls or receives push updates.
+
+### Per‑Environment Cutover
+
+- **Dev**: enable all flags, iterate daily
+- **Staging**: enable auth first, then data endpoints
+- **Prod**: canary rollout (5% → 25% → 50% → 100%)
+
+### Dual‑Stack Without Data Drift
+
+- Both stacks use the **same database**.
+- Only one write path enabled at a time for a given feature flag.
+  - **Frontend gating**: feature flags prevent writes to the disabled backend.
+  - **Backend gating**: FastAPI rejects writes with `409 CONFLICT` when a feature is disabled (authoritative).
+- Reads can be mirrored for validation logs without side effects.
+
+### Rollback Criteria
+
+- Auth failure rate > 2% for 10 minutes
+- Refresh loop rate > 0.5% of sessions
+- 401/403 spike > 3× baseline
+
+### Rollback Mechanics
+
+- **Config owner**: product/infra team owns production feature flag system.
+- **Roll back steps**:
+  1. Disable `USE_FASTAPI_DATA` (immediate read/write rollback)
+  2. Disable `USE_FASTAPI_AUTH` (restore Next auth)
+  3. Flush CDN and edge cache if auth redirects cached
+  4. Monitor auth and error metrics for 30 minutes
+- **Time to flip**: < 5 minutes (flag propagation)
+
+---
+
+## Test Plan
+
+### Required Integration Tests
+
+- Auth: login, signup, refresh, logout, invalid credentials
+- Token rotation + reuse detection
+- Posts: create/edit/delete/comment/favorite/cooked
+- Profile: update, password change
+- Notifications + feedback
+
+### Contract Tests
+
+- Snapshot OpenAPI schemas for FastAPI.
+- Validate frontend requests against OpenAPI in CI.
+
+### Pre‑Prod Validation (CI‑linked Checklist)
+
+- Run full e2e on staging with feature flags enabled
+- Validate refresh loop protection
+- Verify CORS + credentials
+- Verify SSR access token flow
+
+---
+
+## Observability
+
+### Structured Logging Fields
+
+- `requestId`, `userId`, `route`, `method`, `status`, `latencyMs`, `errorCode`,
+  `authMode`, `refreshAttempt`, `refreshResult`, `tokenJti`
+
+### Metrics
+
+- `auth.login.success`, `auth.login.failure`
+- `auth.refresh.success`, `auth.refresh.failure`, `auth.refresh.loop`
+- `http.401.rate`, `http.403.rate`
+
+### Alert Thresholds
+
+- 401/403 rate > 3× baseline for 5 minutes
+- refresh loop detected > 0.5% of sessions
+- login failure rate > 5% for 10 minutes
+
+---
+
+## Open Questions & Proposed Decisions
+
+1. **Source of truth for user/session state**
+
+- **Decision**: FastAPI tokens + refresh token store are the source of truth. Next session cookies remain only for legacy routes during migration.
+
+2. **API versioning/backward compatibility**
+
+- **Decision**: Introduce `/v1` prefix in FastAPI and preserve old paths behind a compatibility layer during rollout. Deprecate with a fixed sunset date.
+
+3. **Data migrations/cleanup**
+
+- **Decision**: Add refresh token table for rotation/revocation. Remove Next session cookie usage after cutover and delete any legacy session artifacts.
+
+---
+
+## Phase 0 — Preparation (No behavior change)
+
+**Goals:** establish migration infrastructure.
+
+1. **Add API base URL configuration**
+
+- Define `NEXT_PUBLIC_API_BASE_URL` for frontend use.
+- Keep current same‑origin behavior if not set.
+
+2. **Introduce a shared API client**
+
+- Centralize `fetch` with:
+  - base URL
+  - standard headers
+  - error normalization
+  - token injection hook (access token)
+
+3. **Document API contract**
+
+- Create a mapping table: frontend usage ↔ FastAPI endpoint ↔ payload/response.
+
+**Exit Criteria**
+
+- Shared API client available.
+- No production behavior changes.
+
+---
+
+## Phase 1 — Token Auth Design
+
+**Goals:** define token lifecycle and endpoint contract.
+
+1. **Auth endpoints (FastAPI)**
+
+- `POST /v1/auth/login` → `{ accessToken, user }` + set refresh cookie
+- `POST /v1/auth/signup` → same as login
+- `POST /v1/auth/refresh` → `{ accessToken }` + rotate refresh cookie
+- `POST /v1/auth/logout` → clear refresh cookie
+
+2. **Token policies**
+
+- Access token TTL: 5–15 minutes
+- Refresh token TTL: 30–90 days
+- Rotation on refresh with reuse detection (optional)
+
+3. **Cookie settings**
+
+- `HttpOnly`, `Secure`, `SameSite=None` if cross‑origin
+- Domain set to frontend root domain
+
+**Exit Criteria**
+
+- FastAPI supports login/signup/refresh/logout with token issuance and refresh rotation.
+
+---
+
+## Phase 2 — Frontend Auth Migration
+
+**Goals:** switch auth flows to token usage, keep cookie middleware temporarily.
+
+1. **Login/Signup/Reset UI**
+
+- Update to use the API client with base URL.
+- Store access token in memory (state/store); refresh token handled via cookie.
+
+2. **Token refresh workflow**
+
+- On 401, call `/v1/auth/refresh` and retry once.
+- Centralize in API client.
+
+3. **Logout**
+
+- Call `/v1/auth/logout`, clear local access token state.
+
+4. **Route guards (temporary dual mode)**
+
+- Keep Next middleware session checks until all pages rely on token flow.
+- Introduce a lightweight client guard for token presence if needed.
+
+**Exit Criteria**
+
+- Login/logout work end‑to‑end against FastAPI.
+- Token refresh works and user session persists.
+
+---
+
+## Phase 3 — Endpoint Parity
+
+**Goals:** fill gaps so all UI features use FastAPI.
+
+### Missing/Unmatched Endpoints (from current analysis)
+
+- Notifications: list, mark‑read, unread‑count
+- Feedback: create + admin list
+- Auth reset
+- Recipe import
+- Account delete
+
+### Payload/Schema Alignment
+
+- **Signup**: align frontend name fields with backend schema
+- **Profile update**: handle avatar upload or update UI to send supported fields
+- **Password change**: align payload keys
+
+**Exit Criteria**
+
+- All existing UI flows map to FastAPI endpoints without Next API routes.
+
+---
+
+## Phase 4 — Cutover and Cleanup
+
+**Goals:** make FastAPI the sole backend for the frontend.
+
+1. **Switch all fetches**
+
+- Replace remaining `/api/*` calls with API client base URL.
+
+2. **Remove Next API routes**
+
+- Delete or deprecate route handlers in src/app/api.
+
+3. **Update middleware**
+
+- Replace cookie checks with token-based logic or external auth check.
+
+4. **Docs and monitoring**
+
+- Update README and API docs.
+- Add API latency and error metrics.
+
+**Exit Criteria**
+
+- No production traffic depends on Next API routes.
+- Frontend uses FastAPI for all data and auth.
+
+---
+
+## Risk Mitigation
+
+- **Dual‑mode auth** during transition
+- **Feature flags** or env toggles for endpoints
+- **Staged rollout** (dev → staging → prod)
+- **Automated tests** covering auth, posts, timeline, notifications
+
+## Validation Checklist
+
+- Login/signup/logout/refresh
+- Protected pages accessible with token
+- Create/edit posts and comments
+- Profile and settings updates
+- Notifications and feedback
+- Recipe import flow
+
+## Ownership & Sequencing
+
+1. Auth endpoints + refresh flow (backend)
+2. API client + login UI migration (frontend)
+3. Endpoint parity (backend)
+4. Remaining UI migration + cleanup (frontend)
+
+---
+
+## Notes
+
+- Access tokens should be **short‑lived** to limit exposure.
+- Refresh token rotation is recommended for long‑term security.
+- If cross‑origin, ensure CORS allows credentials and correct origin.

--- a/prisma/CLAUDE.md
+++ b/prisma/CLAUDE.md
@@ -1,0 +1,42 @@
+# CLAUDE.md — `prisma/`
+
+## Three schemas, one domain
+
+| File                                                       | Provider                   | Used by                                                            | Workflow                                                           |
+| ---------------------------------------------------------- | -------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------ |
+| [schema.prisma](schema.prisma)                             | sqlite                     | Local Next dev (default)                                           | `prisma db push` (no migrations)                                   |
+| [schema.postgres.prisma](schema.postgres.prisma)           | postgresql                 | Local Postgres dev, Cloud SQL, FastAPI ([apps/api/](../apps/api/)) | `prisma migrate deploy` — migrations in [migrations/](migrations/) |
+| [schema.postgres.node.prisma](schema.postgres.node.prisma) | postgresql, JS client only | Docker / Cloud Run Next.js image                                   | `prisma migrate deploy` — uses same migrations                     |
+
+**The three schemas must define the same models with the same field names and shape.** When adding/changing a model:
+
+1. Edit all three schemas in lock-step.
+2. For Postgres, generate a migration: `npx prisma migrate dev --schema prisma/schema.postgres.prisma --name <change>`.
+3. SQLite picks up changes via `npm run db:push` — no migration file is committed for SQLite.
+4. Re-run `npm run db:generate` (uses default schema) and the postgres equivalent if Python client is in use.
+
+## Selecting a schema at runtime
+
+The `DATABASE_URL` env var picks the connection. `PRISMA_SCHEMA` is read by Prisma CLI commands (e.g., the docker entrypoint runs `prisma migrate deploy --schema $PRISMA_SCHEMA`). The runtime client just trusts whatever was generated.
+
+## Seeding ([seed.ts](seed.ts))
+
+`npm run db:seed` runs the script. It:
+
+- Creates one `FamilySpace` if none exists, hashing `FAMILY_MASTER_KEY` (or generating one and **printing it** — save the output).
+- Loads the curated tag catalog (diet/allergen/heat/flavor/cuisine).
+- Will not overwrite an existing family or rotate the master key.
+
+To rotate the master key, do it manually via the DB — there is no API for it.
+
+## Schema gotchas
+
+- **Field naming**: TypeScript camelCase (`familySpaceId`) maps to snake_case columns (`@map("family_space_id")`). Always set both when adding fields.
+- **Storage keys**: photo/avatar columns store opaque storage keys but historically were named `*_url` in the DB (`@map("avatar_url")`, `@map("url")`, `@map("photo_url")`). Don't rename the column — the property is what code uses.
+- **Reaction polymorphism**: `Reaction` has both `targetType`/`targetId` (the canonical pair, with the unique constraint) AND nullable `postId`/`commentId` FKs (for join performance). When inserting, set both representations.
+- **Notification batching**: reactions roll up into one `Notification` per `(recipientId, postId)` with `emojiCounts` JSON; comments and cooked events are 1:1.
+- **Cascades**: most relations cascade on user/post/comment delete. `FeedbackSubmission` uses `SetNull` so feedback survives user deletion.
+
+## After schema changes
+
+Always run `npm run type-check` — Prisma generates TS types and downstream code will fail to compile if a field name shifts.

--- a/src/app/api/CLAUDE.md
+++ b/src/app/api/CLAUDE.md
@@ -1,0 +1,54 @@
+# CLAUDE.md — `src/app/api/`
+
+Next.js App Router route handlers implementing the JSON REST API. Each `route.ts` exports HTTP methods (`GET`, `POST`, `PUT`, `DELETE`).
+
+## The standard handler shape
+
+```ts
+import { withAuth } from '@/lib/apiAuth';
+import { someLimiter, applyRateLimit } from '@/lib/rateLimit';
+import { someSchema } from '@/lib/validation';
+import { validationError, notFoundError } from '@/lib/apiErrors';
+
+export const POST = withAuth(async (request, user) => {
+  const limited = applyRateLimit(someLimiter, someLimiter.getUserKey(user.id));
+  if (limited) return limited;
+
+  const parsed = someSchema.safeParse(await request.json());
+  if (!parsed.success) return validationError(parsed.error.errors[0]?.message);
+
+  // All DB queries MUST scope by user.familySpaceId
+  const row = await prisma.post.findFirst({
+    where: { id: parsed.data.id, familySpaceId: user.familySpaceId },
+  });
+  if (!row) return notFoundError();
+
+  // ... return NextResponse.json(...)
+});
+```
+
+Rules this enforces:
+
+- **`withAuth` / `withRole`** ([src/lib/apiAuth.ts](../../lib/apiAuth.ts)) — every protected handler. Returns 401/403 automatically. Never read the session manually inside the handler.
+- **Family scoping** — every `where` clause for Post/Comment/Reaction/Favorite/CookedEvent/etc. must include `familySpaceId: user.familySpaceId`. Missing it = cross-family data leak.
+- **Permissions** — for ownership checks (edit/delete), use the helpers in [src/lib/permissions.ts](../../lib/permissions.ts) (`canEditPost`, `canDeletePost`, `canDeleteComment`, `canRemoveMember`). Don't open-code `authorId === user.id || isAdmin`.
+- **Validation** — schemas live in [src/lib/validation.ts](../../lib/validation.ts). For multipart/form-data (photos), parse `formData.get('payload')` as JSON and run it through `normalizePostPayload` before the schema (see [src/app/api/posts/route.ts](posts/route.ts)).
+- **Errors** — use the helpers in [src/lib/apiErrors.ts](../../lib/apiErrors.ts). The shape `{ error: { code, message } }` is part of the public contract; don't deviate.
+- **Rate limits** — pre-built limiters in [src/lib/rateLimit.ts](../../lib/rateLimit.ts) cover signup, login, post creation, comments, reactions, cooked events. Apply with `applyRateLimit` and return early on hit.
+
+## Photo-handling routes
+
+Routes that accept photos (`posts`, `comments`) use `multipart/form-data`:
+
+- JSON payload arrives in field `payload`; files arrive in field `photos` (or `photo`).
+- Use `isFileLike` / `savePhotoFile` from [src/lib/uploads.ts](../../lib/uploads.ts).
+- Store the returned `storageKey` in DB columns named `*StorageKey` — never store rendered URLs. URLs are produced at read time via `getSignedUploadUrl`.
+- On delete, call the matching cleanup so GCS / local files don't leak.
+
+## Cache revalidation
+
+Mutations that change visible feed/list state call `revalidatePath('/timeline')`, `'/recipes'`, etc. Match the existing routes' patterns when adding new mutating endpoints.
+
+## Mirror in FastAPI
+
+If you change request/response shape, status codes, or auth behavior, the equivalent endpoint in [apps/api/src/routers/](../../../apps/api/src/routers/) likely needs the same change. The migration plan ([docs/API_BACKEND_MIGRATION_PLAN.md](../../../docs/API_BACKEND_MIGRATION_PLAN.md)) is the source of truth for which endpoints have been ported.

--- a/src/lib/CLAUDE.md
+++ b/src/lib/CLAUDE.md
@@ -1,0 +1,46 @@
+# CLAUDE.md — `src/lib/`
+
+Module map for the shared backend logic. Most of these are imported from API route handlers and server components. Prefer extending an existing module over creating a new one.
+
+## Auth & sessions
+
+- [prisma.ts](prisma.ts) — singleton `PrismaClient`. Always import `prisma` from here, never construct your own.
+- [auth.ts](auth.ts) — bcrypt password hashing/verify. Tests substitute `bcryptjs` via [jest.config.js](../../jest.config.js).
+- [jwt.ts](jwt.ts) — sign/verify the session JWT with `jose`. Tokens carry `userId`, `familySpaceId`, `role`.
+- [session-core.ts](session-core.ts) — cookie set/clear and `getSessionFromRequest`. Edge-runtime safe (used by [src/middleware.ts](../middleware.ts)).
+- [session.ts](session.ts) — Node-runtime `getCurrentUser(request)` that does the DB fetch + signed avatar URL. Re-exports the cookie helpers.
+- [apiAuth.ts](apiAuth.ts) — `withAuth` / `withRole` HOCs for route handlers. **Always use these** in API routes; don't read the session inline.
+- [permissions.ts](permissions.ts) — `canEditPost`, `canDeletePost`, `canDeleteComment`, `canRemoveMember`. Centralizes ownership/admin rules.
+- [masterKey.ts](masterKey.ts) — bcrypt hash/verify for the family master key (signup gate).
+
+## Validation & errors
+
+- [validation.ts](validation.ts) — every Zod schema for request payloads + the course/difficulty/ingredient-unit enums. Add new schemas here; don't inline.
+- [apiErrors.ts](apiErrors.ts) — `validationError` / `notFoundError` / `forbiddenError` / etc. plus `parseRequestBody`/`parseQueryParams`/`parseRouteParams` helpers. The `{ error: { code, message } }` shape is the public API contract.
+
+## Domain logic
+
+- [posts.ts](posts.ts) — `getPostDetail`, recipe-detail serialization (ingredients/steps stored as JSON strings; deserialized here).
+- [postPayload.ts](postPayload.ts) — `normalizePostPayload` + `MAX_PHOTO_COUNT`. Run incoming JSON through this before Zod when handling FormData.
+- [recipes.ts](recipes.ts) — `/api/recipes` filter/search query (title, course, tags, difficulty, time, servings, up to 5 ingredient keywords).
+- [recipeImporter.ts](recipeImporter.ts) — client for the [recipe-url-importer](../../../apps/recipe-url-importer/) service.
+- [timeline.ts](timeline.ts) — type definitions + formatting for timeline items.
+- [timeline-data.ts](timeline-data.ts) — `getTimelineFeed`: unions posts/comments/reactions/cooked/edits per request (no event table).
+- [notifications.ts](notifications.ts) — read/write of the `Notification` table; reactions are batched per `(post, recipient)`.
+- [tags.ts](tags.ts) — curated tag catalog enforcement (only seeded tags allowed).
+- [ingredients.ts](ingredients.ts) — unit enum + display formatting.
+- [family.ts](family.ts) — family member list with role + join date + post counts.
+- [profile.ts](profile.ts) — paginated queries for "My Posts", "Cooked", "Favorites" tabs.
+- [feedback.ts](feedback.ts) — `FeedbackSubmission` writes from the in-app feedback form.
+
+## Infrastructure
+
+- [uploads.ts](uploads.ts) — dual-mode photo storage. Local disk under `public/uploads` when `UPLOADS_BUCKET` is unset; GCS with signed URLs otherwise. **DB stores `storageKey`, never URLs** — resolve at read time via `getSignedUploadUrl` or `createSignedUrlResolver`. Enforces 8MB cap and JPEG/PNG/WEBP/GIF only.
+- [rateLimit.ts](rateLimit.ts) — in-process LRU limiters: `signupLimiter`, `loginLimiter`, `postCreationLimiter`, `commentLimiter`, `reactionLimiter`, `cookedEventLimiter`. Globally mocked in [jest.setup.js](../../jest.setup.js). Per-instance — does not share across replicas.
+- [logger.ts](logger.ts) — `logError`, `logWarn`. Use these instead of `console.*`; tests silence console by default (override with `ALLOW_TEST_LOGS=true`).
+
+## Patterns
+
+- **No raw SQL.** Use Prisma. If a query is unwieldy, build it with Prisma's relation includes rather than dropping to `$queryRaw`.
+- **Always scope by `familySpaceId`** in any cross-entity query. There's no row-level security.
+- **Storage keys vs URLs**: persist keys, render URLs lazily. Avoid leaking signed URLs into long-lived caches (they expire).


### PR DESCRIPTION
## Summary
- Adds root + subdirectory CLAUDE.md files so humans and future Claude Code sessions share the same navigation/convention docs (7 guides)
- Commits the `.github/` templates the new workflow relies on: `GITHUB_GUIDE.md`, `TICKET_FORMAT.md`, three `ISSUE_TEMPLATE/*.md` files, and `pull_request_template.md`
- Commits `docs/API_BACKEND_MIGRATION_PLAN.md` so issues #34–#38 (FastAPI migration phases) and the root CLAUDE.md architecture section have a live reference
- Root `CLAUDE.md` documents the `main` = prod / `develop` = dev branching convention so that rule is loaded into every future session

## Closes
Closes #29

## Test notes
- CI (typecheck, lint, tests, build, scans) should pass — no code changes, only new docs/templates
- After merge: `git status` on `develop` shows no untracked `CLAUDE.md` or `.github/` template files, and no untracked `docs/API_BACKEND_MIGRATION_PLAN.md`
- Opening a new issue via the GitHub web UI should present the three templates (feature, chore, research) and auto-apply the correct `type:` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)