### PR TITLE
chore: claude-test seed user + login helper script (#63)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,10 @@ FAMILY_NAME="Family Recipe"
 # External API toggle (frontend)
 # USE_EXTERNAL_API=false
 # NEXT_PUBLIC_API_BASE_URL="http://localhost:8000"
+
+# Claude verification helper (dev-only — NEVER set in production)
+# `npm run db:seed` upserts a `claude-test` user with this password so
+# `scripts/claude-login.sh` can grab a session cookie in one line. The seed
+# step is a no-op when NODE_ENV=production.
+CLAUDE_TEST_USER="claude-test"
+CLAUDE_TEST_PASSWORD="claude-test-password"

--- a/docs/verification/README.md
+++ b/docs/verification/README.md
@@ -48,14 +48,14 @@ until curl -sf http://localhost:3000 >/dev/null; do sleep 0.5; done
 echo "ready"
 ```
 
-**Cookie-jar login** (pattern reused across playbooks). The `<user>` / `<pass>` placeholders are intentional — a dedicated `claude-test` seed user and `scripts/claude-login.sh` wrapper are tracked as a follow-up in [#63](https://github.com/wnorowskie/family-recipe/issues/63). Until that lands, log in as any seeded family member (the master key output of `npm run db:seed` lets you create one via `/signup`):
+**Cookie-jar login** — use [scripts/claude-login.sh](../../scripts/claude-login.sh), which logs in as the `claude-test` seed user and writes a session cookie to `/tmp/fr-cookies.txt`:
 
 ```bash
-curl -s -c /tmp/fr-cookies.txt \
-  -H "Content-Type: application/json" \
-  -d '{"emailOrUsername":"<user>","password":"<pass>"}' \
-  http://localhost:3000/api/auth/login | jq .
+COOKIES=$(scripts/claude-login.sh)                          # Next on :3000
+COOKIES=$(scripts/claude-login.sh --host http://localhost:8000)  # FastAPI
 ```
+
+The user is created (and its password refreshed) every time `npm run db:seed` runs outside `NODE_ENV=production`. Credentials come from `CLAUDE_TEST_USER` / `CLAUDE_TEST_PASSWORD` in env or `.env.local` (see [.env.example](../../.env.example)). This is the canonical auth path — playbook snippets assume it.
 
 **Stop any leftover dev servers:**
 

--- a/docs/verification/fastapi.md
+++ b/docs/verification/fastapi.md
@@ -29,16 +29,13 @@ FastAPI requires **Postgres** — it uses the Python Prisma client generated aga
 
 The session cookie format is identical to Next — same JWT, same `JWT_SECRET`, same cookie name. A cookie obtained by logging in via Next `/api/auth/login` (see [next-api.md](next-api.md)) also works against FastAPI. Useful for contract parity checks.
 
-Login through FastAPI directly:
+Login through FastAPI directly via [scripts/claude-login.sh](../../scripts/claude-login.sh):
 
 ```bash
-COOKIES=/tmp/fastapi-cookies.txt
-
-curl -s -c "$COOKIES" \
-  -H "Content-Type: application/json" \
-  -d '{"emailOrUsername":"<user>","password":"<pass>"}' \
-  http://localhost:8000/auth/login | jq .
+COOKIES=$(COOKIES=/tmp/fastapi-cookies.txt scripts/claude-login.sh --host http://localhost:8000)
 ```
+
+The script routes to `/auth/login` when the host targets `:8000` and to `/api/auth/login` otherwise. Credentials come from `CLAUDE_TEST_USER` / `CLAUDE_TEST_PASSWORD` (seeded by `npm run db:seed`).
 
 > **Path note.** FastAPI routers mount **without** an `/api/` prefix (e.g. `/posts`, `/recipes`, `/auth/login`). Next mounts the same resources under `/api/*`. When diffing contracts, expect the path to differ even though the response body should match.
 

--- a/docs/verification/next-api.md
+++ b/docs/verification/next-api.md
@@ -31,20 +31,15 @@ If you previously ran the FastAPI setup step (`npx prisma generate --schema ../.
 
 ## Auth — log in and capture a cookie
 
-Every authenticated route needs a `session` cookie. Log in once per session.
+Every authenticated route needs a `session` cookie. Log in once per session using the `claude-test` seed user + [scripts/claude-login.sh](../../scripts/claude-login.sh):
 
 ```bash
-COOKIES=/tmp/fr-cookies.txt
-
-curl -s -c "$COOKIES" \
-  -H "Content-Type: application/json" \
-  -d '{"emailOrUsername":"<seeded-user>","password":"<pass>"}' \
-  http://localhost:3000/api/auth/login | jq .
+COOKIES=$(scripts/claude-login.sh)        # writes /tmp/fr-cookies.txt by default
 ```
 
-Success: `200` with a `user` object, and `$COOKIES` contains a `session` entry. Failure: `401` invalid credentials, `403` no membership, `429` rate-limited.
+The script reads `CLAUDE_TEST_USER` / `CLAUDE_TEST_PASSWORD` from env or `.env.local` (seeded by `npm run db:seed`; see [.env.example](../../.env.example)). Pass `--host http://localhost:8000` to target FastAPI.
 
-Reuse with `-b "$COOKIES"` on every subsequent call.
+Reuse with `-b "$COOKIES"` on every subsequent call. Failure modes: `401` invalid credentials (re-run `npm run db:seed`), `403` no membership, `429` rate-limited.
 
 ## Invariants every handler must preserve
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -4,6 +4,11 @@ import bcrypt from 'bcrypt';
 
 const prisma = new PrismaClient();
 
+const CLAUDE_TEST_USER_DEFAULT = 'claude-test';
+const CLAUDE_TEST_EMAIL = 'claude-test@example.local';
+const CLAUDE_TEST_NAME = 'Claude Test';
+const CLAUDE_TEST_PASSWORD_DEFAULT = 'claude-test-password';
+
 async function main() {
   console.log('🌱 Seeding database...');
 
@@ -11,6 +16,8 @@ async function main() {
   if (existingFamily) {
     console.log('ℹ️  Family space already exists; not overwriting master key.');
   }
+
+  let familySpaceId: string;
 
   if (!existingFamily) {
     const masterKey =
@@ -71,7 +78,51 @@ async function main() {
     }
 
     console.log('🏷️ Seeded canonical tags');
+
+    familySpaceId = familySpace.id;
+  } else {
+    familySpaceId = existingFamily.id;
   }
+
+  await seedTestUser(familySpaceId);
+}
+
+async function seedTestUser(familySpaceId: string) {
+  if (process.env.NODE_ENV === 'production') {
+    console.log('⏭️  Skipping claude-test user (NODE_ENV=production)');
+    return;
+  }
+
+  const username =
+    process.env.CLAUDE_TEST_USER?.trim() || CLAUDE_TEST_USER_DEFAULT;
+  const password =
+    process.env.CLAUDE_TEST_PASSWORD?.trim() || CLAUDE_TEST_PASSWORD_DEFAULT;
+  const passwordHash = await bcrypt.hash(password, 10);
+
+  const user = await prisma.user.upsert({
+    where: { email: CLAUDE_TEST_EMAIL },
+    update: { username, passwordHash, name: CLAUDE_TEST_NAME },
+    create: {
+      email: CLAUDE_TEST_EMAIL,
+      username,
+      name: CLAUDE_TEST_NAME,
+      passwordHash,
+    },
+  });
+
+  await prisma.familyMembership.upsert({
+    where: {
+      familySpaceId_userId: { familySpaceId, userId: user.id },
+    },
+    update: {},
+    create: {
+      familySpaceId,
+      userId: user.id,
+      role: 'member',
+    },
+  });
+
+  console.log(`🧪 Seeded claude-test user (username="${username}")`);
 }
 
 function generateMasterKey() {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -99,9 +99,12 @@ async function seedTestUser(familySpaceId: string) {
     process.env.CLAUDE_TEST_PASSWORD?.trim() || CLAUDE_TEST_PASSWORD_DEFAULT;
   const passwordHash = await bcrypt.hash(password, 10);
 
+  // Username is set on create only. Rotating CLAUDE_TEST_USER between runs
+  // would otherwise hit the User.username unique constraint if another row
+  // already holds the new value. To rotate, delete the row and re-seed.
   const user = await prisma.user.upsert({
     where: { email: CLAUDE_TEST_EMAIL },
-    update: { username, passwordHash, name: CLAUDE_TEST_NAME },
+    update: { passwordHash, name: CLAUDE_TEST_NAME },
     create: {
       email: CLAUDE_TEST_EMAIL,
       username,

--- a/scripts/claude-login.sh
+++ b/scripts/claude-login.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# claude-login.sh — log in as the dev `claude-test` user and save a session cookie jar.
+#
+# Usage:
+#   scripts/claude-login.sh                        # Next dev server on :3000
+#   scripts/claude-login.sh --host http://localhost:8000   # FastAPI
+#   scripts/claude-login.sh --host https://dev.example.com # remote preview
+#
+# Reads CLAUDE_TEST_USER and CLAUDE_TEST_PASSWORD from env or .env.local
+# (same values the `db:seed` script uses). Writes cookies to
+# COOKIES=${COOKIES:-/tmp/fr-cookies.txt} and prints that path on success.
+#
+# Exit codes: 0 on 200, 1 on non-200 or env/parse errors.
+
+set -euo pipefail
+
+HOST="http://localhost:3000"
+COOKIES="${COOKIES:-/tmp/fr-cookies.txt}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --host)
+      HOST="$2"
+      shift 2
+      ;;
+    -h|--help)
+      sed -n '2,14p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Load .env.local if present (without clobbering already-set env vars).
+ENV_FILE="$(dirname "$0")/../.env.local"
+if [[ -f "$ENV_FILE" ]]; then
+  while IFS='=' read -r key value; do
+    [[ -z "$key" || "$key" =~ ^# ]] && continue
+    value="${value%\"}"
+    value="${value#\"}"
+    if [[ "$key" == "CLAUDE_TEST_USER" && -z "${CLAUDE_TEST_USER:-}" ]]; then
+      export CLAUDE_TEST_USER="$value"
+    elif [[ "$key" == "CLAUDE_TEST_PASSWORD" && -z "${CLAUDE_TEST_PASSWORD:-}" ]]; then
+      export CLAUDE_TEST_PASSWORD="$value"
+    fi
+  done < "$ENV_FILE"
+fi
+
+USER="${CLAUDE_TEST_USER:-claude-test}"
+PASSWORD="${CLAUDE_TEST_PASSWORD:-claude-test-password}"
+
+# Next mounts auth under /api/auth/login; FastAPI uses /auth/login.
+if [[ "$HOST" == *":8000"* ]]; then
+  LOGIN_PATH="/auth/login"
+else
+  LOGIN_PATH="/api/auth/login"
+fi
+
+rm -f "$COOKIES"
+
+HTTP_CODE=$(curl -sS -o /tmp/claude-login-body.json -w '%{http_code}' \
+  -c "$COOKIES" \
+  -H "Content-Type: application/json" \
+  -d "{\"emailOrUsername\":\"${USER}\",\"password\":\"${PASSWORD}\"}" \
+  "${HOST}${LOGIN_PATH}")
+
+if [[ "$HTTP_CODE" != "200" ]]; then
+  echo "Login failed: HTTP ${HTTP_CODE}" >&2
+  cat /tmp/claude-login-body.json >&2 || true
+  echo >&2
+  exit 1
+fi
+
+if ! grep -q 'session' "$COOKIES"; then
+  echo "Login returned 200 but no session cookie was set" >&2
+  exit 1
+fi
+
+echo "$COOKIES"

--- a/scripts/claude-login.sh
+++ b/scripts/claude-login.sh
@@ -62,10 +62,14 @@ fi
 
 rm -f "$COOKIES"
 
+# Build the JSON body via jq so " and \ in the password are escaped safely.
+BODY=$(jq -n --arg u "$USER" --arg p "$PASSWORD" \
+  '{emailOrUsername: $u, password: $p}')
+
 HTTP_CODE=$(curl -sS -o /tmp/claude-login-body.json -w '%{http_code}' \
   -c "$COOKIES" \
   -H "Content-Type: application/json" \
-  -d "{\"emailOrUsername\":\"${USER}\",\"password\":\"${PASSWORD}\"}" \
+  -d "$BODY" \
   "${HOST}${LOGIN_PATH}")
 
 if [[ "$HTTP_CODE" != "200" ]]; then
@@ -75,7 +79,9 @@ if [[ "$HTTP_CODE" != "200" ]]; then
   exit 1
 fi
 
-if ! grep -q 'session' "$COOKIES"; then
+# Tab-anchored match against the Netscape cookie-jar format — avoids
+# false-positives from hosts or paths that contain the word "session".
+if ! grep -q $'\tsession\t' "$COOKIES"; then
   echo "Login returned 200 but no session cookie was set" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

- Seed a dedicated `claude-test` user in `prisma/seed.ts` (guarded behind `NODE_ENV !== 'production'`, idempotent, reads `CLAUDE_TEST_USER` / `CLAUDE_TEST_PASSWORD` from env with dev-only defaults).
- Add `scripts/claude-login.sh` that hits `POST /api/auth/login` (Next) or `POST /auth/login` (FastAPI, when `--host` targets `:8000`) with a cookie jar at `/tmp/fr-cookies.txt`.
- Replace the `<seeded-user>` / `<pass>` placeholders in the next-api, fastapi, and verification README playbooks with concrete `scripts/claude-login.sh` invocations. The verification README now names this the canonical auth path for playbooks.

## Closes

Closes #63

## Test notes

Verified locally on a fresh Postgres (via the docker one-liner in [docs/verification/next-api.md](docs/verification/next-api.md)):

- [x] `npm run db:seed` on an empty DB creates family + claude-test user; a second run reports "already exists" and re-upserts the user without duplicates.
- [x] `NODE_ENV=production CLAUDE_TEST_PASSWORD=different npm run db:seed` prints `Skipping claude-test user (NODE_ENV=production)` — the user row is not touched.
- [x] `scripts/claude-login.sh` against `npm run dev` returns the cookie path; `curl -b "$COOKIES" /api/auth/me` returns 200 with the claude-test user.
- [x] `CLAUDE_TEST_PASSWORD=wrong scripts/claude-login.sh` exits non-zero and prints the 401 body.
- [x] `scripts/claude-login.sh --host http://localhost:8000` routes to `/auth/login` (inferred from the port); not exercised end-to-end because the FastAPI service isn't running in this session.
- [x] `npm run type-check`, `npm run lint`, `npm test` (963 tests) all pass.

### Note on the ticket's SQLite test step

The ticket asks for verification against a fresh SQLite DB; that path can't actually run today — `Notification.emojiCounts`/`metadata` are `Json?` in `prisma/schema.prisma`, which the SQLite connector rejects (`prisma db push` fails). Tracked separately as #80 (drop SQLite entirely — nothing depends on it at runtime), so I verified on Postgres instead. The seed code itself is schema-agnostic: the `User` and `FamilyMembership` models it touches are identical across all three schemas, so once #80 lands it will continue to work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)