### PR TITLE
chore(api): add ruff + mypy to dev requirements (#73)

### DIFF
--- a/apps/api/requirements-dev.txt
+++ b/apps/api/requirements-dev.txt
@@ -8,3 +8,7 @@ pytest-cov==7.1.0
 
 # For mocking
 pytest-mock==3.15.1
+
+# Lint + type-check (pinned to match .github/workflows/api-ci.yml)
+ruff==0.7.1
+mypy==1.11.2


### PR DESCRIPTION
## Summary

- Adds `ruff==0.7.1` and `mypy==1.11.2` to [apps/api/requirements-dev.txt](apps/api/requirements-dev.txt), pinned to the versions already used by [.github/workflows/api-ci.yml](.github/workflows/api-ci.yml).
- Closes #73. Surfaced by the #62 field trial: the FastAPI verification playbook tells contributors to run `ruff check .` and `mypy src` locally, but a fresh `.venv` install from `requirements-dev.txt` didn't have them.

No code changes — dev-dependency manifest only. CI already installs these tools in separate jobs, so this does not affect the CI pipeline; it only fixes the local-dev experience.

## Test plan

- [x] `rm -rf apps/api/.venv && python -m venv apps/api/.venv && apps/api/.venv/bin/pip install -r apps/api/requirements-dev.txt` succeeds (Python 3.12 locally; CI uses 3.11).
- [x] `which ruff` → `apps/api/.venv/bin/ruff`, `ruff --version` → `0.7.1`.
- [x] `which mypy` → `apps/api/.venv/bin/mypy`, `mypy --version` → `1.11.2`.
- [x] `ruff check .` from `apps/api/` → `All checks passed!` (exit 0).
- [x] `mypy src --ignore-missing-imports --show-error-codes` from `apps/api/` → `Success: no issues found in 27 source files` (exit 0).
- [x] README scanned for conflicting claims — none (the Testing section just does `pip install -r requirements-dev.txt` + `pytest`, which continues to work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)