### PR TITLE
chore: ignore .claude/worktrees in jest testPathIgnorePatterns

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -57,6 +57,7 @@ const customJestConfig = {
     '/.next/',
     '/figma/',
     '/prisma/migrations/',
+    '/\\.claude/worktrees/',
   ],
 };
 


### PR DESCRIPTION
## Summary
- Adds `/\.claude/worktrees/` to `testPathIgnorePatterns` in [jest.config.js](jest.config.js) so parallel Claude sessions' nested checkouts don't pollute test discovery.
- Before: 184 test suites discovered when worktrees exist; failures in unrelated branches looked like regressions on the current work.
- After: 46 suites (primary tree only), unchanged when no worktrees are present.

Closes #72. Surfaced by the #62 field trial.

## Test plan
- [x] Reproduced the 184-suite count on a polluted primary tree (3 populated `.claude/worktrees/*`).
- [x] With the new ignore pattern applied, `npx jest --listTests | wc -l` drops to 46 on the same polluted tree.
- [x] `npm test` in a clean worktree: **46 suites, 954 tests pass**.
- [x] Coverage globs (`collectCoverageFrom`) are scoped to `src/` and unchanged — 75% threshold behavior is a no-op for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)