### PR TITLE
chore: enable branch protection on main and develop (#30)

### DIFF
--- a/.github/GITHUB_GUIDE.md
+++ b/.github/GITHUB_GUIDE.md
@@ -126,6 +126,28 @@ Example: `feat: cooked-event reactions (#12)`
 
 ---
 
+## Branch protection
+
+`main` and `develop` are protected via GitHub branch protection rules. The configuration is applied via the REST API (see issue #30); ground-truth state is queryable via GraphQL (`branchProtectionRules`).
+
+Shared settings on both branches:
+
+- **PR required** — no direct pushes; all commits arrive via PR
+- **Force pushes blocked** and **deletions blocked**
+- **Strict status checks** — branch must be up-to-date with the base before merge
+- **Conversation resolution required** — open review comments block merge
+- **Required approving reviews: 0** — as a solo maintainer, self-merge is allowed
+- **Admins not enforced** — the repo owner can bypass in genuine emergencies (use sparingly)
+
+Required status checks (from [ci.yml](workflows/ci.yml), the only workflow that runs on every PR): `typecheck`, `lint`, `test`, `build`, `container-scan`, `prisma-validate`, `dependency-scan`, `sast-semgrep`, `iac-scan`, `secrets-scan`. Job names in [api-ci.yml](workflows/api-ci.yml) and [recipe-url-importer-ci.yml](workflows/recipe-url-importer-ci.yml) are path-filtered, so they are **not** listed as required (a path-filtered required check that never runs would permanently block merges). They share names (`lint`, `typecheck`, etc.) with ci.yml jobs, so when they do run and fail, the shared-name required check fails too — effectively required when the relevant paths change.
+
+Difference between branches:
+
+- `develop` — **linear history required** (squash-merge only, matching the feature-PR workflow)
+- `main` — **linear history not required** (release PRs from `develop` use merge commits so individual feature commits stay visible in `main` history)
+
+---
+
 ## Research Spikes
 
 Research issues are complete when:


### PR DESCRIPTION
## Summary
- Applied branch protection rules to `main` and `develop` via GitHub REST API (not in this diff — admin setting).
- Documented the final configuration in [.github/GITHUB_GUIDE.md](.github/GITHUB_GUIDE.md).

Closes #30.

## What changed on GitHub (ground-truth verified via GraphQL)

Both branches now enforce:
- PR required, no direct pushes
- Force pushes blocked, deletions blocked
- Strict status checks (up-to-date with base before merge)
- Conversation resolution required
- 10 required checks from `ci.yml`: `typecheck`, `lint`, `test`, `build`, `container-scan`, `prisma-validate`, `dependency-scan`, `sast-semgrep`, `iac-scan`, `secrets-scan`
- Required approving reviews: 0 (solo-dev self-merge)
- Admins not enforced (emergency-bypass available to repo owner)

Branch-specific:
- `develop` — linear history required (squash-only)
- `main` — linear history NOT required (release PRs use merge commits per the existing workflow)

Path-filtered workflows (`api-ci.yml`, `recipe-url-importer-ci.yml`) are intentionally **not** listed as required checks — a path-filtered check that never runs would block unrelated PRs. Their jobs share names with `ci.yml` (`lint`, `typecheck`, etc.), so when they do run and fail, the shared-name required check still blocks merge.

## Test plan
- [x] GraphQL `branchProtectionRules` query confirms both rules are active with expected settings
- [ ] Attempting a direct push to `develop` is rejected (this PR itself is the proof — I had to branch)
- [ ] A PR with a failing required check shows a disabled Merge button
- [ ] GitHub → Settings → Branches shows both rules as active

🤖 Generated with [Claude Code](https://claude.com/claude-code)