### PR TITLE
fix(deploy): mint dev smoke-check ID token via impersonation (#93)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -161,10 +161,18 @@ jobs:
 
       - name: Smoke check /api/health
         id: smoke_check
+        env:
+          DEPLOYER_SA_EMAIL: ${{ secrets.DEV_GCP_DEPLOYER_SA }}
         run: |
           URI="$(gcloud run services describe "$CLOUD_RUN_SERVICE" --project "$PROJECT_ID" --region "$REGION" --format='value(status.url)')"
-          # Dev service requires auth (--no-allow-unauthenticated); mint an ID token for the deployer SA.
-          TOKEN="$(gcloud auth print-identity-token --audiences="$URI")"
+          # Dev service requires auth (--no-allow-unauthenticated). Under WIF the active
+          # gcloud credential is an access token, which `print-identity-token --audiences`
+          # rejects; --impersonate-service-account routes the mint through the
+          # iamcredentials.generateIdToken API instead (authorized by the deployer SA's
+          # self-binding of roles/iam.serviceAccountTokenCreator).
+          TOKEN="$(gcloud auth print-identity-token \
+            --impersonate-service-account="$DEPLOYER_SA_EMAIL" \
+            --audiences="$URI")"
           for i in {1..20}; do
             STATUS="$(curl -sS -H "Authorization: Bearer $TOKEN" -o /dev/null -w '%{http_code}' "$URI/api/health" || true)"
             if [ "$STATUS" = "200" ]; then


### PR DESCRIPTION
## Summary

- Dev smoke check added in #71/#90 was failing with \`ERROR: (gcloud.auth.print-identity-token) Invalid account type for \`--audiences\`. Requires valid service account.\`
- Root cause: under WIF, \`google-github-actions/auth@v2\` leaves gcloud authenticated via an access token. \`gcloud auth print-identity-token --audiences=...\` expects a key-file-based SA credential for local signing and rejects access-token credentials.
- Fix: pass \`--impersonate-service-account="\$DEPLOYER_SA_EMAIL"\` so the mint routes through \`iamcredentials.generateIdToken\` instead. No IAM change needed — the deployer SA self-binding of \`roles/iam.serviceAccountTokenCreator\` added in #71 already authorizes this API call.
- Also expose \`DEPLOYER_SA_EMAIL\` on the smoke-check step via \`env:\` (derived from \`secrets.DEV_GCP_DEPLOYER_SA\`) so the shell has it available.

## Closes

Closes #93

## Test notes

- **On first dev deploy after #90 merged, the rollback step fired as designed** — dev is currently serving the previous revision. This PR is purely about fixing the smoke check so future dev deploys don't hit the same mint error.
- \`npm run type-check\` clean (no app code touched).
- Confidence in the fix: the error message explicitly calls out "Requires valid service account" on \`--audiences\`. Cross-referencing gcloud docs, \`--impersonate-service-account\` is the documented workaround for access-token credentials. The IAM binding needed is already applied.
- Verification on next develop merge: confirm the smoke check returns 200, confirm rollback does **not** fire, confirm dev \`/api/health\` serves the new revision.
- Not changing prod (\`deploy-prod.yml\` deploys with \`--allow-unauthenticated\`, so no token minting needed — unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)