### PR TITLE
fix: FastAPI get_current_user 500s on every authed request (#74)

### DIFF
--- a/apps/api/src/dependencies.py
+++ b/apps/api/src/dependencies.py
@@ -33,8 +33,12 @@ async def get_current_user(request: Request) -> UserResponse:
     return UserResponse(
         id=user.id,
         name=user.name,
-        emailOrUsername=user.emailOrUsername,
-        avatarUrl=user.avatarUrl,
+        email=user.email,
+        username=user.username,
+        emailOrUsername=user.email,
+        # FastAPI lacks the signed-URL helper the Next app uses to resolve
+        # avatarStorageKey → signed URL; return None until that lands.
+        avatarUrl=None,
         role=membership.role,
         familySpaceId=membership.familySpaceId,
         familySpaceName=membership.familySpace.name if membership.familySpace else None,

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -17,8 +17,11 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 @router.post("/signup", response_model=AuthResponse, status_code=status.HTTP_201_CREATED)
 async def signup(payload: SignupRequest, response: Response):
     try:
-        existing_user = await prisma.user.find_unique(
-            where={"emailOrUsername": payload.emailOrUsername}
+        email = payload.email.strip()
+        username = payload.username.strip()
+
+        existing_user = await prisma.user.find_first(
+            where={"OR": [{"email": email}, {"username": username}]}
         )
         if existing_user:
             return bad_request("A user with this email or username already exists")
@@ -40,7 +43,8 @@ async def signup(payload: SignupRequest, response: Response):
             user = await tx.user.create(
                 data={
                     "name": payload.name,
-                    "emailOrUsername": payload.emailOrUsername,
+                    "email": email,
+                    "username": username,
                     "passwordHash": hash_password(payload.password),
                 }
             )
@@ -65,8 +69,10 @@ async def signup(payload: SignupRequest, response: Response):
         user_response = UserResponse(
             id=user.id,
             name=user.name,
-            emailOrUsername=user.emailOrUsername,
-            avatarUrl=user.avatarUrl,
+            email=user.email,
+            username=user.username,
+            emailOrUsername=user.email,
+            avatarUrl=None,
             role=membership.role,
             familySpaceId=membership.familySpaceId,
             familySpaceName=family_space.name,
@@ -86,8 +92,9 @@ async def signup(payload: SignupRequest, response: Response):
 @router.post("/login", response_model=AuthResponse)
 async def login(payload: LoginRequest, response: Response):
     try:
-        user = await prisma.user.find_unique(
-            where={"emailOrUsername": payload.emailOrUsername},
+        identifier = payload.emailOrUsername.strip()
+        user = await prisma.user.find_first(
+            where={"OR": [{"email": identifier}, {"username": identifier}]},
             include={
                 "memberships": {
                     "include": {"familySpace": True},
@@ -98,7 +105,7 @@ async def login(payload: LoginRequest, response: Response):
         if not user:
             logger.info(
                 "auth.login.invalid_credentials user not found",
-                extra={"emailOrUsername": payload.emailOrUsername},
+                extra={"emailOrUsername": identifier},
             )
             return invalid_credentials()
 
@@ -106,14 +113,14 @@ async def login(payload: LoginRequest, response: Response):
         if not is_valid_password:
             logger.info(
                 "auth.login.invalid_credentials bad password",
-                extra={"emailOrUsername": payload.emailOrUsername},
+                extra={"emailOrUsername": identifier},
             )
             return invalid_credentials()
 
         if not user.memberships:
             logger.info(
                 "auth.login.no_membership",
-                extra={"emailOrUsername": payload.emailOrUsername, "userId": user.id},
+                extra={"emailOrUsername": identifier, "userId": user.id},
             )
             return forbidden("User is not a member of any family space")
 
@@ -131,8 +138,10 @@ async def login(payload: LoginRequest, response: Response):
         user_response = UserResponse(
             id=user.id,
             name=user.name,
-            emailOrUsername=user.emailOrUsername,
-            avatarUrl=user.avatarUrl,
+            email=user.email,
+            username=user.username,
+            emailOrUsername=user.email,
+            avatarUrl=None,
             role=membership.role,
             familySpaceId=membership.familySpaceId,
             familySpaceName=membership.familySpace.name if membership.familySpace else None,

--- a/apps/api/src/routers/family.py
+++ b/apps/api/src/routers/family.py
@@ -24,8 +24,11 @@ async def list_members(user: UserResponse = Depends(get_current_user)):
                 "userId": m.userId,
                 "membershipId": m.id,
                 "name": m.user.name,
-                "emailOrUsername": m.user.emailOrUsername,
-                "avatarUrl": m.user.avatarUrl,
+                "email": m.user.email,
+                "username": m.user.username,
+                "emailOrUsername": m.user.email,
+                # FastAPI lacks the signed-URL helper; see dependencies.py.
+                "avatarUrl": None,
                 "role": m.role,
                 "joinedAt": m.createdAt.isoformat(),
                 "postCount": len(m.user.posts) if m.user.posts else 0,

--- a/apps/api/src/routers/me.py
+++ b/apps/api/src/routers/me.py
@@ -53,18 +53,35 @@ async def update_profile(
     payload: dict, user: UserResponse = Depends(get_current_user)
 ):  # simple dict validation to mirror existing behavior
     name = payload.get("name")
-    email_or_username = payload.get("emailOrUsername")
+    email = payload.get("email")
+    username = payload.get("username")
     if not isinstance(name, str) or not name.strip():
         return bad_request("Name is required")
-    if not isinstance(email_or_username, str) or not email_or_username.strip():
-        return bad_request("Email or username is required")
+    if not isinstance(email, str) or not email.strip():
+        return bad_request("Email is required")
+    if not isinstance(username, str) or not username.strip():
+        return bad_request("Username is required")
 
     try:
         updated = await prisma.user.update(
             where={"id": user.id},
-            data={"name": name.strip(), "emailOrUsername": email_or_username.strip()},
+            data={
+                "name": name.strip(),
+                "email": email.strip(),
+                "username": username.strip(),
+            },
         )
-        return {"user": {"id": updated.id, "name": updated.name, "emailOrUsername": updated.emailOrUsername, "avatarUrl": updated.avatarUrl}}
+        return {
+            "user": {
+                "id": updated.id,
+                "name": updated.name,
+                "email": updated.email,
+                "username": updated.username,
+                "emailOrUsername": updated.email,
+                # FastAPI lacks the signed-URL helper; see dependencies.py.
+                "avatarUrl": None,
+            }
+        }
     except PrismaError:
         return internal_error("Failed to update profile")
     except Exception:

--- a/apps/api/src/schemas/auth.py
+++ b/apps/api/src/schemas/auth.py
@@ -5,7 +5,8 @@ from pydantic import BaseModel, Field
 
 class SignupRequest(BaseModel):
     name: str = Field(min_length=1, max_length=200)
-    emailOrUsername: str = Field(min_length=3, max_length=200)
+    email: str = Field(min_length=3, max_length=200)
+    username: str = Field(min_length=3, max_length=30, pattern=r"^[a-zA-Z0-9_]+$")
     password: str = Field(min_length=6, max_length=200)
     familyMasterKey: str = Field(min_length=6, max_length=200)
     rememberMe: bool = False
@@ -20,6 +21,10 @@ class LoginRequest(BaseModel):
 class UserResponse(BaseModel):
     id: str
     name: str
+    email: str
+    username: str
+    # Mirrors email; kept so Next-era clients that read `emailOrUsername`
+    # continue to work during the FastAPI migration.
     emailOrUsername: str
     avatarUrl: Optional[str] = None
     role: str

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -66,6 +66,8 @@ def test_user() -> UserResponse:
     return UserResponse(
         id="test-user-id-123",
         name="Test User",
+        email="testuser@example.com",
+        username="testuser",
         emailOrUsername="testuser@example.com",
         avatarUrl=None,
         role="member",
@@ -80,6 +82,8 @@ def admin_user() -> UserResponse:
     return UserResponse(
         id="admin-user-id-456",
         name="Admin User",
+        email="admin@example.com",
+        username="adminuser",
         emailOrUsername="admin@example.com",
         avatarUrl=None,
         role="admin",
@@ -94,6 +98,8 @@ def owner_user() -> UserResponse:
     return UserResponse(
         id="owner-user-id-789",
         name="Owner User",
+        email="owner@example.com",
+        username="owneruser",
         emailOrUsername="owner@example.com",
         avatarUrl=None,
         role="owner",
@@ -198,7 +204,8 @@ def valid_signup_payload() -> dict:
     """Valid signup request payload."""
     return {
         "name": "New User",
-        "emailOrUsername": "newuser@example.com",
+        "email": "newuser@example.com",
+        "username": "newuser",
         "password": "securepassword123",
         "familyMasterKey": "family-secret-key",
         "rememberMe": False,

--- a/apps/api/tests/helpers/test_data.py
+++ b/apps/api/tests/helpers/test_data.py
@@ -10,9 +10,10 @@ def make_mock_user(**overrides: Any) -> SimpleNamespace:
     data = {
         "id": overrides.get("id", "user_test_123"),
         "name": overrides.get("name", "Test User"),
-        "emailOrUsername": overrides.get("emailOrUsername", "test@example.com"),
+        "email": overrides.get("email", "test@example.com"),
+        "username": overrides.get("username", "testuser"),
         "passwordHash": overrides.get("passwordHash", "$2b$10$hashed"),
-        "avatarUrl": overrides.get("avatarUrl", None),
+        "avatarStorageKey": overrides.get("avatarStorageKey", None),
         "createdAt": overrides.get("createdAt", now),
         "updatedAt": overrides.get("updatedAt", now),
         "memberships": overrides.get("memberships", []),

--- a/apps/api/tests/integration/conftest.py
+++ b/apps/api/tests/integration/conftest.py
@@ -53,12 +53,12 @@ def mock_user() -> SimpleNamespace:
 
 @pytest.fixture
 def mock_admin_user() -> SimpleNamespace:
-    return make_mock_user(id="admin_123", name="Admin", emailOrUsername="admin@example.com")
+    return make_mock_user(id="admin_123", name="Admin", email="admin@example.com", username="admin")
 
 
 @pytest.fixture
 def mock_owner_user() -> SimpleNamespace:
-    return make_mock_user(id="owner_123", name="Owner", emailOrUsername="owner@example.com")
+    return make_mock_user(id="owner_123", name="Owner", email="owner@example.com", username="owner")
 
 
 @pytest.fixture

--- a/apps/api/tests/integration/test_auth.py
+++ b/apps/api/tests/integration/test_auth.py
@@ -77,7 +77,8 @@ class TestAuthSignup:
     def test_signup_first_user_becomes_owner(self, client, mock_prisma, monkeypatch):
         payload = {
             "name": "New User",
-            "emailOrUsername": "new@example.com",
+            "email": "new@example.com",
+            "username": "newuser",
             "password": "password123",
             "familyMasterKey": "secret-key",
             "rememberMe": False,
@@ -85,11 +86,16 @@ class TestAuthSignup:
 
         family = make_mock_family_space(masterKeyHash="$2b$10$dummyhashforfamily")
 
-        mock_prisma.user.find_unique.return_value = None
+        mock_prisma.user.find_first.return_value = None
         mock_prisma.familyspace.find_first.return_value = family
         mock_prisma.familymembership.count.return_value = 0
 
-        user = make_mock_user(id="user_1", emailOrUsername=payload["emailOrUsername"], name=payload["name"])
+        user = make_mock_user(
+            id="user_1",
+            email=payload["email"],
+            username=payload["username"],
+            name=payload["name"],
+        )
         membership = make_mock_membership(userId=user.id, familySpaceId=family.id, role="owner", familySpace=family)
         self._setup_tx(mock_prisma, user, membership)
 
@@ -101,23 +107,32 @@ class TestAuthSignup:
         assert response.status_code == 201
         body = response.json()
         assert body["user"]["role"] == "owner"
+        assert body["user"]["email"] == payload["email"]
+        assert body["user"]["username"] == payload["username"]
+        assert body["user"]["emailOrUsername"] == payload["email"]
         assert "set-cookie" in response.headers
 
     def test_signup_subsequent_user_becomes_member(self, client, mock_prisma, monkeypatch):
         payload = {
             "name": "Next User",
-            "emailOrUsername": "next@example.com",
+            "email": "next@example.com",
+            "username": "nextuser",
             "password": "password123",
             "familyMasterKey": "secret-key",
             "rememberMe": False,
         }
 
         family = make_mock_family_space()
-        mock_prisma.user.find_unique.return_value = None
+        mock_prisma.user.find_first.return_value = None
         mock_prisma.familyspace.find_first.return_value = family
         mock_prisma.familymembership.count.return_value = 1
 
-        user = make_mock_user(id="user_2", emailOrUsername=payload["emailOrUsername"], name=payload["name"])
+        user = make_mock_user(
+            id="user_2",
+            email=payload["email"],
+            username=payload["username"],
+            name=payload["name"],
+        )
         membership = make_mock_membership(userId=user.id, familySpaceId=family.id, role="member", familySpace=family)
         self._setup_tx(mock_prisma, user, membership)
 
@@ -130,13 +145,14 @@ class TestAuthSignup:
         assert response.json()["user"]["role"] == "member"
 
     def test_signup_rejects_duplicate_email(self, client, mock_prisma):
-        mock_prisma.user.find_unique.return_value = make_mock_user()
+        mock_prisma.user.find_first.return_value = make_mock_user()
 
         response = client.post(
             "/auth/signup",
             json={
                 "name": "Dup User",
-                "emailOrUsername": "test@example.com",
+                "email": "test@example.com",
+                "username": "dupuser",
                 "password": "password123",
                 "familyMasterKey": "secret-key",
                 "rememberMe": False,
@@ -148,7 +164,7 @@ class TestAuthSignup:
 
     def test_signup_invalid_master_key(self, client, mock_prisma, monkeypatch):
         family = make_mock_family_space(masterKeyHash="$2b$10$hash")
-        mock_prisma.user.find_unique.return_value = None
+        mock_prisma.user.find_first.return_value = None
         mock_prisma.familyspace.find_first.return_value = family
         mock_prisma.familymembership.count.return_value = 0
         monkeypatch.setattr("src.security.verify_password", lambda pwd, hash: False)
@@ -158,7 +174,8 @@ class TestAuthSignup:
             "/auth/signup",
             json={
                 "name": "User",
-                "emailOrUsername": "user@example.com",
+                "email": "user@example.com",
+                "username": "someuser",
                 "password": "password123",
                 "familyMasterKey": "wrongkey",
                 "rememberMe": False,
@@ -169,14 +186,15 @@ class TestAuthSignup:
         assert response.json()["error"]["code"] == "BAD_REQUEST"
 
     def test_signup_no_family_space(self, client, mock_prisma):
-        mock_prisma.user.find_unique.return_value = None
+        mock_prisma.user.find_first.return_value = None
         mock_prisma.familyspace.find_first.return_value = None
 
         response = client.post(
             "/auth/signup",
             json={
                 "name": "User",
-                "emailOrUsername": "user@example.com",
+                "email": "user@example.com",
+                "username": "someuser",
                 "password": "password123",
                 "familyMasterKey": "secret-key",
                 "rememberMe": False,
@@ -197,7 +215,7 @@ class TestAuthLogin:
         assert response.status_code == 422
 
     def test_login_user_not_found(self, client, mock_prisma):
-        mock_prisma.user.find_unique.return_value = None
+        mock_prisma.user.find_first.return_value = None
 
         response = client.post(
             "/auth/login",
@@ -211,13 +229,13 @@ class TestAuthLogin:
         family = make_mock_family_space()
         membership = make_mock_membership(familySpaceId=family.id, familySpace=family)
         user = make_mock_user(memberships=[membership])
-        mock_prisma.user.find_unique.return_value = user
+        mock_prisma.user.find_first.return_value = user
         monkeypatch.setattr("src.security.verify_password", lambda pwd, hash: False)
         monkeypatch.setattr("src.routers.auth.verify_password", lambda pwd, hash: False)
 
         response = client.post(
             "/auth/login",
-            json={"emailOrUsername": user.emailOrUsername, "password": "wrongpwd"},
+            json={"emailOrUsername": user.email, "password": "wrongpwd"},
         )
 
         assert response.status_code == 401
@@ -225,13 +243,13 @@ class TestAuthLogin:
 
     def test_login_no_membership_forbidden(self, client, mock_prisma, monkeypatch):
         user = make_mock_user(memberships=[])
-        mock_prisma.user.find_unique.return_value = user
+        mock_prisma.user.find_first.return_value = user
         monkeypatch.setattr("src.security.verify_password", lambda pwd, hash: True)
         monkeypatch.setattr("src.routers.auth.verify_password", lambda pwd, hash: True)
 
         response = client.post(
             "/auth/login",
-            json={"emailOrUsername": user.emailOrUsername, "password": "password123"},
+            json={"emailOrUsername": user.email, "password": "password123"},
         )
 
         assert response.status_code == 403
@@ -241,31 +259,34 @@ class TestAuthLogin:
         family = make_mock_family_space()
         membership = make_mock_membership(familySpaceId=family.id, familySpace=family)
         user = make_mock_user(memberships=[membership])
-        mock_prisma.user.find_unique.return_value = user
+        mock_prisma.user.find_first.return_value = user
         monkeypatch.setattr("src.security.verify_password", lambda pwd, hash: True)
         monkeypatch.setattr("src.routers.auth.verify_password", lambda pwd, hash: True)
 
         response = client.post(
             "/auth/login",
-            json={"emailOrUsername": user.emailOrUsername, "password": "password123"},
+            json={"emailOrUsername": user.username, "password": "password123"},
         )
 
         assert response.status_code == 200
         assert "set-cookie" in response.headers
         body = response.json()
         assert body["user"]["id"] == user.id
+        assert body["user"]["email"] == user.email
+        assert body["user"]["username"] == user.username
+        assert body["user"]["emailOrUsername"] == user.email
 
     def test_login_remember_me_extends_cookie(self, client, mock_prisma, monkeypatch):
         family = make_mock_family_space()
         membership = make_mock_membership(familySpaceId=family.id, familySpace=family)
         user = make_mock_user(memberships=[membership])
-        mock_prisma.user.find_unique.return_value = user
+        mock_prisma.user.find_first.return_value = user
         monkeypatch.setattr("src.security.verify_password", lambda pwd, hash: True)
         monkeypatch.setattr("src.routers.auth.verify_password", lambda pwd, hash: True)
 
         response = client.post(
             "/auth/login",
-            json={"emailOrUsername": user.emailOrUsername, "password": "password123", "rememberMe": True},
+            json={"emailOrUsername": user.email, "password": "password123", "rememberMe": True},
         )
 
         assert response.status_code == 200

--- a/apps/api/tests/integration/test_family.py
+++ b/apps/api/tests/integration/test_family.py
@@ -19,8 +19,9 @@ def _make_user(idx: int = 1, **overrides) -> SimpleNamespace:
     data = {
         "id": overrides.get("id", f"user-{idx}"),
         "name": overrides.get("name", f"Member {idx}"),
-        "emailOrUsername": overrides.get("emailOrUsername", f"member{idx}@example.com"),
-        "avatarUrl": overrides.get("avatarUrl", f"https://cdn.test/avatar-{idx}.jpg"),
+        "email": overrides.get("email", f"member{idx}@example.com"),
+        "username": overrides.get("username", f"member{idx}"),
+        "avatarStorageKey": overrides.get("avatarStorageKey", f"avatars/avatar-{idx}.jpg"),
         "posts": overrides.get("posts", []),
     }
     data.update(overrides)
@@ -59,8 +60,10 @@ def test_list_members_success(client, mock_prisma, member_auth):
                 "userId": membership.userId,
                 "membershipId": membership.id,
                 "name": user.name,
-                "emailOrUsername": user.emailOrUsername,
-                "avatarUrl": user.avatarUrl,
+                "email": user.email,
+                "username": user.username,
+                "emailOrUsername": user.email,
+                "avatarUrl": None,
                 "role": "admin",
                 "joinedAt": _NOW.isoformat(),
                 "postCount": 1,

--- a/apps/api/tests/integration/test_me.py
+++ b/apps/api/tests/integration/test_me.py
@@ -112,48 +112,87 @@ def test_me_favorites_requires_auth(client):
 
 
 def test_update_profile_success(client, mock_prisma, member_auth):
-    updated_user = SimpleNamespace(id="user_test_123", name="New Name", emailOrUsername="new@example.com", avatarUrl="https://cdn.test/avatar.jpg")
+    updated_user = SimpleNamespace(
+        id="user_test_123",
+        name="New Name",
+        email="new@example.com",
+        username="newname",
+    )
     mock_prisma.user.update = AsyncMock(return_value=updated_user)
 
     response = client.put(
         "/me/profile",
         headers=member_auth,
-        json={"name": "  New Name  ", "emailOrUsername": "  new@example.com  "},
+        json={
+            "name": "  New Name  ",
+            "email": "  new@example.com  ",
+            "username": "  newname  ",
+        },
     )
 
     assert response.status_code == 200
     assert response.json()["user"] == {
         "id": updated_user.id,
         "name": updated_user.name,
-        "emailOrUsername": updated_user.emailOrUsername,
-        "avatarUrl": updated_user.avatarUrl,
+        "email": updated_user.email,
+        "username": updated_user.username,
+        "emailOrUsername": updated_user.email,
+        "avatarUrl": None,
     }
     call_kwargs = mock_prisma.user.update.await_args.kwargs
-    assert call_kwargs["data"] == {"name": "New Name", "emailOrUsername": "new@example.com"}
+    assert call_kwargs["data"] == {
+        "name": "New Name",
+        "email": "new@example.com",
+        "username": "newname",
+    }
 
 
 def test_update_profile_missing_name_400(client, member_auth):
-    response = client.put("/me/profile", headers=member_auth, json={"emailOrUsername": "test@example.com"})
+    response = client.put(
+        "/me/profile",
+        headers=member_auth,
+        json={"email": "test@example.com", "username": "testuser"},
+    )
 
     assert response.status_code == 400
     assert response.json()["error"]["message"] == "Name is required"
 
 
 def test_update_profile_missing_email_400(client, member_auth):
-    response = client.put("/me/profile", headers=member_auth, json={"name": "Test"})
+    response = client.put(
+        "/me/profile",
+        headers=member_auth,
+        json={"name": "Test", "username": "testuser"},
+    )
 
     assert response.status_code == 400
-    assert response.json()["error"]["message"] == "Email or username is required"
+    assert response.json()["error"]["message"] == "Email is required"
+
+
+def test_update_profile_missing_username_400(client, member_auth):
+    response = client.put(
+        "/me/profile",
+        headers=member_auth,
+        json={"name": "Test", "email": "test@example.com"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["message"] == "Username is required"
 
 
 def test_update_profile_returns_updated_user_shape(client, mock_prisma, member_auth):
-    updated_user = SimpleNamespace(id="user_test_123", name="Tester", emailOrUsername="tester", avatarUrl=None)
+    updated_user = SimpleNamespace(
+        id="user_test_123",
+        name="Tester",
+        email="tester@example.com",
+        username="tester",
+    )
     mock_prisma.user.update = AsyncMock(return_value=updated_user)
 
     response = client.put(
         "/me/profile",
         headers=member_auth,
-        json={"name": "Tester", "emailOrUsername": "tester"},
+        json={"name": "Tester", "email": "tester@example.com", "username": "tester"},
     )
 
     assert response.status_code == 200
@@ -161,14 +200,19 @@ def test_update_profile_returns_updated_user_shape(client, mock_prisma, member_a
         "user": {
             "id": updated_user.id,
             "name": "Tester",
-            "emailOrUsername": "tester",
+            "email": "tester@example.com",
+            "username": "tester",
+            "emailOrUsername": "tester@example.com",
             "avatarUrl": None,
         }
     }
 
 
 def test_update_profile_requires_auth(client):
-    response = client.put("/me/profile", json={"name": "Test", "emailOrUsername": "test"})
+    response = client.put(
+        "/me/profile",
+        json={"name": "Test", "email": "test@example.com", "username": "test"},
+    )
 
     assert response.status_code == 401
 

--- a/apps/api/tests/unit/test_permissions.py
+++ b/apps/api/tests/unit/test_permissions.py
@@ -16,6 +16,8 @@ def member_user() -> UserResponse:
     return UserResponse(
         id="member-123",
         name="Member User",
+        email="member@example.com",
+        username="memberuser",
         emailOrUsername="member@example.com",
         avatarUrl=None,
         role="member",
@@ -29,6 +31,8 @@ def admin_user() -> UserResponse:
     return UserResponse(
         id="admin-456",
         name="Admin User",
+        email="admin@example.com",
+        username="adminuser",
         emailOrUsername="admin@example.com",
         avatarUrl=None,
         role="admin",
@@ -42,6 +46,8 @@ def owner_user() -> UserResponse:
     return UserResponse(
         id="owner-789",
         name="Owner User",
+        email="owner@example.com",
+        username="owneruser",
         emailOrUsername="owner@example.com",
         avatarUrl=None,
         role="owner",


### PR DESCRIPTION
## Summary

- FastAPI treated `emailOrUsername` as a Prisma column, but the schema has separate `email` + `username` — `emailOrUsername` is a computed convenience the Next app derives in TypeScript. Every authed FastAPI request 500'd, and signup/login/profile/family all issued broken queries against the same non-existent field.
- Realigns the FastAPI auth + profile + family layer with the Next contract: `SignupRequest` takes `email`+`username`, `LoginRequest` does `OR: [{email},{username}]` lookup, `UserResponse` carries both fields plus a backward-compat `emailOrUsername` mirroring `email`.
- Fixtures drop the ad-hoc `emailOrUsername` injection that was hiding the bug and now model the real schema (`email`, `username`, `avatarStorageKey`).

## Closes

Closes #74

## Scope note — avatarUrl deferred to #82

While fixing this I discovered a parallel bug: every `.avatarUrl` read in the FastAPI tree (`posts.py`, `comments.py`, `timeline.py`, `recipes.py`) references a non-existent column — the real field is `avatarStorageKey`, and Next resolves it to a signed URL via `getSignedUploadUrl`. FastAPI has no equivalent helper yet.

Full fix needs a Python signed-URL helper plus ~15 call-site updates — filed as #82. The four handlers this PR touches (`dependencies`, `auth`, `me`, `family`) return `avatarUrl=None` with a short comment pointing at that follow-up.

**Impact on the #74 AC:** `/auth/login` → `/auth/me` now works end-to-end, but the ticket's example verification endpoint `/recipes` still 500s because `recipes.py:233` reads `post.author.avatarUrl`. #82 is needed to close the field-trial scenario completely.

## Test notes

- `pytest apps/api/tests/` — 299 passing (up from 295; added `username`-missing case on `/me/profile`)
- `ruff check` clean
- `mypy src` — 1 pre-existing error on `prisma.models` import (present on `main`, unrelated)
- Live verify (`curl /auth/login` → `/auth/me` → `/recipes`) deferred — recommended after #82 lands since `/recipes` will still 500 until then. The `test_me_authenticated` integration test now exercises the `get_current_user` path with a realistic `make_mock_user` (no `emailOrUsername` injection), so a regression in that path would surface there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)