### PR TITLE
fix(api): resolve FastAPI avatarStorageKey via signed-URL helper (#82)

### DIFF
--- a/apps/api/src/dependencies.py
+++ b/apps/api/src/dependencies.py
@@ -4,6 +4,7 @@ from .db import prisma
 from .schemas.auth import UserResponse
 from .security import verify_token
 from .settings import settings
+from .uploads import get_signed_upload_url
 
 
 async def get_current_user(request: Request) -> UserResponse:
@@ -30,15 +31,14 @@ async def get_current_user(request: Request) -> UserResponse:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
 
     membership = user.memberships[0]
+    avatar_url = await get_signed_upload_url(getattr(user, "avatarStorageKey", None))
     return UserResponse(
         id=user.id,
         name=user.name,
         email=user.email,
         username=user.username,
         emailOrUsername=user.email,
-        # FastAPI lacks the signed-URL helper the Next app uses to resolve
-        # avatarStorageKey → signed URL; return None until that lands.
-        avatarUrl=None,
+        avatarUrl=avatar_url,
         role=membership.role,
         familySpaceId=membership.familySpaceId,
         familySpaceName=membership.familySpace.name if membership.familySpace else None,

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -8,6 +8,7 @@ from ..dependencies import get_current_user
 from ..errors import bad_request, forbidden, internal_error, invalid_credentials
 from ..schemas.auth import AuthResponse, LoginRequest, SignupRequest, UserResponse
 from ..security import clear_session_cookie, hash_password, set_session_cookie, sign_token, verify_password
+from ..uploads import get_signed_upload_url
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +73,7 @@ async def signup(payload: SignupRequest, response: Response):
             email=user.email,
             username=user.username,
             emailOrUsername=user.email,
-            avatarUrl=None,
+            avatarUrl=await get_signed_upload_url(getattr(user, "avatarStorageKey", None)),
             role=membership.role,
             familySpaceId=membership.familySpaceId,
             familySpaceName=family_space.name,
@@ -141,7 +142,7 @@ async def login(payload: LoginRequest, response: Response):
             email=user.email,
             username=user.username,
             emailOrUsername=user.email,
-            avatarUrl=None,
+            avatarUrl=await get_signed_upload_url(getattr(user, "avatarStorageKey", None)),
             role=membership.role,
             familySpaceId=membership.familySpaceId,
             familySpaceName=membership.familySpace.name if membership.familySpace else None,

--- a/apps/api/src/routers/comments.py
+++ b/apps/api/src/routers/comments.py
@@ -10,7 +10,13 @@ from ..errors import forbidden, internal_error, not_found
 from ..permissions import can_delete_comment
 from ..schemas.auth import UserResponse
 from ..schemas.comments import CreateCommentRequest
-from ..uploads import ALLOWED_MIME_TYPES, delete_uploads, save_photo_file
+from ..uploads import (
+    ALLOWED_MIME_TYPES,
+    create_signed_url_resolver,
+    delete_uploads,
+    get_signed_upload_url,
+    save_photo_file,
+)
 from ..utils import iso, is_cuid
 
 router = APIRouter(prefix="/posts/{post_id}/comments", tags=["comments"])
@@ -62,6 +68,7 @@ async def list_comments(
         has_more = len(comments) > limit_clamped
         comments = comments[:limit_clamped]
         ids = [c.id for c in comments]
+        resolve_avatar = create_signed_url_resolver()
         reaction_map: Dict[str, List[ReactionSummary]] = {}
         if ids:
             reactions = await prisma.reaction.find_many(
@@ -79,20 +86,31 @@ async def list_comments(
                     lst.append(found)
                 found["count"] += 1
                 found["users"].append(
-                    {"id": r.user.id, "name": r.user.name, "avatarUrl": r.user.avatarUrl}
+                    {
+                        "id": r.user.id,
+                        "name": r.user.name,
+                        "avatarUrl": await resolve_avatar(getattr(r.user, "avatarStorageKey", None)),
+                    }
                 )
 
-        serialized = [
-            {
-                "id": c.id,
-                "text": c.text,
-                "photoUrl": c.photoUrl,
-                "createdAt": iso(c.createdAt),
-                "author": {"id": c.author.id, "name": c.author.name, "avatarUrl": c.author.avatarUrl} if c.author else None,
-                "reactions": reaction_map.get(c.id, []),
-            }
-            for c in reversed(comments)
-        ]
+        serialized = []
+        for c in reversed(comments):
+            serialized.append(
+                {
+                    "id": c.id,
+                    "text": c.text,
+                    "photoUrl": c.photoUrl,
+                    "createdAt": iso(c.createdAt),
+                    "author": {
+                        "id": c.author.id,
+                        "name": c.author.name,
+                        "avatarUrl": await resolve_avatar(getattr(c.author, "avatarStorageKey", None)),
+                    }
+                    if c.author
+                    else None,
+                    "reactions": reaction_map.get(c.id, []),
+                }
+            )
         return {"comments": serialized, "hasMore": has_more, "nextOffset": offset + len(serialized)}
     except PrismaError:
         return internal_error("Failed to load comments")
@@ -141,7 +159,15 @@ async def create_comment(
                 "text": comment.text,
                 "photoUrl": comment.photoUrl,
                 "createdAt": iso(comment.createdAt),
-                "author": {"id": comment.author.id, "name": comment.author.name, "avatarUrl": comment.author.avatarUrl} if comment.author else None,
+                "author": {
+                    "id": comment.author.id,
+                    "name": comment.author.name,
+                    "avatarUrl": await get_signed_upload_url(
+                        getattr(comment.author, "avatarStorageKey", None)
+                    ),
+                }
+                if comment.author
+                else None,
                 "reactions": [],
             }
         }

--- a/apps/api/src/routers/family.py
+++ b/apps/api/src/routers/family.py
@@ -6,6 +6,7 @@ from ..dependencies import get_current_user
 from ..errors import forbidden, internal_error, not_found
 from ..permissions import can_remove_member
 from ..schemas.auth import UserResponse
+from ..uploads import create_signed_url_resolver
 from ..utils import is_cuid
 
 router = APIRouter(prefix="/family/members", tags=["family"])
@@ -19,6 +20,7 @@ async def list_members(user: UserResponse = Depends(get_current_user)):
             include={"user": {"include": {"posts": True}}},
             order={"createdAt": "asc"},
         )
+        resolve_avatar = create_signed_url_resolver()
         members = [
             {
                 "userId": m.userId,
@@ -27,8 +29,7 @@ async def list_members(user: UserResponse = Depends(get_current_user)):
                 "email": m.user.email,
                 "username": m.user.username,
                 "emailOrUsername": m.user.email,
-                # FastAPI lacks the signed-URL helper; see dependencies.py.
-                "avatarUrl": None,
+                "avatarUrl": await resolve_avatar(getattr(m.user, "avatarStorageKey", None)),
                 "role": m.role,
                 "joinedAt": m.createdAt.isoformat(),
                 "postCount": len(m.user.posts) if m.user.posts else 0,

--- a/apps/api/src/routers/me.py
+++ b/apps/api/src/routers/me.py
@@ -7,6 +7,7 @@ from ..dependencies import get_current_user
 from ..errors import bad_request, internal_error
 from ..schemas.auth import UserResponse
 from ..security import hash_password, verify_password
+from ..uploads import get_signed_upload_url
 from ..utils import iso
 
 logger = logging.getLogger(__name__)
@@ -78,8 +79,7 @@ async def update_profile(
                 "email": updated.email,
                 "username": updated.username,
                 "emailOrUsername": updated.email,
-                # FastAPI lacks the signed-URL helper; see dependencies.py.
-                "avatarUrl": None,
+                "avatarUrl": await get_signed_upload_url(getattr(updated, "avatarStorageKey", None)),
             }
         }
     except PrismaError:

--- a/apps/api/src/routers/posts.py
+++ b/apps/api/src/routers/posts.py
@@ -11,7 +11,13 @@ from ..errors import conflict, forbidden, internal_error, not_found
 from ..permissions import can_edit_post
 from ..schemas.auth import UserResponse
 from ..schemas.posts import CookedRequest, CreatePostRequest, FavoriteResponse, UpdatePostRequest
-from ..uploads import ALLOWED_MIME_TYPES, MAX_PHOTO_COUNT, delete_uploads, save_photo_file
+from ..uploads import (
+    ALLOWED_MIME_TYPES,
+    MAX_PHOTO_COUNT,
+    create_signed_url_resolver,
+    delete_uploads,
+    save_photo_file,
+)
 from ..utils import iso, is_cuid
 
 router = APIRouter(prefix="/posts", tags=["posts"])
@@ -219,12 +225,17 @@ async def _load_post_detail(
         order={"createdAt": "asc"},
         include={"user": True},
     )
+    resolve_avatar = create_signed_url_resolver()
     reaction_summary_map: Dict[str, Dict[str, Any]] = {}
     for r in post_reactions:
         entry = reaction_summary_map.get(r.emoji) or {"emoji": r.emoji, "count": 0, "users": []}
         entry["count"] += 1
         entry["users"].append(
-            {"id": r.user.id, "name": r.user.name, "avatarUrl": r.user.avatarUrl}
+            {
+                "id": r.user.id,
+                "name": r.user.name,
+                "avatarUrl": await resolve_avatar(getattr(r.user, "avatarStorageKey", None)),
+            }
         )
         reaction_summary_map[r.emoji] = entry
 
@@ -248,7 +259,11 @@ async def _load_post_detail(
             comment_reaction_map[r.targetId] = lst
         found["count"] += 1
         found["users"].append(
-            {"id": r.user.id, "name": r.user.name, "avatarUrl": r.user.avatarUrl}
+            {
+                "id": r.user.id,
+                "name": r.user.name,
+                "avatarUrl": await resolve_avatar(getattr(r.user, "avatarStorageKey", None)),
+            }
         )
 
     comments = []
@@ -259,23 +274,36 @@ async def _load_post_detail(
                 "text": c.text,
                 "photoUrl": c.photoUrl,
                 "createdAt": iso(c.createdAt),
-                "author": {"id": c.author.id, "name": c.author.name, "avatarUrl": c.author.avatarUrl} if c.author else None,
+                "author": {
+                    "id": c.author.id,
+                    "name": c.author.name,
+                    "avatarUrl": await resolve_avatar(getattr(c.author, "avatarStorageKey", None)),
+                }
+                if c.author
+                else None,
                 "reactions": comment_reaction_map.get(c.id, []),
             }
         )
 
     has_more_cooked = len(cooked_records) > cooked_limit
     cooked_records = cooked_records[:cooked_limit]
-    cooked = [
-        {
-            "id": e.id,
-            "rating": e.rating,
-            "note": e.note,
-            "createdAt": iso(e.createdAt),
-            "user": {"id": e.user.id, "name": e.user.name, "avatarUrl": e.user.avatarUrl} if e.user else None,
-        }
-        for e in cooked_records
-    ]
+    cooked = []
+    for e in cooked_records:
+        cooked.append(
+            {
+                "id": e.id,
+                "rating": e.rating,
+                "note": e.note,
+                "createdAt": iso(e.createdAt),
+                "user": {
+                    "id": e.user.id,
+                    "name": e.user.name,
+                    "avatarUrl": await resolve_avatar(getattr(e.user, "avatarStorageKey", None)),
+                }
+                if e.user
+                else None,
+            }
+        )
 
     courses_out = _parse_courses_from_recipe_details(post.recipeDetails) if hasattr(post, "recipeDetails") else []
 
@@ -288,7 +316,13 @@ async def _load_post_detail(
             "updatedAt": iso(post.updatedAt),
             "mainPhotoUrl": post.mainPhotoUrl,
             "isFavorited": is_favorited,
-            "author": {"id": post.author.id, "name": post.author.name, "avatarUrl": post.author.avatarUrl} if post.author else None,
+            "author": {
+                "id": post.author.id,
+                "name": post.author.name,
+                "avatarUrl": await resolve_avatar(getattr(post.author, "avatarStorageKey", None)),
+            }
+            if post.author
+            else None,
             "editor": {"id": post.editor.id, "name": post.editor.name} if post.editor else None,
             "lastEditNote": post.lastEditNote,
             "lastEditAt": iso(post.lastEditAt),
@@ -596,16 +630,24 @@ async def log_cooked(
         )
         has_more = len(cooked_page) > 5
         cooked_page = cooked_page[:5]
-        recent_cooked = [
-            {
-                "id": e.id,
-                "rating": e.rating,
-                "note": e.note,
-                "createdAt": iso(e.createdAt),
-                "user": {"id": e.user.id, "name": e.user.name, "avatarUrl": e.user.avatarUrl} if e.user else None,
-            }
-            for e in cooked_page
-        ]
+        resolve_avatar = create_signed_url_resolver()
+        recent_cooked = []
+        for e in cooked_page:
+            recent_cooked.append(
+                {
+                    "id": e.id,
+                    "rating": e.rating,
+                    "note": e.note,
+                    "createdAt": iso(e.createdAt),
+                    "user": {
+                        "id": e.user.id,
+                        "name": e.user.name,
+                        "avatarUrl": await resolve_avatar(getattr(e.user, "avatarStorageKey", None)),
+                    }
+                    if e.user
+                    else None,
+                }
+            )
         return {
             "cookedStats": {"timesCooked": times_cooked, "averageRating": average_rating},
             "recentCooked": recent_cooked,

--- a/apps/api/src/routers/posts.py
+++ b/apps/api/src/routers/posts.py
@@ -675,17 +675,26 @@ async def list_cooked(
         )
         has_more = len(events) > limit_clamped
         events = events[:limit_clamped]
-        return {
-            "cookedEvents": [
+        resolve_avatar = create_signed_url_resolver()
+        cooked_events = []
+        for e in events:
+            cooked_events.append(
                 {
                     "id": e.id,
                     "rating": e.rating,
                     "note": e.note,
                     "createdAt": iso(e.createdAt),
-                    "user": e.user,
+                    "user": {
+                        "id": e.user.id,
+                        "name": e.user.name,
+                        "avatarUrl": await resolve_avatar(getattr(e.user, "avatarStorageKey", None)),
+                    }
+                    if e.user
+                    else None,
                 }
-                for e in events
-            ],
+            )
+        return {
+            "cookedEvents": cooked_events,
             "hasMore": has_more,
             "nextOffset": offset + len(events),
         }

--- a/apps/api/src/routers/recipes.py
+++ b/apps/api/src/routers/recipes.py
@@ -8,6 +8,7 @@ from ..db import prisma
 from ..dependencies import get_current_user
 from ..errors import internal_error
 from ..schemas.auth import UserResponse
+from ..uploads import create_signed_url_resolver
 
 router = APIRouter(prefix="/recipes", tags=["recipes"])
 
@@ -220,6 +221,7 @@ async def browse_recipes(
             has_more = len(sorted_posts) > offset + limit
             posts = sorted_posts[offset : offset + limit]
 
+        resolve_avatar = create_signed_url_resolver()
         items = []
         for post in posts:
             courses = _parse_courses_from_recipe_details(post.recipeDetails)
@@ -230,7 +232,7 @@ async def browse_recipes(
                 "author": {
                     "id": post.author.id,
                     "name": post.author.name,
-                    "avatarUrl": post.author.avatarUrl,
+                    "avatarUrl": await resolve_avatar(getattr(post.author, "avatarStorageKey", None)),
                 },
                 "courses": courses,
                 "primaryCourse": courses[0] if courses else post.recipeDetails.course if getattr(post.recipeDetails, "course", None) else None,

--- a/apps/api/src/routers/timeline.py
+++ b/apps/api/src/routers/timeline.py
@@ -6,6 +6,7 @@ from ..db import prisma
 from ..dependencies import get_current_user
 from ..errors import internal_error
 from ..schemas.auth import UserResponse
+from ..uploads import create_signed_url_resolver
 from ..utils import iso
 
 logger = logging.getLogger(__name__)
@@ -111,24 +112,29 @@ async def get_timeline(
             }
             return mapping.get(entry_type, "shared")
 
-        items = [
-            {
+        resolve_avatar = create_signed_url_resolver()
+        items = []
+        for entry in slice_items:
+            actor = entry["actor"]
+            item = {
                 "id": entry["id"],
                 "type": entry["type"],
                 "timestamp": iso(entry["createdAt"]),
                 "actor": {
-                    "id": entry["actor"].id,
-                    "name": entry["actor"].name,
-                    "avatarUrl": entry["actor"].avatarUrl,
+                    "id": actor.id,
+                    "name": actor.name,
+                    "avatarUrl": await resolve_avatar(getattr(actor, "avatarStorageKey", None)),
                 },
                 "post": entry["post"],
                 "actionText": action_text(entry["type"]),
-                **({"comment": entry["comment"]} if "comment" in entry else {}),
-                **({"reaction": entry["reaction"]} if "reaction" in entry else {}),
-                **({"cooked": entry["cooked"]} if "cooked" in entry else {}),
             }
-            for entry in slice_items
-        ]
+            if "comment" in entry:
+                item["comment"] = entry["comment"]
+            if "reaction" in entry:
+                item["reaction"] = entry["reaction"]
+            if "cooked" in entry:
+                item["cooked"] = entry["cooked"]
+            items.append(item)
 
         return {"items": items, "hasMore": has_more, "nextOffset": offset + len(items)}
     except PrismaError as e:

--- a/apps/api/src/uploads.py
+++ b/apps/api/src/uploads.py
@@ -3,7 +3,7 @@ import hashlib
 import os
 import time
 from pathlib import Path
-from typing import List, Optional, TypedDict, Union
+from typing import Awaitable, Callable, Dict, List, Optional, TypedDict, Union
 from uuid import uuid4
 
 import httpx
@@ -242,3 +242,50 @@ async def delete_uploads(urls: List[Union[str, None, float, int]]) -> None:
                 path.unlink(missing_ok=True)  # type: ignore[arg-type]
             except Exception:
                 continue
+
+
+async def get_signed_upload_url(storage_key: Optional[str]) -> Optional[str]:
+    """Resolve a Prisma avatarStorageKey / postPhoto storageKey to a URL.
+
+    Mirrors src/lib/uploads.ts#getSignedUploadUrl: local-path passthrough
+    when no bucket is configured, else a time-limited V4 signed GCS URL.
+    """
+    if not storage_key:
+        return None
+
+    if not settings.uploads_bucket:
+        return f"/uploads/{storage_key}"
+
+    access_token = await _get_gcp_access_token()
+    service_account_email = await _fetch_metadata("instance/service-accounts/default/email")
+    private_key = os.environ.get("GCS_SIGNING_PRIVATE_KEY")
+
+    return await _generate_signed_url_v4(
+        bucket=settings.uploads_bucket,
+        object_key=storage_key,
+        expires_in_seconds=settings.uploads_signed_url_ttl_seconds,
+        access_token=access_token,
+        service_account_email=service_account_email,
+        private_key=private_key,
+    )
+
+
+def create_signed_url_resolver() -> Callable[[Optional[str]], Awaitable[Optional[str]]]:
+    """Return a resolver that memoizes get_signed_upload_url by storage key.
+
+    Use when a single request touches the same user / photo multiple times
+    (e.g. reactions + comments + cooked events in a post detail) so GCS is
+    only signed once per key.
+    """
+    cache: Dict[str, Optional[str]] = {}
+
+    async def resolve(storage_key: Optional[str]) -> Optional[str]:
+        if not storage_key:
+            return None
+        if storage_key in cache:
+            return cache[storage_key]
+        result = await get_signed_upload_url(storage_key)
+        cache[storage_key] = result
+        return result
+
+    return resolve

--- a/apps/api/src/uploads.py
+++ b/apps/api/src/uploads.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import hashlib
 import os
@@ -275,17 +276,19 @@ def create_signed_url_resolver() -> Callable[[Optional[str]], Awaitable[Optional
 
     Use when a single request touches the same user / photo multiple times
     (e.g. reactions + comments + cooked events in a post detail) so GCS is
-    only signed once per key.
+    only signed once per key. Caches the in-flight Task so concurrent
+    awaits for the same key dedupe to one IAM call — matches the Promise
+    caching in src/lib/uploads.ts#createSignedUrlResolver.
     """
-    cache: Dict[str, Optional[str]] = {}
+    cache: Dict[str, "asyncio.Task[Optional[str]]"] = {}
 
     async def resolve(storage_key: Optional[str]) -> Optional[str]:
         if not storage_key:
             return None
-        if storage_key in cache:
-            return cache[storage_key]
-        result = await get_signed_upload_url(storage_key)
-        cache[storage_key] = result
-        return result
+        task = cache.get(storage_key)
+        if task is None:
+            task = asyncio.ensure_future(get_signed_upload_url(storage_key))
+            cache[storage_key] = task
+        return await task
 
     return resolve

--- a/apps/api/tests/integration/test_comments.py
+++ b/apps/api/tests/integration/test_comments.py
@@ -21,7 +21,7 @@ class TestListComments:
             text=text,
             photoUrl=None,
             createdAt=now,
-            author=SimpleNamespace(id=author_id, name=f"User {author_id}", avatarUrl=None),
+            author=SimpleNamespace(id=author_id, name=f"User {author_id}", avatarStorageKey=None),
         )
 
     def test_list_comments_success(self, client, mock_prisma, member_auth):
@@ -55,17 +55,17 @@ class TestListComments:
                 SimpleNamespace(
                     targetId="c1",
                     emoji="❤️",
-                    user=SimpleNamespace(id="u1", name="Alice", avatarUrl=None),
+                    user=SimpleNamespace(id="u1", name="Alice", avatarStorageKey=None),
                 ),
                 SimpleNamespace(
                     targetId="c1",
                     emoji="❤️",
-                    user=SimpleNamespace(id="u2", name="Bob", avatarUrl=None),
+                    user=SimpleNamespace(id="u2", name="Bob", avatarStorageKey=None),
                 ),
                 SimpleNamespace(
                     targetId="c1",
                     emoji="👍",
-                    user=SimpleNamespace(id="u3", name="Cara", avatarUrl=None),
+                    user=SimpleNamespace(id="u3", name="Cara", avatarStorageKey=None),
                 ),
             ]
         )
@@ -97,7 +97,7 @@ class TestCreateComment:
             text=text,
             photoUrl=photo_url,
             createdAt=now,
-            author=SimpleNamespace(id="user-1", name="Test User", avatarUrl=None),
+            author=SimpleNamespace(id="user-1", name="Test User", avatarStorageKey=None),
         )
 
     def test_create_comment_text_only(self, client, mock_prisma, member_auth):

--- a/apps/api/tests/integration/test_family.py
+++ b/apps/api/tests/integration/test_family.py
@@ -63,7 +63,7 @@ def test_list_members_success(client, mock_prisma, member_auth):
                 "email": user.email,
                 "username": user.username,
                 "emailOrUsername": user.email,
-                "avatarUrl": None,
+                "avatarUrl": f"/uploads/{user.avatarStorageKey}",
                 "role": "admin",
                 "joinedAt": _NOW.isoformat(),
                 "postCount": 1,

--- a/apps/api/tests/integration/test_family.py
+++ b/apps/api/tests/integration/test_family.py
@@ -47,7 +47,7 @@ def _make_membership(user: SimpleNamespace, **overrides) -> SimpleNamespace:
 
 
 def test_list_members_success(client, mock_prisma, member_auth):
-    user = _make_user(idx=1, posts=[SimpleNamespace(id="p1")])
+    user = _make_user(idx=1, avatarStorageKey="avatars/avatar-1.jpg", posts=[SimpleNamespace(id="p1")])
     membership = _make_membership(user, role="admin")
     mock_prisma.familymembership.find_many = AsyncMock(return_value=[membership])
 
@@ -63,7 +63,7 @@ def test_list_members_success(client, mock_prisma, member_auth):
                 "email": user.email,
                 "username": user.username,
                 "emailOrUsername": user.email,
-                "avatarUrl": f"/uploads/{user.avatarStorageKey}",
+                "avatarUrl": "/uploads/avatars/avatar-1.jpg",
                 "role": "admin",
                 "joinedAt": _NOW.isoformat(),
                 "postCount": 1,

--- a/apps/api/tests/integration/test_posts.py
+++ b/apps/api/tests/integration/test_posts.py
@@ -849,8 +849,18 @@ class TestCookedEvents:
     def test_list_cooked_success(self, client, mock_prisma, member_auth):
         mock_prisma.cookedevent.find_many = AsyncMock(
             return_value=[
-                self._event("e1", rating=5, note=None, user=SimpleNamespace(id="u1")),
-                self._event("e2", rating=None, note="nice", user=SimpleNamespace(id="u2")),
+                self._event(
+                    "e1",
+                    rating=5,
+                    note=None,
+                    user=SimpleNamespace(id="u1", name="Alice", avatarStorageKey="avatars/a.jpg", passwordHash="secret"),
+                ),
+                self._event(
+                    "e2",
+                    rating=None,
+                    note="nice",
+                    user=SimpleNamespace(id="u2", name="Bob", avatarStorageKey=None, passwordHash="secret"),
+                ),
             ]
         )
 
@@ -859,12 +869,25 @@ class TestCookedEvents:
         assert response.status_code == 200, response.json()
         body = response.json()
         assert len(body["cookedEvents"]) == 2
+        assert body["cookedEvents"][0]["user"] == {
+            "id": "u1",
+            "name": "Alice",
+            "avatarUrl": "/uploads/avatars/a.jpg",
+        }
+        assert body["cookedEvents"][1]["user"] == {"id": "u2", "name": "Bob", "avatarUrl": None}
+        # Confirm the raw User model is not leaked (no passwordHash / avatarStorageKey)
+        raw = response.text
+        assert "passwordHash" not in raw
+        assert "avatarStorageKey" not in raw
         assert body["hasMore"] is False
         assert body["nextOffset"] == 2
 
     def test_list_cooked_pagination(self, client, mock_prisma, member_auth):
         mock_prisma.cookedevent.find_many = AsyncMock(
-            return_value=[self._event("e1"), self._event("e2")]
+            return_value=[
+                self._event("e1", user=SimpleNamespace(id="u1", name="A", avatarStorageKey=None)),
+                self._event("e2", user=SimpleNamespace(id="u2", name="B", avatarStorageKey=None)),
+            ]
         )
 
         response = client.get(f"/posts/{POST_ID}/cooked?limit=1", headers=member_auth)

--- a/apps/api/tests/integration/test_posts.py
+++ b/apps/api/tests/integration/test_posts.py
@@ -197,7 +197,7 @@ class TestGetPostDetail:
             updatedAt=now,
             mainPhotoUrl=None,
             authorId=author_id,
-            author=SimpleNamespace(id=author_id, name="Alice", avatarUrl=None),
+            author=SimpleNamespace(id=author_id, name="Alice", avatarStorageKey=None),
             editor=None,
             lastEditNote=None,
             lastEditAt=None,
@@ -242,14 +242,14 @@ class TestGetPostDetail:
                     text="Nice",
                     photoUrl=None,
                     createdAt=now,
-                    author=SimpleNamespace(id="u1", name="Bob", avatarUrl=None),
+                    author=SimpleNamespace(id="u1", name="Bob", avatarStorageKey=None),
                 ),
                 SimpleNamespace(
                     id="c2",
                     text="Great",
                     photoUrl=None,
                     createdAt=now,
-                    author=SimpleNamespace(id="u2", name="Ann", avatarUrl=None),
+                    author=SimpleNamespace(id="u2", name="Ann", avatarStorageKey=None),
                 ),
             ]
         )
@@ -271,9 +271,9 @@ class TestGetPostDetail:
         mock_prisma.favorite.find_unique = AsyncMock(return_value=None)
         mock_prisma.reaction.find_many = AsyncMock(
             return_value=[
-                SimpleNamespace(emoji="❤️", user=SimpleNamespace(id="u1", name="Bob", avatarUrl=None), targetType="post", targetId="post-1"),
-                SimpleNamespace(emoji="❤️", user=SimpleNamespace(id="u2", name="Sue", avatarUrl=None), targetType="post", targetId="post-1"),
-                SimpleNamespace(emoji="👍", user=SimpleNamespace(id="u3", name="Eve", avatarUrl=None), targetType="post", targetId="post-1"),
+                SimpleNamespace(emoji="❤️", user=SimpleNamespace(id="u1", name="Bob", avatarStorageKey=None), targetType="post", targetId="post-1"),
+                SimpleNamespace(emoji="❤️", user=SimpleNamespace(id="u2", name="Sue", avatarStorageKey=None), targetType="post", targetId="post-1"),
+                SimpleNamespace(emoji="👍", user=SimpleNamespace(id="u3", name="Eve", avatarStorageKey=None), targetType="post", targetId="post-1"),
             ]
         )
 
@@ -304,8 +304,8 @@ class TestGetPostDetail:
         mock_prisma.cookedevent.find_many = AsyncMock(
             side_effect=[
                 [
-                    SimpleNamespace(id="k1", rating=5, note=None, createdAt=now, user=SimpleNamespace(id="u1", name="Bob", avatarUrl=None)),
-                    SimpleNamespace(id="k2", rating=3, note=None, createdAt=now, user=SimpleNamespace(id="u2", name="Ann", avatarUrl=None)),
+                    SimpleNamespace(id="k1", rating=5, note=None, createdAt=now, user=SimpleNamespace(id="u1", name="Bob", avatarStorageKey=None)),
+                    SimpleNamespace(id="k2", rating=3, note=None, createdAt=now, user=SimpleNamespace(id="u2", name="Ann", avatarStorageKey=None)),
                 ],
                 [SimpleNamespace(id="k1", rating=5, note=None, createdAt=now), SimpleNamespace(id="k2", rating=3, note=None, createdAt=now)],
             ]
@@ -404,7 +404,7 @@ class TestUpdatePost:
             updatedAt=now,
             mainPhotoUrl=main_photo_url,
             authorId=author_id,
-            author=SimpleNamespace(id=author_id, name="Alice", avatarUrl=None),
+            author=SimpleNamespace(id=author_id, name="Alice", avatarStorageKey=None),
             editor=None,
             lastEditNote=last_edit_note,
             lastEditAt=last_edit_at or now,

--- a/apps/api/tests/integration/test_recipes.py
+++ b/apps/api/tests/integration/test_recipes.py
@@ -15,7 +15,7 @@ def _make_author(idx: int = 1, **overrides) -> SimpleNamespace:
     data = {
         "id": f"author-{idx}",
         "name": f"Chef {idx}",
-        "avatarUrl": f"https://cdn.test/avatar-{idx}.jpg",
+        "avatarStorageKey": f"avatars/avatar-{idx}.jpg",
     }
     data.update(overrides)
     return SimpleNamespace(**data)

--- a/apps/api/tests/integration/test_timeline.py
+++ b/apps/api/tests/integration/test_timeline.py
@@ -16,7 +16,7 @@ class TestTimelineRouter:
         return BASE_TIME + timedelta(minutes=minutes)
 
     def _actor(self, suffix: str = "1") -> SimpleNamespace:
-        return SimpleNamespace(id=f"user-{suffix}", name=f"User {suffix}", avatarUrl=f"https://cdn.test/{suffix}.jpg")
+        return SimpleNamespace(id=f"user-{suffix}", name=f"User {suffix}", avatarStorageKey=f"avatars/{suffix}.jpg")
 
     def _post(
         self,
@@ -235,7 +235,11 @@ class TestTimelineRouter:
 
         assert response.status_code == 200, response.json()
         item = response.json()["items"][0]
-        assert item["actor"] == {"id": actor.id, "name": actor.name, "avatarUrl": actor.avatarUrl}
+        assert item["actor"] == {
+            "id": actor.id,
+            "name": actor.name,
+            "avatarUrl": f"/uploads/{actor.avatarStorageKey}",
+        }
 
     def test_timeline_includes_post_summary(self, client, mock_prisma, member_auth):
         reaction = self._reaction(post=self._post_summary("post-summary", "Summary"), created_at=self._ts(4))

--- a/apps/api/tests/unit/test_uploads.py
+++ b/apps/api/tests/unit/test_uploads.py
@@ -14,6 +14,8 @@ from src.uploads import (
     _sign_string_with_iam,
     _generate_signed_url_v4,
     _upload_to_gcs,
+    create_signed_url_resolver,
+    get_signed_upload_url,
     save_photo_file,
     delete_uploads,
 )
@@ -641,3 +643,76 @@ class TestEdgeCases:
 
         with pytest.raises(ValueError, match="FILE_TOO_LARGE"):
             await save_photo_file(mock_file)
+
+
+# =============================================================================
+# Signed URL Helper Tests (read side)
+# =============================================================================
+
+
+class TestGetSignedUploadUrl:
+    @pytest.mark.asyncio
+    async def test_returns_none_for_falsy_key(self):
+        assert await get_signed_upload_url(None) is None
+        assert await get_signed_upload_url("") is None
+
+    @pytest.mark.asyncio
+    async def test_returns_local_path_without_bucket(self):
+        with patch("src.uploads.settings") as mock_settings:
+            mock_settings.uploads_bucket = ""
+
+            assert await get_signed_upload_url("avatars/foo.jpg") == "/uploads/avatars/foo.jpg"
+
+    @pytest.mark.asyncio
+    async def test_returns_signed_url_with_bucket(self):
+        with patch("src.uploads.settings") as mock_settings:
+            mock_settings.uploads_bucket = "test-bucket"
+            mock_settings.uploads_signed_url_ttl_seconds = 3600
+
+            with patch("src.uploads._get_gcp_access_token", return_value="token"):
+                with patch("src.uploads._fetch_metadata", return_value="sa@gcp.com"):
+                    with patch(
+                        "src.uploads._generate_signed_url_v4",
+                        return_value="https://signed.example/foo",
+                    ) as mock_sign:
+                        result = await get_signed_upload_url("photo.jpg")
+
+            assert result == "https://signed.example/foo"
+            mock_sign.assert_called_once()
+            assert mock_sign.call_args.kwargs["object_key"] == "photo.jpg"
+            assert mock_sign.call_args.kwargs["bucket"] == "test-bucket"
+            assert mock_sign.call_args.kwargs["expires_in_seconds"] == 3600
+
+
+class TestCreateSignedUrlResolver:
+    @pytest.mark.asyncio
+    async def test_returns_none_for_falsy_key(self):
+        resolve = create_signed_url_resolver()
+
+        assert await resolve(None) is None
+        assert await resolve("") is None
+
+    @pytest.mark.asyncio
+    async def test_memoizes_calls_per_key(self):
+        with patch("src.uploads.settings") as mock_settings:
+            mock_settings.uploads_bucket = ""
+            resolve = create_signed_url_resolver()
+
+            with patch("src.uploads.get_signed_upload_url", new=AsyncMock(return_value="/uploads/x")) as mock_get:
+                first = await resolve("x")
+                second = await resolve("x")
+                other = await resolve("y")
+
+        assert first == "/uploads/x"
+        assert second == "/uploads/x"
+        assert other == "/uploads/x"
+        # "x" resolved once (cached), "y" resolved once → two total
+        assert mock_get.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_surfaces_resolver_errors(self):
+        resolve = create_signed_url_resolver()
+
+        with patch("src.uploads.get_signed_upload_url", new=AsyncMock(side_effect=RuntimeError("boom"))):
+            with pytest.raises(RuntimeError, match="boom"):
+                await resolve("broken-key")

--- a/apps/api/tests/unit/test_uploads.py
+++ b/apps/api/tests/unit/test_uploads.py
@@ -694,20 +694,38 @@ class TestCreateSignedUrlResolver:
 
     @pytest.mark.asyncio
     async def test_memoizes_calls_per_key(self):
-        with patch("src.uploads.settings") as mock_settings:
-            mock_settings.uploads_bucket = ""
-            resolve = create_signed_url_resolver()
+        resolve = create_signed_url_resolver()
 
-            with patch("src.uploads.get_signed_upload_url", new=AsyncMock(return_value="/uploads/x")) as mock_get:
-                first = await resolve("x")
-                second = await resolve("x")
-                other = await resolve("y")
+        async def fake(key):
+            return f"/uploads/{key}"
+
+        with patch("src.uploads.get_signed_upload_url", new=AsyncMock(side_effect=fake)) as mock_get:
+            first = await resolve("x")
+            second = await resolve("x")
+            other = await resolve("y")
 
         assert first == "/uploads/x"
         assert second == "/uploads/x"
-        assert other == "/uploads/x"
+        assert other == "/uploads/y"
         # "x" resolved once (cached), "y" resolved once → two total
         assert mock_get.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_dedupes_concurrent_awaits_for_same_key(self):
+        import asyncio
+
+        resolve = create_signed_url_resolver()
+
+        async def fake(key):
+            await asyncio.sleep(0)  # yield so both resolvers can reach the cache miss
+            return f"/uploads/{key}"
+
+        with patch("src.uploads.get_signed_upload_url", new=AsyncMock(side_effect=fake)) as mock_get:
+            a, b = await asyncio.gather(resolve("shared"), resolve("shared"))
+
+        assert a == "/uploads/shared"
+        assert b == "/uploads/shared"
+        assert mock_get.await_count == 1
 
     @pytest.mark.asyncio
     async def test_surfaces_resolver_errors(self):


### PR DESCRIPTION
## Summary
- Adds `get_signed_upload_url` + `create_signed_url_resolver` to [apps/api/src/uploads.py](apps/api/src/uploads.py), mirroring the Next [getSignedUploadUrl](src/lib/uploads.ts) / `createSignedUrlResolver` pair (local `/uploads/<key>` when `UPLOADS_BUCKET` is unset, V4-signed GCS URL otherwise). Resolver caches the in-flight `asyncio.Task` so concurrent awaits for the same key dedupe to one IAM call — matches the TS Promise caching.
- Every FastAPI router that returned a user/author block now reads `.avatarStorageKey` via `getattr(...)` and resolves through the helper: `dependencies.py`, `auth.py` (signup + login), `me.py` (`/me/profile`), `family.py` (`/family/members`), `posts.py` (`_load_post_detail`, `/posts/{id}/cooked` POST + GET), `comments.py` (list + create), `timeline.py`, `recipes.py`. Per-request resolver used in the multi-user endpoints so GCS is only signed once per key.
- **Drive-by fix**: `GET /posts/{id}/cooked` was returning `e.user` unmodified — with the regenerated Prisma Python client that serializes the full User row (including `passwordHash`). Normalized to the same `{id, name, avatarUrl}` shape the Next endpoint returns and added an assertion that `passwordHash` / `avatarStorageKey` can never appear in the response body.
- Integration fixtures swept: `SimpleNamespace(..., avatarUrl=...)` → `SimpleNamespace(..., avatarStorageKey=...)` — the old pattern attached a non-Prisma attribute which masked the AttributeError. `test_list_members_success` assertion hard-codes the expected resolved path.

Closes #82. Follow-up to #74.

## Test plan
- [x] `pytest apps/api/tests/` — **306 pass** (up from 299; new coverage: helper falsy key / local passthrough / GCS path, resolver memoization keyed by input, concurrent-await dedup, error propagation, `list_cooked` shape normalization).
- [x] `ruff check apps/api/src apps/api/tests` — clean.
- [x] `npm test` — 963 pass.
- [x] Regenerated the Python Prisma client from `prisma/schema.postgres.prisma` and confirmed `User.avatarStorageKey` exists (the field the old code was missing).
- [ ] **Live smoke test deferred.** Local `.env` DATABASE_URL points at an unreachable host, and no standardized sandbox creds exist yet. Tracked in #76 (rewritten to cover the turnkey local-stack script that would unblock this). Reviewer should run the curl + contract-parity diff from [docs/verification/fastapi.md](docs/verification/fastapi.md) before merging.
- [ ] `mypy apps/api/src` — one pre-existing error (`prisma.models` import stub missing in `recipes.py`), unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)