### PR TITLE
research: Claude local verification before PR (#59)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,18 @@ When working against Postgres locally, set `PRISMA_SCHEMA=prisma/schema.postgres
 - **`bcrypt` vs `bcryptjs`**: prod uses native `bcrypt`; jest aliases it to `bcryptjs` (see [jest.config.js](jest.config.js)) so tests don't need native compilation. Don't import `bcryptjs` directly in app code.
 - **Server vs client components**: default to server components for data fetching; mark `'use client'` only for interactive forms/state. Server components reuse `getCurrentUser` by passing a `NextRequest`-shaped object.
 
+## Before opening a PR
+
+The pre-commit hook runs `type-check` + `lint-staged`; nothing else is automatic. Run the verification playbook matching what you changed — see [docs/verification/README.md](docs/verification/README.md) for the index. In short:
+
+- **UI** (anything under [src/app/](src/app/) or [src/components/](src/components/)) → [docs/verification/ui.md](docs/verification/ui.md)
+- **Next API** ([src/app/api/](src/app/api/)) → [docs/verification/next-api.md](docs/verification/next-api.md)
+- **FastAPI** ([apps/api/](apps/api/)) → [docs/verification/fastapi.md](docs/verification/fastapi.md)
+- **Recipe URL importer** ([apps/recipe-url-importer/](apps/recipe-url-importer/)) → [docs/verification/recipe-url-importer.md](docs/verification/recipe-url-importer.md)
+- **Prisma schema** ([prisma/](prisma/)) → [docs/verification/prisma.md](docs/verification/prisma.md)
+
+Always finish with `npm test` (the pre-commit hook doesn't run it). If the session can't run a tool a change needs (e.g., no browser for a hydration-sensitive UI change), say so in the PR body — don't claim UI success from `curl` alone.
+
 ## Branches and releases
 
 - `main` = **production**. `develop` = **dev environment**.

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -34,3 +34,7 @@ npx prisma generate --schema ../../prisma/schema.postgres.prisma --generator cli
 ## Testing
 
 `pytest tests/unit/` for unit tests, `pytest tests/integration/` for integration. CI runs both plus ruff, mypy, trivy, pip-audit, semgrep, gitleaks ([.github/workflows/api-ci.yml](../../.github/workflows/api-ci.yml)).
+
+## Verification
+
+Before opening a PR that touches this service, run the [FastAPI playbook](../../docs/verification/fastapi.md) — includes the curl+cookie loop, contract parity check against the Next mirror, and the local quality gates.

--- a/apps/recipe-url-importer/CLAUDE.md
+++ b/apps/recipe-url-importer/CLAUDE.md
@@ -21,3 +21,7 @@ Standalone Python service that fetches a public recipe URL and returns a normali
 ## Tests
 
 `PYTHONPATH=src pytest`. CI is [.github/workflows/recipe-url-importer-ci.yml](../../.github/workflows/recipe-url-importer-ci.yml).
+
+## Verification
+
+Before opening a PR that touches this service, run the [importer playbook](../../docs/verification/recipe-url-importer.md) — includes the `/v1/parse` loop, SSRF probes, and downstream-client check.

--- a/docs/research/claude-local-verification.md
+++ b/docs/research/claude-local-verification.md
@@ -1,0 +1,196 @@
+# Claude Local Verification Before Opening a PR
+
+Research output for [#59](https://github.com/wnorowskie/family-recipe/issues/59).
+
+## Decision
+
+**Adopt a three-layer verification workflow that Claude runs before handing off a PR.** Keep the layers independent so Claude can stop at the first one that gives sufficient signal for the change at hand.
+
+- **L0 — HTTP against `npm run dev` (default, free, already works).** Background `next dev`, `curl` routes, diff response bodies or status codes. Covers ~60% of changes — API routes, server components, route gating, static strings in HTML.
+- **L1 — Claude Code's native Chrome integration (`claude --chrome`).** First-party, ships with Claude Code 2.0.73+. Used on demand when the change needs a real browser (hydrated client components, forms, photo uploads, navigation flows). Beta but officially supported, no MCP config to maintain.
+- **L2 — Playwright MCP (optional, headless fallback).** `claude mcp add playwright npx @playwright/mcp@latest`. Use when Claude is running in a session that cannot open a visible browser window (remote/background agent, Claude Desktop without the extension). Accessibility snapshots, not screenshots — token-cheap.
+
+**Reject** per-branch Cloud Run preview deploys for this repo (overkill for V1's one-family scope). **Reject** Chrome DevTools MCP as a default; keep it on hand for one-off performance or network debugging sessions only.
+
+**Also land two small repo changes**, documented below, that make L0 reliable:
+
+1. A `scripts/claude-login.sh` helper — curl-login with a cookie jar, usable against any dev/preview host.
+2. An explicit `DATABASE_URL="file:./prisma/dev.db"` override pattern for starting dev when local Postgres is down (the default `.env` points at Postgres and today Claude stalls when it isn't running).
+
+## Why this option
+
+- **First-party tooling over third-party glue.** Claude Code's Chrome integration is supported by Anthropic, ships with every Claude Code release, and shares the dev's already-authenticated Chrome profile — no fake cookie jars, no test fixtures drifting from prod auth. MCPs are an escape hatch, not the default. ([code.claude.com/docs/en/chrome](https://code.claude.com/docs/en/chrome))
+- **Most V1 changes don't need a browser.** The app is ~70% server components ([src/lib/CLAUDE.md](../../src/lib/CLAUDE.md)), and every mutation goes through a JSON REST route under [src/app/api/](../../src/app/api/). For those, `curl` + a cookie jar is the fastest-to-spin-up check. Reserving the browser for genuine UI changes keeps the context window light and the feedback loop fast.
+- **No new infra.** Nothing deploys, nothing new to host, no test-account provisioning on GCS. The only persistent additions are one shell script and one documented env override.
+- **Layered design matches the automated-testing spike ([#58](https://github.com/wnorowskie/family-recipe/issues/58)).** Both spikes converge on Playwright. When #58 picks its CI framework, this doc's L2 tooling reuses the same runner — the fixtures Claude needs locally are the same ones the CI suite needs.
+
+## Alternatives considered
+
+| Option                                                                        | Why rejected                                                                                                                                                                                                                                                                                                                                                                                                               |
+| ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Chrome DevTools MCP as the default L1                                         | 34-tool surface area is heavier than needed for typical verification. Performance traces / Lighthouse / network panel are valuable for debugging but not for "does this change work." Keep it installable on demand. ([ChromeDevTools/chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp))                                                                                                         |
+| `shot-scraper` CLI only (no browser integration)                              | Gets screenshots cheaply but gives Claude no way to interact — can't click a form, can't follow a redirect, can't read console errors. Fine as a _supplement_ for visual diffs; insufficient as the primary tool. ([simonw/shot-scraper](https://github.com/simonw/shot-scraper))                                                                                                                                          |
+| Per-branch Cloud Run preview deploys                                          | Well-documented pattern ([Cloud Run tutorial](https://cloud.google.com/run/docs/tutorials/configure-deployment-previews)), but every PR now costs a deploy + a revision, and Claude then has to wait minutes for rollout before verifying. V1 is a single private family — the value is sharing previews with human testers, not Claude verification. Revisit if we ever have multiple reviewers who need visual previews. |
+| Dedicated docker-compose stack for verification                               | Would bundle Postgres + Next + the FastAPI service. Too much to spin up per verification; the existing SQLite path already works for everything except cross-service contract tests.                                                                                                                                                                                                                                       |
+| `@playwright/cli` (Microsoft's token-efficient alternative to Playwright MCP) | Interesting — ~4× fewer tokens than MCP for the same task ([Playwright MCP 2026 notes](https://testcollab.com/blog/playwright-mcp)) — but it's newer and less battle-tested. Worth revisiting in 6 months; Playwright MCP is the safer default today.                                                                                                                                                                      |
+| Require a dedicated test environment (e.g. a third Cloud Run service)         | Adds ops burden with no clear win over `npm run dev` + SQLite. If local verification becomes flaky, reconsider.                                                                                                                                                                                                                                                                                                            |
+
+## Answers to the ticket questions
+
+### Current state of Claude-accessible browser tooling
+
+| Tool                                | What Claude gets                                                                                                                                                                                                  | Install cost                                                                                                                                                                          | When to pick                                                                                                                 |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Bash + `curl` against `npm run dev` | HTTP status, response body, headers, cookies. Sees server-rendered HTML (verified below).                                                                                                                         | Already available.                                                                                                                                                                    | API routes, server components, route gating, HTML string checks, contract verification.                                      |
+| `claude --chrome` / `/chrome`       | Full browser: click, type, navigate, read console, screenshot. Uses the user's real Chrome profile. Beta, Chrome/Edge only, local only (no WSL). Requires Claude Code 2.0.73+ and the Claude-in-Chrome extension. | One-time: install extension + `/chrome` → "Enabled by default" or pass `--chrome`. ([docs](https://code.claude.com/docs/en/chrome))                                                   | Any change that needs hydration, interaction, or visual confirmation.                                                        |
+| Playwright MCP (`@playwright/mcp`)  | Headless Chromium, accessibility-tree snapshots (not screenshots — text-based, token-cheap), 20+ tools for nav/click/form.                                                                                        | `claude mcp add playwright npx @playwright/mcp@latest`. Installs Playwright browsers (~300MB) on first run. ([microsoft/playwright-mcp](https://github.com/microsoft/playwright-mcp)) | Remote/background agents without a visible browser; repeatable regression checks; when the Chrome extension isn't available. |
+| Chrome DevTools MCP                 | Performance traces, network panel, console reads, Lighthouse, CrUX, memory snapshots, 34 tools.                                                                                                                   | `claude mcp add chrome-devtools npx chrome-devtools-mcp@latest`. ([ChromeDevTools/chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp))                        | One-off perf or network debugging. Not a daily driver.                                                                       |
+| `shot-scraper` CLI                  | Static screenshots of any URL. Built on Playwright.                                                                                                                                                               | `pip install shot-scraper && shot-scraper install`. ([simonw/shot-scraper](https://github.com/simonw/shot-scraper))                                                                   | Visual diffs as a cheap supplement to L0 — capture before/after PNGs when changing CSS.                                      |
+
+### Screenshots before/after for UI changes
+
+Two paths depending on how the session is running:
+
+- **Interactive session with Chrome available**: use `claude --chrome`. Ask Claude to navigate, screenshot, then apply the change, refresh, screenshot again, compare. The screenshots land back in the conversation context. Highest signal.
+- **Headless / background session**: use `shot-scraper http://localhost:3000/<path> -o before.png`, apply the change, repeat. Diff with `git diff --no-index before.png after.png` (shows binary differs) or open both in an image viewer.
+
+For the typical private-app change, the Chrome integration's built-in screenshot is enough — no need to install `shot-scraper` up front.
+
+### API-only changes — `curl` + cookie auth
+
+Login is a plain JSON POST to [`/api/auth/login`](../../src/app/api/auth/login/route.ts) that sets an HTTP-only `session` cookie. Everything else follows the cookie jar.
+
+```bash
+# One-time: start dev (see DB caveat below)
+DATABASE_URL="file:./prisma/dev.db" npm run dev &
+
+# Login, save cookie
+curl -s -c /tmp/fr-cookies.txt \
+  -H "Content-Type: application/json" \
+  -d '{"emailOrUsername":"claude-test","password":"TestPass123!"}' \
+  http://localhost:3000/api/auth/login | jq .
+
+# Hit a protected route
+curl -s -b /tmp/fr-cookies.txt http://localhost:3000/api/posts | jq .
+```
+
+**The missing piece today is the seeded test user.** [prisma/seed.ts](../../prisma/seed.ts) creates the `FamilySpace` and tag catalog but not a verified user Claude can log in as. Follow-up: add a `scripts/claude-login.sh` wrapper and, optionally, a `seed:test-user` sub-task that creates a `claude-test` user idempotently when `NODE_ENV !== "production"`.
+
+### Auth, photo uploads, and DB state — how to avoid pollution
+
+| Concern                              | Strategy                                                                                                                                                                                                                                          |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Don't overwrite real family data** | Point `DATABASE_URL` at `file:./prisma/dev.db` (SQLite, gitignored per [.gitignore](../../.gitignore)) for Claude's verification sessions. Never run verification against the dev Postgres instance that a real family member is testing against. |
+| **Auth without leaking secrets**     | The dedicated `claude-test` user's password lives in `.env.local` (gitignored), not committed. The family master key is either already in `.env` or printed by `db:seed` — Claude can read it from there, never from source.                      |
+| **Photo uploads in GCS**             | Don't. Leave `UPLOADS_BUCKET` unset locally so [src/lib/uploads.ts](../../src/lib/uploads.ts) writes to `public/uploads/`. Claude can inspect the written files directly on disk. No GCS credentials ever needed locally.                         |
+| **DB reset between sessions**        | `rm prisma/dev.db && DATABASE_URL="file:./prisma/dev.db" npx prisma db push --schema prisma/schema.prisma && npm run db:seed` is the hard reset. For most verifications, state carry-over is fine.                                                |
+| **Don't pollute `public/uploads`**   | Periodically `git clean -fdx public/uploads/` after verification sessions (gitignored but fills the disk over time). Not urgent.                                                                                                                  |
+
+### Local dev vs dedicated test env vs preview deploys
+
+**Pick local dev with SQLite.** Rationale:
+
+- `next dev` starts in under a second (empirically: 240ms on this machine, captured in the POC below).
+- SQLite avoids the "is Postgres running?" flake. The default `.env` currently points at `127.0.0.1:5432`; if that daemon is down, `next dev` will boot but every DB-touching route returns 500. Claude hits this silently and assumes the change is broken.
+- No CI credits spent, no cloud state to clean up.
+
+A dedicated preview deploy becomes worth it only when: (a) multiple humans need to visually review, or (b) the change touches GCS or Cloud Run infra that local can't faithfully emulate. Neither applies to >95% of PRs on this repo.
+
+### Cost
+
+- **Zero extra infra.** Everything runs on the developer's machine.
+- **Context budget**: curl responses are small (KB). The Chrome integration loads a tool schema per session — the docs ([code.claude.com/docs/en/chrome](https://code.claude.com/docs/en/chrome)) note "Enabling Chrome by default in the CLI increases context usage since browser tools are always loaded." Keep it opt-in per session (`claude --chrome`) rather than default-on unless the task genuinely needs it.
+- **Time budget per change**: ~30s for L0 (curl HTML/API), ~1–2 min for L1 (navigate, click, screenshot, compare). Both are dwarfed by `npm test`, so they fit inside the existing verification loop without extending it.
+
+### Recommended default workflow per change type
+
+| Change type                              | Minimum verification before PR                                                                                                                                                                                                                                                            |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **API route** (`src/app/api/...`)        | L0 only. Background `npm run dev`, `curl` the endpoint with + without auth, confirm status codes, response shape, and that the family-scoping filter is present in the query. Re-check the mirror router in [apps/api/src/routers/](../../apps/api/src/routers/) if the contract changed. |
+| **Server component** (no `'use client'`) | L0 for string/markup checks (`curl /path \| grep`). L1 if the change is visual.                                                                                                                                                                                                           |
+| **Client component** (`'use client'`)    | L1 always. Initial HTML from `curl` shows the pre-hydration state, not the real user experience. Load the page in the Chrome integration and exercise the interaction.                                                                                                                    |
+| **Prisma schema**                        | Update all three schemas ([prisma/CLAUDE.md](../../prisma/CLAUDE.md)), run `npm run db:push` on SQLite, re-run `npm run type-check`, then L0 against the affected endpoint.                                                                                                               |
+| **Photo upload path**                    | L1. Must actually submit a form with a file; `curl` can do multipart but misses the front-end validation. Verify file lands in `public/uploads/` and DB row has a non-null `storageKey`.                                                                                                  |
+| **Auth / session**                       | L0 login flow (above) + L1 for the logged-in redirect. Re-verify [src/proxy.ts](../../src/proxy.ts) gating via L0 with and without cookie.                                                                                                                                                |
+| **UI polish / CSS**                      | L1 with screenshots before/after. Also test mobile viewport (`/chrome` supports viewport resize).                                                                                                                                                                                         |
+
+**Always, regardless of change type**: `npm run type-check && npm run lint && npm test` (pre-commit hook enforces the first two; the third is the one Claude must remember).
+
+### Integration with the automated-testing spike (#58)
+
+[#58](https://github.com/wnorowskie/family-recipe/issues/58) picks the durable test framework for CI; this doc picks the ad-hoc tooling for Claude's per-PR verification. **They should land on the same framework** — Playwright.
+
+- The `claude-login.sh` helper and the `claude-test` seed user proposed here are the same fixtures #58's test suite will need.
+- Playwright MCP (L2) runs the same engine as Playwright test (#58 likely pick), so a test Claude writes using MCP tools translates directly into a committable spec.
+- The "API contract snapshot" idea raised in #58 can reuse L0's `curl` → `jq` recipes verbatim.
+
+Keep this doc's L0 workflow even after #58 lands. Running the full Playwright suite per verification is too slow; `curl` stays the fastest check for the 80% case.
+
+### CLAUDE.md updates
+
+Add a new section to the root [CLAUDE.md](../../CLAUDE.md) between "Conventions worth knowing" and "Branches and releases":
+
+```markdown
+## Before opening a PR
+
+In addition to the pre-commit gate (`type-check` + `lint`), run the verification layer appropriate to the change (see [docs/research/claude-local-verification.md](docs/research/claude-local-verification.md) for the full matrix):
+
+- **Always**: `npm test` (the pre-commit hook does not run it).
+- **API route / server-component change**: background `npm run dev`, `curl` the affected route, confirm status + response shape.
+- **Client-component / UI change**: load the page in the Claude Code Chrome integration (`claude --chrome` or `/chrome`). For hydration-sensitive pages, initial `curl` HTML is not enough.
+- **Any DB-touching change**: override `DATABASE_URL="file:./prisma/dev.db"` for the dev server when local Postgres isn't running. Don't verify against a real family's data.
+
+If the current session can't run a browser, fall back to Playwright MCP headless (`claude mcp add playwright npx @playwright/mcp@latest`) or state the gap explicitly in the PR body — do not claim UI success without running the UI.
+```
+
+This is proposed, not committed in this PR — the CLAUDE.md edit lands in the follow-up implementation ticket so the research PR stays scope-pure.
+
+## Worked example (from this branch)
+
+The POC loop took ~2 minutes end-to-end:
+
+```text
+# 1. Start dev server against SQLite (Postgres was down; confirmed the default
+#    `.env` stalls without it):
+$ DATABASE_URL="file:./prisma/dev.db" npm run dev &
+   ✓ Ready in 240ms
+   - Local: http://localhost:3000
+
+# 2. Capture baseline HTML:
+$ curl -s -o /tmp/before.html http://localhost:3000/login
+   status=200 size=16995
+
+# 3. Edit src/app/(auth)/login/page.tsx — change "Log In" → "Log In Here"
+
+# 4. Re-capture after Fast Refresh (brief settle time):
+$ curl -s -o /tmp/after.html http://localhost:3000/login
+   status=200 size=17000
+
+# 5. Diff the changed string:
+$ diff <(grep -o 'Log In[^<]*' /tmp/before.html) \
+       <(grep -o 'Log In[^<]*' /tmp/after.html)
+< Log In
+> Log In Here
+
+# 6. Revert the edit; git diff is clean.
+```
+
+This is pure L0 — no browser, no MCP, no test fixtures. It confirms a UI string change landed in server-rendered HTML. For a change that actually needs the browser (say, the mobile nav menu toggle), L1 is the right tool; the same dev server is already warm.
+
+## Implementation follow-ups
+
+Open separate tickets for each — this PR ships the doc only.
+
+1. **`chore: claude-test seed user + login helper`** — add an idempotent `seed:test-user` sub-task (dev-only) and `scripts/claude-login.sh` that wraps the curl flow. Unblocks Claude's L0 auth loop and #58's test fixtures.
+2. **`chore: document SQLite override in README`** — one-liner in the README Commands section so the Postgres-down case isn't rediscovered by every contributor.
+3. **`chore: add "Before opening a PR" section to CLAUDE.md`** — the block above. Small but durable.
+4. **`chore: install Playwright MCP in the project .claude/settings.json`** — once #58 lands on Playwright, both spikes share the install.
+
+## Sources
+
+- [Use Claude Code with Chrome (beta) — Claude docs](https://code.claude.com/docs/en/chrome)
+- [microsoft/playwright-mcp](https://github.com/microsoft/playwright-mcp) · [Playwright MCP 2026 update](https://testcollab.com/blog/playwright-mcp)
+- [ChromeDevTools/chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp)
+- [simonw/shot-scraper](https://github.com/simonw/shot-scraper)
+- [Cloud Run deployment previews tutorial](https://cloud.google.com/run/docs/tutorials/configure-deployment-previews) · [Deploy Previews to Cloud Run (GitHub Action)](https://github.com/marketplace/actions/deploy-previews-to-cloud-run)
+- [docs/research/README.md](README.md) — style guide for this doc

--- a/docs/research/claude-local-verification.md
+++ b/docs/research/claude-local-verification.md
@@ -12,16 +12,16 @@ Research output for [#59](https://github.com/wnorowskie/family-recipe/issues/59)
 
 **Reject** per-branch Cloud Run preview deploys for this repo (overkill for V1's one-family scope). **Reject** Chrome DevTools MCP as a default; keep it on hand for one-off performance or network debugging sessions only.
 
-**Also land two small repo changes**, documented below, that make L0 reliable:
+**Two operational patterns the playbooks need**, documented below:
 
-1. A `scripts/claude-login.sh` helper — curl-login with a cookie jar, usable against any dev/preview host.
-2. An explicit `DATABASE_URL="file:./prisma/dev.db"` override pattern for starting dev when local Postgres is down (the default `.env` points at Postgres and today Claude stalls when it isn't running).
+1. A `scripts/claude-login.sh` helper — curl-login with a cookie jar. **Deferred to a follow-up ticket** (see "Implementation follow-ups" below); the playbooks currently use inline `curl` with `<user>`/`<pass>` placeholders.
+2. An explicit `DATABASE_URL="file:./prisma/dev.db"` override pattern for starting dev when local Postgres is down (the default `.env` points at Postgres and today Claude stalls when it isn't running). **Documented in the playbooks that ship in this PR.**
 
 ## Why this option
 
 - **First-party tooling over third-party glue.** Claude Code's Chrome integration is supported by Anthropic, ships with every Claude Code release, and shares the dev's already-authenticated Chrome profile — no fake cookie jars, no test fixtures drifting from prod auth. MCPs are an escape hatch, not the default. ([code.claude.com/docs/en/chrome](https://code.claude.com/docs/en/chrome))
 - **Most V1 changes don't need a browser.** The app is ~70% server components ([src/lib/CLAUDE.md](../../src/lib/CLAUDE.md)), and every mutation goes through a JSON REST route under [src/app/api/](../../src/app/api/). For those, `curl` + a cookie jar is the fastest-to-spin-up check. Reserving the browser for genuine UI changes keeps the context window light and the feedback loop fast.
-- **No new infra.** Nothing deploys, nothing new to host, no test-account provisioning on GCS. The only persistent additions are one shell script and one documented env override.
+- **No new infra.** Nothing deploys, nothing new to host, no test-account provisioning on GCS. The persistent additions are documentation-only: the playbooks in `docs/verification/` and the env-override pattern they reference.
 - **Layered design matches the automated-testing spike ([#58](https://github.com/wnorowskie/family-recipe/issues/58)).** Both spikes converge on Playwright. When #58 picks its CI framework, this doc's L2 tooling reuses the same runner — the fixtures Claude needs locally are the same ones the CI suite needs.
 
 ## Alternatives considered
@@ -143,7 +143,7 @@ In addition to the pre-commit gate (`type-check` + `lint`), run the verification
 If the current session can't run a browser, fall back to Playwright MCP headless (`claude mcp add playwright npx @playwright/mcp@latest`) or state the gap explicitly in the PR body — do not claim UI success without running the UI.
 ```
 
-This is proposed, not committed in this PR — the CLAUDE.md edit lands in the follow-up implementation ticket so the research PR stays scope-pure.
+This block landed in this PR's second commit (alongside the per-service [docs/verification/](../verification/) playbooks). Root [CLAUDE.md](../../CLAUDE.md) and each service's CLAUDE.md now link to the matching playbook.
 
 ## Worked example (from this branch)
 
@@ -179,12 +179,12 @@ This is pure L0 — no browser, no MCP, no test fixtures. It confirms a UI strin
 
 ## Implementation follow-ups
 
-Open separate tickets for each — this PR ships the doc only.
+This PR ships the research doc, the [docs/verification/](../verification/) playbooks, and the CLAUDE.md wiring. Tracked follow-ups:
 
-1. **`chore: claude-test seed user + login helper`** — add an idempotent `seed:test-user` sub-task (dev-only) and `scripts/claude-login.sh` that wraps the curl flow. Unblocks Claude's L0 auth loop and #58's test fixtures.
-2. **`chore: document SQLite override in README`** — one-liner in the README Commands section so the Postgres-down case isn't rediscovered by every contributor.
-3. **`chore: add "Before opening a PR" section to CLAUDE.md`** — the block above. Small but durable.
-4. **`chore: install Playwright MCP in the project .claude/settings.json`** — once #58 lands on Playwright, both spikes share the install.
+1. [#62](https://github.com/wnorowskie/family-recipe/issues/62) **research: validate verification playbooks on a real change** — pressure-test the playbooks end-to-end on a real ticket before investing more in the workflow. Do this first.
+2. [#63](https://github.com/wnorowskie/family-recipe/issues/63) **chore: `claude-test` seed user + `scripts/claude-login.sh`** — add an idempotent dev-only seed step and a login wrapper. Replaces the `<user>`/`<pass>` placeholders in the playbooks.
+3. [#64](https://github.com/wnorowskie/family-recipe/issues/64) **chore: document SQLite override in README** — one-liner so non-Claude contributors discover the pattern too.
+4. [#65](https://github.com/wnorowskie/family-recipe/issues/65) **chore: install Playwright MCP in `.claude/settings.json`** — once #58 lands on Playwright, both spikes share the install.
 
 ## Sources
 

--- a/docs/verification/README.md
+++ b/docs/verification/README.md
@@ -48,7 +48,7 @@ until curl -sf http://localhost:3000 >/dev/null; do sleep 0.5; done
 echo "ready"
 ```
 
-**Cookie-jar login** (pattern reused across playbooks):
+**Cookie-jar login** (pattern reused across playbooks). The `<user>` / `<pass>` placeholders are intentional — a dedicated `claude-test` seed user and `scripts/claude-login.sh` wrapper are tracked as a follow-up in [#63](https://github.com/wnorowskie/family-recipe/issues/63). Until that lands, log in as any seeded family member (the master key output of `npm run db:seed` lets you create one via `/signup`):
 
 ```bash
 curl -s -c /tmp/fr-cookies.txt \
@@ -56,8 +56,6 @@ curl -s -c /tmp/fr-cookies.txt \
   -d '{"emailOrUsername":"<user>","password":"<pass>"}' \
   http://localhost:3000/api/auth/login | jq .
 ```
-
-A `claude-test` seed user + wrapper script are a planned follow-up (see the research doc's "Implementation follow-ups"). Until then, log in as any seeded family member.
 
 **Stop any leftover dev servers:**
 

--- a/docs/verification/README.md
+++ b/docs/verification/README.md
@@ -1,0 +1,71 @@
+# Verification Playbooks
+
+Short, copy-pastable playbooks Claude (and humans) run before opening a PR. Each service has its own page — open the one matching the thing you changed.
+
+Decision rationale and tool alternatives: [docs/research/claude-local-verification.md](../research/claude-local-verification.md). This directory is the operational distillation.
+
+## When to verify
+
+**Before opening any PR.** The pre-commit hook runs `type-check` + `lint-staged`; nothing else is automatic. Verification catches what the type checker can't: wrong response shapes, broken gating, silent 500s, hydration bugs, cross-family data leaks.
+
+## The three layers
+
+Pick the lowest layer that gives enough signal for the change. Stack layers only when a single one is insufficient.
+
+| Layer  | Tool                                                                                                                   | Best for                                                                 |
+| ------ | ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| **L0** | `curl` against `npm run dev` / `uvicorn`                                                                               | API routes, server components, HTML strings, auth gating, response shape |
+| **L1** | [`claude --chrome`](https://code.claude.com/docs/en/chrome) (first-party Chrome integration)                           | Client components, forms, photo uploads, nav flows, hydration            |
+| **L2** | [Playwright MCP](https://github.com/microsoft/playwright-mcp) (`claude mcp add playwright npx @playwright/mcp@latest`) | Headless fallback when L1 isn't available (remote/background agents)     |
+
+Always finish with `npm run type-check && npm run lint && npm test` for Next changes, or the equivalent pytest for Python services.
+
+## Playbooks
+
+| Change touches…                      | Playbook                                         |
+| ------------------------------------ | ------------------------------------------------ |
+| Pages or components under `src/app/` | [ui.md](ui.md)                                   |
+| `src/app/api/**/route.ts`            | [next-api.md](next-api.md)                       |
+| `apps/api/src/routers/**`            | [fastapi.md](fastapi.md)                         |
+| `apps/recipe-url-importer/**`        | [recipe-url-importer.md](recipe-url-importer.md) |
+| Any `prisma/schema*.prisma`          | [prisma.md](prisma.md)                           |
+
+A single change can touch multiple — run each relevant playbook. Prisma changes almost always pair with one or both API playbooks.
+
+## Shared helpers
+
+**SQLite override for the Next dev server** — the checked-in `.env` points at local Postgres; if it isn't running, DB routes 500 silently. When working on UI or Next-API changes without touching Postgres-only features:
+
+```bash
+DATABASE_URL="file:./prisma/dev.db" npm run dev
+```
+
+**Start dev server in the background + wait for ready:**
+
+```bash
+DATABASE_URL="file:./prisma/dev.db" npm run dev &
+until curl -sf http://localhost:3000 >/dev/null; do sleep 0.5; done
+echo "ready"
+```
+
+**Cookie-jar login** (pattern reused across playbooks):
+
+```bash
+curl -s -c /tmp/fr-cookies.txt \
+  -H "Content-Type: application/json" \
+  -d '{"emailOrUsername":"<user>","password":"<pass>"}' \
+  http://localhost:3000/api/auth/login | jq .
+```
+
+A `claude-test` seed user + wrapper script are a planned follow-up (see the research doc's "Implementation follow-ups"). Until then, log in as any seeded family member.
+
+**Stop any leftover dev servers:**
+
+```bash
+lsof -ti :3000 | xargs -r kill -9 2>/dev/null
+lsof -ti :8000 | xargs -r kill -9 2>/dev/null
+```
+
+## When verification isn't possible
+
+If the session can't run the tool a change needs (e.g., no browser available for a hydration-sensitive UI change), **say so in the PR body**. Don't claim UI success from `curl` alone — pre-hydration HTML isn't the user experience.

--- a/docs/verification/fastapi.md
+++ b/docs/verification/fastapi.md
@@ -1,0 +1,106 @@
+# FastAPI verification
+
+Run this when the change touches [apps/api/](../../apps/api/) — routers, schemas, dependencies, security helpers. Service context: [apps/api/CLAUDE.md](../../apps/api/CLAUDE.md). Setup/run: [apps/api/README.md](../../apps/api/README.md).
+
+FastAPI mirrors the Next API contract. A change here almost always pairs with a change to [src/app/api/](../../src/app/api/) — see [next-api.md](next-api.md).
+
+## Start the service
+
+```bash
+cd apps/api
+source .venv/bin/activate
+uvicorn apps.api.src.main:app --reload --port 8000 &
+until curl -sf http://localhost:8000/health >/dev/null; do sleep 0.5; done
+```
+
+If `.venv` doesn't exist:
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt -r requirements-dev.txt
+npx prisma generate --schema ../../prisma/schema.postgres.prisma --generator clientPy
+```
+
+FastAPI listens on `:8000`. The recipe-url-importer also defaults to `:8000` — don't run both at once. Pick a different port (`--port 8001`) if you need both.
+
+FastAPI requires **Postgres** — it uses the Python Prisma client generated against `schema.postgres.prisma`. There is no SQLite path. If local Postgres isn't running, start it (docker-compose or native) before running the API.
+
+## Auth and cookie flow
+
+The session cookie format is identical to Next — same JWT, same `JWT_SECRET`, same cookie name. A cookie obtained by logging in via Next `/api/auth/login` (see [next-api.md](next-api.md)) also works against FastAPI. Useful for contract parity checks.
+
+Login through FastAPI directly:
+
+```bash
+COOKIES=/tmp/fastapi-cookies.txt
+
+curl -s -c "$COOKIES" \
+  -H "Content-Type: application/json" \
+  -d '{"emailOrUsername":"<user>","password":"<pass>"}' \
+  http://localhost:8000/api/auth/login | jq .
+```
+
+## L0 — curl the route
+
+Same patterns as [next-api.md](next-api.md) — just swap the host to `:8000`.
+
+```bash
+# Unauthenticated → 401
+curl -s -w "\n%{http_code}\n" http://localhost:8000/api/posts
+
+# Authenticated
+curl -s -b "$COOKIES" http://localhost:8000/api/posts | jq .
+
+# Validation error
+curl -s -b "$COOKIES" -H "Content-Type: application/json" \
+  -d '{"garbage":true}' http://localhost:8000/api/posts | jq .
+```
+
+## Contract parity check
+
+When changing a shape or status code, diff both services against the same input:
+
+```bash
+NEXT=http://localhost:3000
+API=http://localhost:8000
+
+# Log in against both (they can share the JWT cookie if JWT_SECRET matches)
+diff <(curl -s -b "$COOKIES" "$NEXT/api/posts" | jq -S .) \
+     <(curl -s -b "$COOKIES" "$API/api/posts" | jq -S .)
+```
+
+Any non-empty diff is a parity bug unless intentional (rare — the migration plan is explicit that the contract should not change during cutover).
+
+## Invariants to preserve
+
+Mirror the Next API rules:
+
+- [ ] Auth goes through the dependencies in [apps/api/src/dependencies.py](../../apps/api/src/dependencies.py) (`require_user` / `require_admin`) — never parse the cookie inline
+- [ ] Every DB query scopes by `family_space_id` — missing = cross-family leak
+- [ ] Request/response models come from [apps/api/src/schemas/](../../apps/api/src/schemas/) (Pydantic)
+- [ ] Permission checks use [apps/api/src/permissions.py](../../apps/api/src/permissions.py)
+- [ ] Error shape is `{ "error": { "code", "message" } }` — the public contract, unchanged from Next
+
+## Tests
+
+```bash
+cd apps/api
+source .venv/bin/activate
+
+pytest tests/unit/ -v
+pytest tests/integration/ -v
+```
+
+Tests run in CI via [.github/workflows/api-ci.yml](../../.github/workflows/api-ci.yml) — also ruff, mypy, pip-audit, semgrep, gitleaks, trivy on the image.
+
+## Before opening the PR
+
+```bash
+# Python quality gates (CI will run these; run locally to fail fast)
+cd apps/api
+ruff check .
+mypy src
+pytest
+```
+
+Stop the service: `lsof -ti :8000 | xargs -r kill -9`.

--- a/docs/verification/next-api.md
+++ b/docs/verification/next-api.md
@@ -36,7 +36,7 @@ Grep the diff and confirm each of these is still true:
 - [ ] Input goes through a Zod schema from [src/lib/validation.ts](../../src/lib/validation.ts) (not an inline schema)
 - [ ] Errors use helpers from [src/lib/apiErrors.ts](../../src/lib/apiErrors.ts) (not ad-hoc `NextResponse.json({error:...})`)
 - [ ] Every DB query filters by `user.familySpaceId` — missing = cross-family leak
-- [ ] Mutating routes call `revalidatePath(...)` for the affected list views
+- [ ] Mutations that change a feed or list view call `revalidatePath(...)` for the affected path(s) — not every mutation needs this; only the ones visible on `/timeline`, `/recipes`, etc.
 - [ ] Rate limiter applied (see [src/lib/rateLimit.ts](../../src/lib/rateLimit.ts))
 
 ## L0 — curl the route

--- a/docs/verification/next-api.md
+++ b/docs/verification/next-api.md
@@ -1,0 +1,120 @@
+# Next.js API verification
+
+Run this when the change touches any `route.ts` under [src/app/api/](../../src/app/api/). Handler conventions: [src/app/api/CLAUDE.md](../../src/app/api/CLAUDE.md).
+
+These routes are the **current production backend**. When changing a contract here, check whether the FastAPI mirror in [apps/api/src/routers/](../../apps/api/src/routers/) needs the same change — see [fastapi.md](fastapi.md).
+
+## Start the dev server
+
+```bash
+DATABASE_URL="file:./prisma/dev.db" npm run dev &
+until curl -sf http://localhost:3000 >/dev/null; do sleep 0.5; done
+```
+
+## Auth — log in and capture a cookie
+
+Every authenticated route needs a `session` cookie. Log in once per session.
+
+```bash
+COOKIES=/tmp/fr-cookies.txt
+
+curl -s -c "$COOKIES" \
+  -H "Content-Type: application/json" \
+  -d '{"emailOrUsername":"<seeded-user>","password":"<pass>"}' \
+  http://localhost:3000/api/auth/login | jq .
+```
+
+Success: `200` with a `user` object, and `$COOKIES` contains a `session` entry. Failure: `401` invalid credentials, `403` no membership, `429` rate-limited.
+
+Reuse with `-b "$COOKIES"` on every subsequent call.
+
+## Invariants every handler must preserve
+
+Grep the diff and confirm each of these is still true:
+
+- [ ] Handler is wrapped in `withAuth` / `withRole` (never reads the session manually) — see [src/lib/apiAuth.ts](../../src/lib/apiAuth.ts)
+- [ ] Input goes through a Zod schema from [src/lib/validation.ts](../../src/lib/validation.ts) (not an inline schema)
+- [ ] Errors use helpers from [src/lib/apiErrors.ts](../../src/lib/apiErrors.ts) (not ad-hoc `NextResponse.json({error:...})`)
+- [ ] Every DB query filters by `user.familySpaceId` — missing = cross-family leak
+- [ ] Mutating routes call `revalidatePath(...)` for the affected list views
+- [ ] Rate limiter applied (see [src/lib/rateLimit.ts](../../src/lib/rateLimit.ts))
+
+## L0 — curl the route
+
+### Unauthenticated path
+
+```bash
+# Should return 401
+curl -s -w "\n%{http_code}\n" http://localhost:3000/api/<resource> | tail -5
+```
+
+### Authenticated happy path
+
+```bash
+curl -s -b "$COOKIES" \
+  -w "\nstatus=%{http_code}\n" \
+  http://localhost:3000/api/<resource> | jq .
+```
+
+Confirm the JSON shape matches the Zod output schema (or the consumer's expectations).
+
+### Validation errors
+
+```bash
+# Bad payload — expect 400 with { error: { code: "VALIDATION_ERROR", message } }
+curl -s -b "$COOKIES" \
+  -H "Content-Type: application/json" \
+  -d '{"garbage":true}' \
+  http://localhost:3000/api/<resource> | jq .
+```
+
+### Cross-family guard
+
+When changing a by-id lookup (GET/PATCH/DELETE on `/api/posts/:id` etc.), the missing-`familySpaceId` bug is silent: the query still returns the row, just from a different family. There's no unit test that catches this if it's removed.
+
+Quick manual probe: create a post with user A, log in as user B (different family), `GET /api/posts/:idFromA` should return `404`, not `200`.
+
+## Multipart routes (photos)
+
+Routes under `/api/posts` and `/api/comments` accept `multipart/form-data`:
+
+```bash
+# JSON payload in `payload` field, file in `photos`
+curl -s -b "$COOKIES" \
+  -F 'payload={"title":"Test","kind":"update"};type=application/json' \
+  -F 'photos=@/path/to/image.jpg' \
+  http://localhost:3000/api/posts | jq .
+
+# Confirm file landed on disk
+ls -l public/uploads/ | tail -5
+```
+
+The returned post row must have a non-null `storageKey`, never a rendered URL.
+
+## Running the Jest integration test for the route
+
+The integration suite mocks Prisma but exercises the full handler pipeline — much cheaper than curl for iterating on a single route:
+
+```bash
+npx jest __tests__/integration/api/<resource>.test.ts
+```
+
+If your change lacks an integration test, [**tests**/CLAUDE.md](../../__tests__/CLAUDE.md) shows the pattern.
+
+## FastAPI mirror
+
+If this change altered request/response shape, status codes, or auth behavior, also:
+
+1. Update the equivalent router in [apps/api/src/routers/](../../apps/api/src/routers/)
+2. Run [fastapi.md](fastapi.md) against the mirror
+3. Check [docs/API_BACKEND_MIGRATION_PLAN.md](../API_BACKEND_MIGRATION_PLAN.md) hasn't drifted
+
+## Before opening the PR
+
+```bash
+npm run type-check
+npm run lint
+npm test
+```
+
+Stop the dev server: `lsof -ti :3000 | xargs -r kill -9`.

--- a/docs/verification/prisma.md
+++ b/docs/verification/prisma.md
@@ -1,0 +1,110 @@
+# Prisma schema verification
+
+Run this when the change edits any `prisma/schema*.prisma` file or adds a migration. Multi-schema context: [prisma/CLAUDE.md](../../prisma/CLAUDE.md).
+
+Schema changes are the single most cross-cutting thing in this repo. They can break:
+
+- the Next monolith (TypeScript Prisma client)
+- the FastAPI service (Python Prisma client)
+- any integration test that touches the affected model
+- the Cloud Run docker image's startup migration
+- family-scoping invariants if a new relation is added without the right filter
+
+All three schemas must describe the same domain.
+
+## Edit all three schemas in lock-step
+
+| File                                                                                                 | Used by                            | Workflow                             |
+| ---------------------------------------------------------------------------------------------------- | ---------------------------------- | ------------------------------------ |
+| [prisma/schema.prisma](../../prisma/schema.prisma) (sqlite)                                          | Local Next dev                     | `prisma db push` — no migration file |
+| [prisma/schema.postgres.prisma](../../prisma/schema.postgres.prisma) (postgres)                      | Local Postgres, Cloud SQL, FastAPI | `prisma migrate dev`                 |
+| [prisma/schema.postgres.node.prisma](../../prisma/schema.postgres.node.prisma) (postgres, JS client) | Docker / Cloud Run Next image      | `prisma migrate deploy`              |
+
+A new field/model/relation must appear in **all three** with the same name, shape, and `@map(...)` column name. Miss one and CI catches it only partway — the runtime fails at the boundary.
+
+## After editing
+
+```bash
+# 1. Generate clients
+npm run db:generate
+npx prisma generate --schema prisma/schema.postgres.prisma
+
+# 2. Apply schema to local SQLite (no migration file)
+npm run db:push
+
+# 3. Create a Postgres migration (commit the generated file)
+npx prisma migrate dev --schema prisma/schema.postgres.prisma --name <short-change>
+```
+
+The Python client for FastAPI:
+
+```bash
+cd apps/api && source .venv/bin/activate
+npx prisma generate --schema ../../prisma/schema.postgres.prisma --generator clientPy
+```
+
+## Verify the TypeScript side compiles
+
+```bash
+npm run type-check
+```
+
+If a field was renamed, every downstream file that referenced it will break here. Fix before proceeding.
+
+## Verify the Next API still works
+
+Pick one route that queries the changed model and run the [next-api.md](next-api.md) loop against it. For new models, also run a unit test that writes + reads through the relation.
+
+If the change added a relation, **grep for `familySpaceId` in the new queries**. Any query on Post/Comment/Reaction/Favorite/CookedEvent/etc. must scope by family. Missing = cross-family leak.
+
+## Verify the FastAPI side
+
+```bash
+cd apps/api && source .venv/bin/activate
+mypy src           # catches Pydantic / client-type drift
+pytest tests/
+```
+
+Then run the [fastapi.md](fastapi.md) loop on the mirror route.
+
+## Gotchas
+
+- **Field naming**: TypeScript camelCase maps to snake_case columns (`familySpaceId` → `@map("family_space_id")`). Both must be set on every new field.
+- **Storage keys** (`avatarStorageKey`, `photoStorageKey`, etc.) historically live in columns still named `*_url` (`@map("avatar_url")`, `@map("photo_url")`). **Don't rename the column** — just the property.
+- **Reaction polymorphism**: adding a reaction target requires updating both `targetType`/`targetId` (the canonical pair) and the nullable `postId`/`commentId` FKs used for join performance.
+- **Cascades**: most user/post/comment deletes cascade. `FeedbackSubmission` uses `SetNull` so feedback survives user deletion — don't change to cascade.
+- **Migration rollback**: there is no formal rollback path. A bad migration ships with the next deploy; plan forward-only fixes.
+
+## Migration file review checklist
+
+Open the generated migration SQL before committing:
+
+- [ ] No destructive `DROP TABLE` / `DROP COLUMN` on a column with live data (rename + copy + drop across two migrations instead)
+- [ ] `DEFAULT` values set for new `NOT NULL` columns on existing tables
+- [ ] Indexes added for any new FK or frequently-filtered column
+- [ ] No surprise changes to unrelated tables (Prisma sometimes regenerates FK names)
+
+## Seeding
+
+`npm run db:seed` is idempotent — it skips if a `FamilySpace` already exists. After a schema change that affects seed data (new tag category, new default row), update [prisma/seed.ts](../../prisma/seed.ts) and re-run against a fresh SQLite DB:
+
+```bash
+rm -f prisma/dev.db
+DATABASE_URL="file:./prisma/dev.db" npm run db:push
+DATABASE_URL="file:./prisma/dev.db" npm run db:seed
+```
+
+## Before opening the PR
+
+```bash
+npm run type-check                   # catches TS client drift
+npx prisma validate --schema prisma/schema.postgres.prisma
+npx prisma format --check prisma/schema.postgres.prisma   # CI runs this
+npm test
+```
+
+If FastAPI tests also exist for the affected model:
+
+```bash
+cd apps/api && source .venv/bin/activate && pytest tests/
+```

--- a/docs/verification/recipe-url-importer.md
+++ b/docs/verification/recipe-url-importer.md
@@ -1,0 +1,105 @@
+# Recipe URL importer verification
+
+Run this when the change touches [apps/recipe-url-importer/](../../apps/recipe-url-importer/). Service context: [apps/recipe-url-importer/CLAUDE.md](../../apps/recipe-url-importer/CLAUDE.md). Behavior contract: [apps/recipe-url-importer/SPEC.md](../../apps/recipe-url-importer/SPEC.md) — **treat SPEC.md as the source of truth** for request/response shape, confidence scoring, SSRF rules, and error codes.
+
+No DB, no auth (in local dev). The service fetches a public URL and returns a normalized `RecipeDraft`.
+
+## Start the service
+
+```bash
+cd apps/recipe-url-importer
+source .venv/bin/activate
+PYTHONPATH=src uvicorn --app-dir src recipe_url_importer.app:app --reload --port 8000 &
+until curl -sf http://localhost:8000/health >/dev/null 2>&1; do sleep 0.5; done
+```
+
+If `.venv` doesn't exist:
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt -r requirements-dev.txt
+```
+
+Note: the FastAPI service ([apps/api/](../../apps/api/)) also defaults to `:8000`. Don't run both at once, or pass `--port 8001` to one of them.
+
+## L0 — parse a URL
+
+The main endpoint is `POST /v1/parse`:
+
+```bash
+curl -s -H "Content-Type: application/json" \
+  -d '{"url":"https://www.example.com/recipe"}' \
+  http://localhost:8000/v1/parse | jq .
+```
+
+Confirm the response matches the `RecipeDraft` shape in [SPEC.md](../../apps/recipe-url-importer/SPEC.md). Key fields to eyeball: `title`, `ingredients[]`, `steps[]`, `confidence`, `source`.
+
+Try a few URL types:
+
+| URL pattern                              | Expected                                          |
+| ---------------------------------------- | ------------------------------------------------- |
+| Site with JSON-LD recipe schema          | High `confidence`, clean ingredients/steps        |
+| Site with microdata only                 | Medium confidence, may require heuristic fallback |
+| Non-recipe URL (news article, blog post) | Low confidence or `RECIPE_NOT_FOUND`              |
+| Malformed URL                            | `400` with a validation error                     |
+
+## SSRF / safety probes
+
+If the change touches fetch or URL validation, re-verify the SSRF guards in [apps/recipe-url-importer/src/recipe_url_importer/security/](../../apps/recipe-url-importer/src/recipe_url_importer/security/):
+
+```bash
+# Private IP — must be rejected
+curl -s -H "Content-Type: application/json" \
+  -d '{"url":"http://127.0.0.1:22/"}' \
+  http://localhost:8000/v1/parse | jq .
+
+# Loopback hostname
+curl -s -H "Content-Type: application/json" \
+  -d '{"url":"http://localhost/"}' \
+  http://localhost:8000/v1/parse | jq .
+
+# Non-HTTP scheme
+curl -s -H "Content-Type: application/json" \
+  -d '{"url":"file:///etc/passwd"}' \
+  http://localhost:8000/v1/parse | jq .
+```
+
+All three should return a non-2xx with the appropriate error code per SPEC.md.
+
+## Invariants to preserve
+
+- [ ] No database imports — this service is stateless
+- [ ] No auth imports (Cloud Run OIDC handles auth in prod — local dev skips it; the Next client in [src/lib/recipeImporter.ts](../../src/lib/recipeImporter.ts) signs requests when `IMPORTER_AUDIENCE` is set)
+- [ ] `IMPORTER_MAX_HTML_BYTES` and timeout caps are respected on every fetch path
+- [ ] SSRF guards run before any outbound request
+- [ ] Response cache (in-memory) still keys by URL only
+
+## Integration with the Next backend
+
+If the change altered the response shape, update the client:
+
+- [src/lib/recipeImporter.ts](../../src/lib/recipeImporter.ts) — request builder and response parser
+- Any Zod schema in [src/lib/validation.ts](../../src/lib/validation.ts) that describes the draft
+
+Then run the relevant Next route ([next-api.md](next-api.md)) that calls the importer (e.g. `POST /api/recipes/import`).
+
+## Tests
+
+```bash
+cd apps/recipe-url-importer
+source .venv/bin/activate
+PYTHONPATH=src pytest -v
+```
+
+CI: [.github/workflows/recipe-url-importer-ci.yml](../../.github/workflows/recipe-url-importer-ci.yml).
+
+## Before opening the PR
+
+```bash
+cd apps/recipe-url-importer
+ruff check .
+mypy src
+PYTHONPATH=src pytest
+```
+
+Stop the service: `lsof -ti :8000 | xargs -r kill -9`.

--- a/docs/verification/ui.md
+++ b/docs/verification/ui.md
@@ -1,0 +1,83 @@
+# UI verification
+
+Run this when the change touches anything under [src/app/](../../src/app/) (pages, layouts, components, route groups) or [src/components/](../../src/components/).
+
+Rule of thumb: **if the change adds, removes, or alters anything a user sees, do L1.** Pre-hydration HTML (what `curl` returns) is not the user experience for `'use client'` components.
+
+## Start the dev server
+
+```bash
+DATABASE_URL="file:./prisma/dev.db" npm run dev &
+until curl -sf http://localhost:3000 >/dev/null; do sleep 0.5; done
+```
+
+If the change only reads data, SQLite is fine. If it tests a Postgres-only feature (search, transactions), start the real Postgres instead.
+
+## L0 — server-rendered HTML / static strings
+
+Fastest check. Works for server components, page metadata, route gating, and client components' initial markup.
+
+```bash
+# Capture baseline
+curl -s -o /tmp/before.html http://localhost:3000/<path>
+
+# Make the edit
+
+# Re-capture (wait a beat for Fast Refresh to recompile)
+sleep 2
+curl -s -o /tmp/after.html http://localhost:3000/<path>
+
+diff /tmp/before.html /tmp/after.html
+```
+
+Also useful:
+
+- `curl -I http://localhost:3000/<path>` — status + headers
+- Gated route without cookie should 307 to `/login?redirect=...` (see [src/proxy.ts](../../src/proxy.ts))
+
+## L1 — real browser (`claude --chrome`)
+
+Required for:
+
+- `'use client'` components with state or effects
+- Forms (validation, submission, redirect)
+- Photo uploads (the `<input type=file>` + preview + submit round-trip)
+- Navigation — `router.replace`, `router.refresh`, `<Link>` prefetch
+- Responsive / mobile viewport checks
+- Any visual change where "looks right" is part of the acceptance criteria
+
+Prompt shape:
+
+```
+Open http://localhost:3000/<path>. <Interaction step>. Tell me what you see
+and screenshot before/after.
+```
+
+Specific-enough prompts beat generic ones. "Click submit with an empty password and report the error message" > "test the form."
+
+## L1 fallback — Playwright MCP
+
+If the session can't run `claude --chrome` (remote, WSL, no extension installed):
+
+```bash
+claude mcp add playwright npx @playwright/mcp@latest
+```
+
+Use `browser_navigate` → `browser_snapshot` (accessibility tree — token-cheap) → `browser_take_screenshot` only when the snapshot misses something visual.
+
+## Gotchas specific to this app
+
+- **Photos**: local mode writes to `public/uploads/` (see [src/lib/uploads.ts](../../src/lib/uploads.ts)). After an upload test, check the file is on disk and the Prisma row has a non-null `*StorageKey`. Don't expect signed URLs locally.
+- **Timeline is computed per request** ([src/lib/timeline-data.ts](../../src/lib/timeline-data.ts)) — a post shows up on the timeline the instant it's saved; no indexing delay.
+- **Family scoping is implicit** — if a list or detail view renders, it was already scoped by `familySpaceId`. If something is visible that shouldn't be, the bug is server-side, not rendering.
+- **Server vs client**: default is server component. `'use client'` only for interactive forms/state. When reviewing your own PR, grep the diff for `'use client'` — if it appeared on a component that doesn't need state, revert.
+
+## Before opening the PR
+
+```bash
+npm run type-check
+npm run lint
+npm test
+```
+
+Stop the dev server: `lsof -ti :3000 | xargs -r kill -9`.

--- a/docs/verification/ui.md
+++ b/docs/verification/ui.md
@@ -11,7 +11,7 @@ DATABASE_URL="file:./prisma/dev.db" npm run dev &
 until curl -sf http://localhost:3000 >/dev/null; do sleep 0.5; done
 ```
 
-If the change only reads data, SQLite is fine. If it tests a Postgres-only feature (search, transactions), start the real Postgres instead.
+If the change only reads data, SQLite is fine. If it exercises a Postgres-specific feature (full-text search, `JSONB` operators, Postgres-only types or functions), start the real Postgres instead.
 
 ## L0 — server-rendered HTML / static strings
 

--- a/prisma/CLAUDE.md
+++ b/prisma/CLAUDE.md
@@ -40,3 +40,7 @@ To rotate the master key, do it manually via the DB — there is no API for it.
 ## After schema changes
 
 Always run `npm run type-check` — Prisma generates TS types and downstream code will fail to compile if a field name shifts.
+
+## Verification
+
+Before opening a PR that touches any schema or migration, run the [Prisma playbook](../docs/verification/prisma.md) — covers the three-schema lock-step edit, migration SQL review checklist, and the downstream Next + FastAPI checks.

--- a/src/app/api/CLAUDE.md
+++ b/src/app/api/CLAUDE.md
@@ -49,6 +49,10 @@ Routes that accept photos (`posts`, `comments`) use `multipart/form-data`:
 
 Mutations that change visible feed/list state call `revalidatePath('/timeline')`, `'/recipes'`, etc. Match the existing routes' patterns when adding new mutating endpoints.
 
+## Verification
+
+Before opening a PR that touches a `route.ts`, run the [Next API playbook](../../../docs/verification/next-api.md) — covers the curl+cookie loop, cross-family guard probe, multipart routes, and the Jest integration pattern.
+
 ## Mirror in FastAPI
 
 If you change request/response shape, status codes, or auth behavior, the equivalent endpoint in [apps/api/src/routers/](../../../apps/api/src/routers/) likely needs the same change. The migration plan ([docs/API_BACKEND_MIGRATION_PLAN.md](../../../docs/API_BACKEND_MIGRATION_PLAN.md)) is the source of truth for which endpoints have been ported.


### PR DESCRIPTION
## Summary

- **Research spike** at [docs/research/claude-local-verification.md](../blob/research/59/claude-local-verification/docs/research/claude-local-verification.md): picks a three-layer verification workflow (L0 `curl`, L1 `claude --chrome`, L2 Playwright MCP). Rejects per-branch Cloud Run previews and Chrome DevTools MCP as defaults.
- **Operational playbooks** under [docs/verification/](../tree/research/59/claude-local-verification/docs/verification): one runbook per service (UI, Next API, FastAPI, recipe-url-importer, Prisma), plus a README index. Copy-pastable commands, invariants to preserve, before-PR checklist.
- **CLAUDE.md wiring**: root CLAUDE.md gets a "Before opening a PR" section linking to the playbook index; each service's existing CLAUDE.md (src/app/api/, apps/api/, apps/recipe-url-importer/, prisma/) links to its own playbook.
- Worked POC trace embedded in the research doc (dev server on SQLite override + one-line edit verified via curl+diff).

## Closes

Closes #59

## Test notes

**What ships in this PR (docs-only):**

- The research doc (`docs/research/claude-local-verification.md`) — decision + alternatives + answers to every ticket question.
- Five verification playbooks (`docs/verification/*.md`) + a README index — added during review per reviewer request to make the workflow operational, not just documented.
- Root `CLAUDE.md` "Before opening a PR" section + per-service CLAUDE.md links.

**What does NOT ship here (deliberately deferred to follow-up tickets):**

- `scripts/claude-login.sh` + `claude-test` seed user → [#63](https://github.com/wnorowskie/family-recipe/issues/63). The playbooks use `<user>` / `<pass>` placeholders and point at #63 inline.
- README.md updates for the SQLite override + verification index link → [#64](https://github.com/wnorowskie/family-recipe/issues/64).
- Project-level Playwright MCP install → [#65](https://github.com/wnorowskie/family-recipe/issues/65), gated on #58's framework pick.
- Field-trial validation of the playbooks → [#62](https://github.com/wnorowskie/family-recipe/issues/62).

**Verification:**

- Every internal link in the new docs resolves against current repo layout.
- No code changes — CI (typecheck / lint / test / prisma-validate / audit / security scans) should pass on unchanged application code.
- The POC trace in the research doc was actually executed on this branch; edit was reverted and working tree was verified clean before the first commit.