### PR TITLE
chore: add docs/research/ directory for research spike outputs (#31)

### DIFF
--- a/.github/GITHUB_GUIDE.md
+++ b/.github/GITHUB_GUIDE.md
@@ -130,7 +130,7 @@ Example: `feat: cooked-event reactions (#12)`
 
 Research issues are complete when:
 
-1. A written summary is committed to `docs/research/{topic}.md`
+1. A written summary is committed to `docs/research/{topic}.md` — see [docs/research/README.md](../docs/research/README.md) for conventions
 2. The doc answers the questions listed in the issue
 3. The issue is closed with a comment linking to the committed doc
 

--- a/.github/ISSUE_TEMPLATE/research.md
+++ b/.github/ISSUE_TEMPLATE/research.md
@@ -14,7 +14,7 @@ labels: 'type: research'
 -
 
 **Output:**
-A written summary committed to `docs/research/<topic>.md`
+A written summary committed to `docs/research/<topic>.md` (see [docs/research/README.md](../../docs/research/README.md) for conventions)
 
 **Testing:**
 

--- a/.github/TICKET_FORMAT.md
+++ b/.github/TICKET_FORMAT.md
@@ -74,5 +74,5 @@ So that [outcome]
 
 - Acceptance Criteria describe **observable outcomes**, not implementation steps
 - Testing describes **how to validate** the ticket is complete, not how to implement it
-- Research outputs are always committed to `docs/research/` and linked in the closing comment
+- Research outputs are always committed to [`docs/research/`](../docs/research/README.md) and linked in the closing comment
 - Chore tasks use checkboxes so progress is visible directly in the ticket

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,0 +1,34 @@
+# Research Docs
+
+Outputs from `type: research` spikes. Each file captures a decision — not a narrative, not a log of what was tried.
+
+## Purpose
+
+Research spikes exist to answer specific questions before implementation starts. The doc produced is the durable artifact: it records the decision, the rationale, and anything a future implementer needs in order to build against it without redoing the investigation.
+
+If the content belongs in product/architecture docs (e.g. [../PRODUCT_SPEC.md](../PRODUCT_SPEC.md), [../TECHNICAL_SPEC.md](../TECHNICAL_SPEC.md)), put it there instead. This directory is for spike outputs that inform a later decision.
+
+## Naming
+
+One file per spike, named after the topic:
+
+```
+docs/research/{topic}.md
+```
+
+Examples: `feature-flag-store.md`, `refresh-token-store.md`, `gcs-vs-r2-uploads.md`. Use kebab-case, no dates, no ticket numbers in the filename — link the issue from inside the doc instead.
+
+## What a good research doc looks like
+
+- **Starts with the decision.** Lead with the chosen option and a one-paragraph summary of why. A reader should know the answer before they know the alternatives.
+- **Answers every question the ticket listed.** Use the ticket's "Questions to Answer" section as the spine of the doc.
+- **Names the alternatives considered and why they were rejected.** Future-you will want to know whether option X was ruled out on merit or never looked at.
+- **Includes anything the implementer needs to act on it** — a Prisma snippet, a config shape, an integration sketch, a cost estimate. Link to source material (RFCs, vendor docs, GitHub issues) rather than paraphrasing at length.
+- **Is concise.** A good spike doc is 1–3 pages. If it is longer, the decision is probably buried.
+
+## Workflow
+
+1. Open a `type: research` ticket using the [issue template](../../.github/ISSUE_TEMPLATE/research.md) — list the specific questions up front.
+2. Branch from `develop` as `research/{issue}/{topic}` per [.github/GITHUB_GUIDE.md](../../.github/GITHUB_GUIDE.md).
+3. Commit the doc to `docs/research/{topic}.md` and open a PR.
+4. On merge, close the ticket with a comment linking to the committed doc.


### PR DESCRIPTION
## Summary

- Creates `docs/research/` with a README covering purpose, naming convention, and what a good research doc looks like
- Cross-links the README from `.github/GITHUB_GUIDE.md`, `.github/TICKET_FORMAT.md`, and the research issue template so contributors discover the conventions from any entry point
- Unblocks the next research spikes (#39 feature-flag store, #40 refresh-token store) by giving them a home

## Closes

Closes #31

## Test notes

- Docs-only change; no code or CI gates affected
- All three updated links resolve from their source file to `docs/research/README.md`
- `docs/research/README.md` renders correctly on GitHub