### PR TITLE
chore: upgrade python-dotenv to 1.2.2 in FastAPI service (#67)

### DIFF
--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -5,7 +5,7 @@ PyJWT==2.12.0
 bcrypt==4.1.2
 pydantic-settings==2.7.0
 google-cloud-storage==2.18.2
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 httpx==0.27.2
 rsa==4.9
 python-multipart==0.0.26


### PR DESCRIPTION
## Summary

- Bumps `python-dotenv` from `1.0.1` → `1.2.2` in [apps/api/requirements.txt](apps/api/requirements.txt), fixing [GHSA-mf9w-mj56-hr94](https://github.com/advisories/GHSA-mf9w-mj56-hr94) flagged by `pip-audit`.
- No change needed in [apps/api/requirements-dev.txt](apps/api/requirements-dev.txt) — it only re-references `requirements.txt`.

## Closes

Closes #67

## Test notes

- `pip-audit -r apps/api/requirements.txt -r apps/api/requirements-dev.txt` → **No known vulnerabilities found**.
- `pytest tests/unit/` in `apps/api` → **93 passed** on the new version.
- `from dotenv import load_dotenv, dotenv_values` still imports cleanly on `1.2.2`.
- No `dotenv` call sites inside `apps/api/src/` (used transitively via `pydantic-settings`), so no API surface changes to reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)