### PR TITLE
feat: migrate mount-fetch components off useEffect subscriptions (#57)

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation';
 import LogoutButton from '@/components/LogoutButton';
 import BottomNav from '@/components/navigation/BottomNav';
 import NotificationBell from '@/components/navigation/NotificationBell';
+import { prisma } from '@/lib/prisma';
 import { getCurrentUser } from '@/lib/session';
 
 export default async function AppLayout({
@@ -29,6 +30,10 @@ export default async function AppLayout({
     redirect('/login');
   }
 
+  const initialUnreadCount = await prisma.notification.count({
+    where: { recipientId: user.id, readAt: null },
+  });
+
   return (
     <div className="min-h-screen bg-gray-50 pb-24">
       <header className="sticky top-0 z-30 border-b border-gray-200 bg-white/95 backdrop-blur">
@@ -42,7 +47,7 @@ export default async function AppLayout({
             </p>
           </div>
           <div className="flex items-center gap-3">
-            <NotificationBell />
+            <NotificationBell initialCount={initialUnreadCount} />
             <LogoutButton />
           </div>
         </div>

--- a/src/app/(app)/notifications/page.tsx
+++ b/src/app/(app)/notifications/page.tsx
@@ -1,6 +1,49 @@
-import NotificationsFeed from '@/components/notifications/NotificationsFeed';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import NotificationsFeed, {
+  type NotificationResponseItem,
+} from '@/components/notifications/NotificationsFeed';
+import { getCurrentUser } from '@/lib/session';
+import { fetchNotifications } from '@/lib/notifications';
 
-export default function NotificationsPage() {
+const PAGE_SIZE = 20;
+
+export default async function NotificationsPage() {
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get('session');
+
+  if (!sessionCookie) {
+    redirect('/login');
+  }
+
+  const mockRequest = {
+    cookies: {
+      get: () => sessionCookie,
+    },
+  } as any;
+
+  const user = await getCurrentUser(mockRequest);
+
+  if (!user) {
+    redirect('/login');
+  }
+
+  const { notifications, hasMore, nextOffset } = await fetchNotifications({
+    recipientId: user.id,
+    familySpaceId: user.familySpaceId,
+    limit: PAGE_SIZE,
+    offset: 0,
+  });
+
+  const initialNotifications: NotificationResponseItem[] = notifications.map(
+    (notification) => ({
+      ...notification,
+      createdAt: notification.createdAt.toISOString(),
+      updatedAt: notification.updatedAt.toISOString(),
+      readAt: notification.readAt ? notification.readAt.toISOString() : null,
+    })
+  );
+
   return (
     <section className="space-y-4">
       <div>
@@ -9,7 +52,11 @@ export default function NotificationsPage() {
           Stay on top of comments, reactions, and cooks on your posts.
         </p>
       </div>
-      <NotificationsFeed />
+      <NotificationsFeed
+        initialNotifications={initialNotifications}
+        initialHasMore={hasMore}
+        initialNextOffset={nextOffset}
+      />
     </section>
   );
 }

--- a/src/app/(app)/timeline/page.tsx
+++ b/src/app/(app)/timeline/page.tsx
@@ -1,13 +1,55 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
 import TimelineFeed from '@/components/timeline/TimelineFeed';
+import { getCurrentUser } from '@/lib/session';
+import { getTimelineFeed } from '@/lib/timeline-data';
+import type { TimelineItem } from '@/lib/timeline';
+
+const PAGE_SIZE = 20;
 
 export default async function TimelinePage() {
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get('session');
+
+  if (!sessionCookie) {
+    redirect('/login');
+  }
+
+  const mockRequest = {
+    cookies: {
+      get: () => sessionCookie,
+    },
+  } as any;
+
+  const user = await getCurrentUser(mockRequest);
+
+  if (!user) {
+    redirect('/login');
+  }
+
+  const { items, hasMore, nextOffset } = await getTimelineFeed({
+    familySpaceId: user.familySpaceId,
+    limit: PAGE_SIZE,
+    offset: 0,
+  });
+
+  // Normalize Date fields to ISO strings so initial items match the shape of
+  // paginated items returned by /api/timeline.
+  const initialItems = JSON.parse(JSON.stringify(items)) as TimelineItem[];
+
   return (
     <section className="space-y-4">
       <div>
         <h2 className="text-xl font-semibold text-gray-900">Family Timeline</h2>
-        <p className="text-sm text-gray-500">See what everyone has been cooking.</p>
+        <p className="text-sm text-gray-500">
+          See what everyone has been cooking.
+        </p>
       </div>
-      <TimelineFeed />
+      <TimelineFeed
+        initialItems={initialItems}
+        initialHasMore={hasMore}
+        initialNextOffset={nextOffset}
+      />
     </section>
   );
 }

--- a/src/components/navigation/NotificationBell.tsx
+++ b/src/components/navigation/NotificationBell.tsx
@@ -3,29 +3,31 @@
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
-export default function NotificationBell() {
-  const [unreadCount, setUnreadCount] = useState<number>(0);
+interface NotificationBellProps {
+  initialCount: number;
+}
 
-  const fetchUnreadCount = async () => {
-    try {
-      const response = await fetch('/api/notifications/unread-count', {
-        cache: 'no-store',
-      });
-      if (!response.ok) return;
-      const data = await response.json();
-      setUnreadCount(
-        typeof data.unreadCount === 'number' ? data.unreadCount : 0
-      );
-    } catch (error) {
-      console.error('Failed to fetch unread notifications', error);
-    }
-  };
+export default function NotificationBell({
+  initialCount,
+}: NotificationBellProps) {
+  const [unreadCount, setUnreadCount] = useState<number>(initialCount);
 
   useEffect(() => {
-    // Mount-time fetch + 60s poll to keep the unread badge current.
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- client-only polling subscription; SWR/RSC migration tracked in #57
-    fetchUnreadCount();
-    const interval = setInterval(fetchUnreadCount, 60000);
+    const refresh = async () => {
+      try {
+        const response = await fetch('/api/notifications/unread-count', {
+          cache: 'no-store',
+        });
+        if (!response.ok) return;
+        const data = await response.json();
+        setUnreadCount(
+          typeof data.unreadCount === 'number' ? data.unreadCount : 0
+        );
+      } catch (error) {
+        console.error('Failed to fetch unread notifications', error);
+      }
+    };
+    const interval = setInterval(refresh, 60000);
     return () => clearInterval(interval);
   }, []);
 

--- a/src/components/notifications/NotificationsFeed.tsx
+++ b/src/components/notifications/NotificationsFeed.tsx
@@ -36,85 +36,59 @@ interface ApiResponse {
   nextOffset: number;
 }
 
+interface NotificationsFeedProps {
+  initialNotifications: NotificationResponseItem[];
+  initialHasMore: boolean;
+  initialNextOffset: number;
+}
+
 const PAGE_SIZE = 20;
 
-export default function NotificationsFeed() {
-  const [notifications, setNotifications] = useState<
-    NotificationResponseItem[]
-  >([]);
-  const [hasMore, setHasMore] = useState(false);
-  const [offset, setOffset] = useState(0);
-  const [isLoading, setIsLoading] = useState(true);
+export default function NotificationsFeed({
+  initialNotifications,
+  initialHasMore,
+  initialNextOffset,
+}: NotificationsFeedProps) {
+  const [notifications, setNotifications] =
+    useState<NotificationResponseItem[]>(initialNotifications);
+  const [hasMore, setHasMore] = useState(initialHasMore);
+  const [offset, setOffset] = useState(initialNextOffset);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [error, setError] = useState('');
 
-  const markAllRead = async () => {
-    try {
-      await fetch('/api/notifications/mark-read', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({}),
-      });
-    } catch (err) {
+  useEffect(() => {
+    // Fire-and-forget: mark notifications read once the feed has been opened.
+    // No state is set in this effect body; the bell refreshes via its own poll.
+    fetch('/api/notifications/mark-read', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    }).catch((err) => {
       console.error('Failed to mark notifications as read', err);
-    }
-  };
+    });
+  }, []);
 
-  const fetchNotifications = async (currentOffset: number = 0) => {
+  const handleLoadMore = async () => {
+    setIsLoadingMore(true);
     try {
       const response = await fetch(
-        `/api/notifications?limit=${PAGE_SIZE}&offset=${currentOffset}`,
-        {
-          cache: 'no-store',
-        }
+        `/api/notifications?limit=${PAGE_SIZE}&offset=${offset}`,
+        { cache: 'no-store' }
       );
-
       if (!response.ok) {
         throw new Error('Failed to fetch notifications');
       }
-
       const data: ApiResponse = await response.json();
-
-      if (currentOffset === 0) {
-        setNotifications(data.notifications);
-      } else {
-        setNotifications((prev) => [...prev, ...data.notifications]);
-      }
-
+      setNotifications((prev) => [...prev, ...data.notifications]);
       setHasMore(data.hasMore);
       setOffset(data.nextOffset);
     } catch (err) {
       setError('Failed to load notifications');
       console.error('Notification fetch error:', err);
     } finally {
-      setIsLoading(false);
       setIsLoadingMore(false);
     }
   };
-
-  useEffect(() => {
-    // Mount-time: mark existing notifications read and fetch the first page.
-    markAllRead();
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- client-only initial fetch for paginated list; SWR/RSC migration tracked in #57
-    fetchNotifications(0);
-  }, []);
-
-  const handleLoadMore = () => {
-    setIsLoadingMore(true);
-    fetchNotifications(offset);
-  };
-
-  if (isLoading) {
-    return (
-      <div className="rounded-2xl bg-white p-6 shadow-sm">
-        <div className="space-y-4">
-          <div className="h-4 w-32 animate-pulse rounded bg-gray-200" />
-          <div className="h-4 w-48 animate-pulse rounded bg-gray-200" />
-          <div className="h-24 w-full animate-pulse rounded bg-gray-100" />
-        </div>
-      </div>
-    );
-  }
 
   if (error) {
     return (

--- a/src/components/timeline/TimelineFeed.tsx
+++ b/src/components/timeline/TimelineFeed.tsx
@@ -1,68 +1,45 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import TimelineCard from './TimelineCard';
 import EmptyState from './EmptyState';
 import { TimelineItem } from '@/lib/timeline';
 
-export default function TimelineFeed() {
-  const [items, setItems] = useState<TimelineItem[]>([]);
-  const [hasMore, setHasMore] = useState(false);
-  const [offset, setOffset] = useState(0);
-  const [isLoading, setIsLoading] = useState(true);
+interface TimelineFeedProps {
+  initialItems: TimelineItem[];
+  initialHasMore: boolean;
+  initialNextOffset: number;
+}
+
+export default function TimelineFeed({
+  initialItems,
+  initialHasMore,
+  initialNextOffset,
+}: TimelineFeedProps) {
+  const [items, setItems] = useState<TimelineItem[]>(initialItems);
+  const [hasMore, setHasMore] = useState(initialHasMore);
+  const [offset, setOffset] = useState(initialNextOffset);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [error, setError] = useState('');
 
-  const fetchTimeline = async (currentOffset: number = 0) => {
+  const handleLoadMore = async () => {
+    setIsLoadingMore(true);
     try {
-      const response = await fetch(
-        `/api/timeline?limit=20&offset=${currentOffset}`
-      );
-
+      const response = await fetch(`/api/timeline?limit=20&offset=${offset}`);
       if (!response.ok) {
         throw new Error('Failed to fetch timeline');
       }
-
       const data = await response.json();
-
-      if (currentOffset === 0) {
-        setItems(data.items);
-      } else {
-        setItems((prev) => [...prev, ...data.items]);
-      }
-
+      setItems((prev) => [...prev, ...data.items]);
       setHasMore(data.hasMore);
       setOffset(data.nextOffset);
     } catch (err) {
       setError('Failed to load timeline');
       console.error('Timeline fetch error:', err);
     } finally {
-      setIsLoading(false);
       setIsLoadingMore(false);
     }
   };
-
-  useEffect(() => {
-    // Mount-time fetch for the first timeline page.
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- client-only initial fetch for paginated list; SWR/RSC migration tracked in #57
-    fetchTimeline(0);
-  }, []);
-
-  const handleLoadMore = () => {
-    setIsLoadingMore(true);
-    fetchTimeline(offset);
-  };
-
-  if (isLoading) {
-    return (
-      <div className="bg-white rounded-lg shadow p-8 text-center">
-        <div className="animate-pulse">
-          <div className="h-4 bg-gray-200 rounded w-3/4 mx-auto mb-4"></div>
-          <div className="h-4 bg-gray-200 rounded w-1/2 mx-auto"></div>
-        </div>
-      </div>
-    );
-  }
 
   if (error) {
     return (


### PR DESCRIPTION
## Summary

- Moves `NotificationBell`, `NotificationsFeed`, and `TimelineFeed` from `useEffect` mount-fetch to the server component + client boundary pattern already used by `RecipesBrowseClient`.
- Pages (and the `(app)` layout for the bell) now fetch first-page data server-side and pass it in as `initial*` props. Client components only own pagination/interval state.
- All three `eslint-disable-next-line react-hooks/set-state-in-effect` suppressions added in #51 are removed. `NotificationBell`'s 60s poll is preserved — `setState` now fires inside the `setInterval` callback (subscription pattern), not as inline effect work. `NotificationsFeed` still does fire-and-forget `markAllRead` on mount, but that effect no longer calls `setState`, so the rule doesn't trigger.

## Closes

Closes #57

## Test notes

- `npm run lint` — 0 warnings / 0 errors; no `set-state-in-effect` disables remain in `src/`
- `npm run type-check` — clean
- `npm test` — 46 suites / 954 tests pass (no dedicated tests on these components; `/api/timeline` and `/api/notifications` integration tests continue to pass)
- **Browser regression not run from this session** — worktree had no seeded DB and the repo's SQLite `schema.prisma` is currently failing `prisma generate` with Json-field errors (pre-existing on `develop`, unrelated to this change). Please verify manually:
  - Timeline: first paint has data (no spinner flash), scroll + Load More still appends pages
  - Notifications bell: badge count renders on first paint; updates within ~1 minute
  - Notifications page: mark-read still clears the badge, Load More still works