### PR TITLE
fix: unblock CI security scans (trivy-action pin + low-risk vuln fixes)

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Load image
         run: docker load -i family-recipe-api.tar
       - name: Container scan (Trivy)
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: family-recipe-api:ci
           format: table

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Load image
         run: docker load -i family-recipe.tar
       - name: Container scan (Trivy)
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: family-recipe:ci
           format: table
@@ -138,7 +138,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: IaC scan (Trivy)
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'config'
           scan-ref: 'infra'

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: IaC scan (Trivy)
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'config'
           scan-ref: 'infra'

--- a/.github/workflows/recipe-url-importer-ci.yml
+++ b/.github/workflows/recipe-url-importer-ci.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Load image
         run: docker load -i recipe-url-importer.tar
       - name: Container scan (Trivy)
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: recipe-url-importer:ci
           format: table

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -1,11 +1,11 @@
 fastapi==0.125.0
 uvicorn[standard]==0.32.0
 prisma==0.15.0
-PyJWT==2.9.0
+PyJWT==2.12.0
 bcrypt==4.1.2
 pydantic-settings==2.7.0
 google-cloud-storage==2.18.2
 python-dotenv==1.0.1
 httpx==0.27.2
 rsa==4.9
-python-multipart==0.0.21
+python-multipart==0.0.26

--- a/apps/recipe-url-importer/requirements.txt
+++ b/apps/recipe-url-importer/requirements.txt
@@ -4,6 +4,6 @@ httpx==0.27.2
 pydantic-settings==2.7.0
 beautifulsoup4==4.12.3
 lxml==5.3.0
-lxml_html_clean==0.4.0
+lxml_html_clean==0.4.4
 readability-lxml==0.8.1
 python-dateutil==2.9.0.post0

--- a/package-lock.json
+++ b/package-lock.json
@@ -816,27 +816,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -5314,6 +5293,27 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/glob/node_modules/jackspeak": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
@@ -5330,15 +5330,15 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -9945,9 +9945,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.3.tgz",
-      "integrity": "sha512-ENg5JUHUm2rDD7IvKNFGzyElLXNjachNLp6RaGf4+JOgxXHkqA+gq81ZAMCUmtMtqBsoU62lcp6S27g1LCYGGQ==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",


### PR DESCRIPTION
## Summary

Fixes #43. Two root causes covered:

- **Trivy action version**: `aquasecurity/trivy-action@0.24.0` does not exist on the marketplace. Pinned all 5 call sites to `v0.35.0` by SHA (`57a97c7e7821a5776cebc9bb87c984fa69cba8f1`) across `ci.yml`, `api-ci.yml`, `recipe-url-importer-ci.yml`, and `infra.yml` — unblocks `container-scan` and `iac-scan`.
- **Low-risk dependency vulns**:
  - Next.js transitives (`npm audit fix`, no `--force`): `@isaacs/brace-expansion`, `minimatch`, `tar`, `@mapbox/node-pre-gyp`. `package.json` untouched.
  - FastAPI: `PyJWT 2.9.0 → 2.12.0`, `python-multipart 0.0.21 → 0.0.26`
  - Recipe URL Importer: `lxml_html_clean 0.4.0 → 0.4.4`

## Out of scope (tracked in #44)

- Next.js `14.2.35 → 16.2.4` — major bump, clears the 5-advisory `next` cluster. Deferred per CLAUDE.md ("prefer minimal, non-breaking changes" while testing with real family users).
- pytest `8.3.4 → 9.0.3` across both Python services — major bump affecting the test suite.

After this PR the Next `dependency-scan` job will still fail on the `next` advisory until #44 lands; everything else (container-scan × 3, iac-scan × 2, FastAPI + Importer dependency-scan) should go green.

## Test plan

- [ ] `ci.yml`: typecheck, lint, test, build, container-scan, iac-scan, dependency-scan (Next — expected still red, see above), prisma-validate, sast-semgrep, secrets-scan all run; all except Next dependency-scan pass
- [ ] `api-ci.yml`: container-scan + dependency-scan pass (FastAPI)
- [ ] `recipe-url-importer-ci.yml`: container-scan + dependency-scan pass (Importer)
- [ ] `infra.yml`: iac-scan passes
- [ ] Verified locally: `pip-audit` on both Python services returns only the deferred pytest advisory; `npm audit --production --audit-level=high` returns only the deferred next advisory

🤖 Generated with [Claude Code](https://claude.com/claude-code)