### PR TITLE
chore: bump pytest 8→9 in Python services (#44)

### DIFF
--- a/apps/api/requirements-dev.txt
+++ b/apps/api/requirements-dev.txt
@@ -2,9 +2,9 @@
 -r requirements.txt
 
 # Testing
-pytest==8.3.4
-pytest-asyncio==0.24.0
-pytest-cov==6.0.0
+pytest==9.0.3
+pytest-asyncio==1.3.0
+pytest-cov==7.1.0
 
 # For mocking
-pytest-mock==3.14.0
+pytest-mock==3.15.1

--- a/apps/recipe-url-importer/requirements-dev.txt
+++ b/apps/recipe-url-importer/requirements-dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 
-pytest==8.3.4
-pytest-asyncio==0.24.0
-pytest-cov==6.0.0
-pytest-mock==3.14.0
+pytest==9.0.3
+pytest-asyncio==1.3.0
+pytest-cov==7.1.0
+pytest-mock==3.15.1
 ruff==0.7.1


### PR DESCRIPTION
## Summary

- Bumps `pytest` 8.3.4 → 9.0.3 in `apps/api/requirements-dev.txt` and `apps/recipe-url-importer/requirements-dev.txt` — closes `GHSA-6w46-j5rx-g56g` surfaced by the `dependency-scan` CI job.
- Bumps compatible plugins: `pytest-asyncio` 0.24.0 → 1.3.0, `pytest-cov` 6.0.0 → 7.1.0, `pytest-mock` 3.14.0 → 3.15.1.
- Both `pytest.ini` files already pin `asyncio_default_fixture_loop_scope = function`, so the `pytest-asyncio` 1.x default-change is a no-op for us (ticket-noted risk does not apply).

## Closes

Partial fix for #44 — this PR covers the `pytest` half. Next.js 14→16 (the other advisory cluster) is split into a separate PR for isolated review, per the ticket's own guidance.

## Test notes

Validated locally on Python 3.12:

- `apps/api`: `PYTHONPATH=src pytest tests/` → **294 passed** (93 unit + 201 integration)
- `apps/recipe-url-importer`: `PYTHONPATH=src pytest` → **4 passed**
- No new warnings or deprecation notices from `pytest` itself (the 2 warnings in the importer suite are pre-existing `bs4`/`lxml` deprecations, unrelated).

CI `dependency-scan` jobs for both services should go green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)