### PR TITLE
chore(#85): release-testing skill + dev-deployment verification playbook

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: pr-review
+description: Review a GitHub PR in this repo against its linked issue(s), repo conventions in .github/GITHUB_GUIDE.md, and code quality. Use when the user says /pr-review, asks to review a PR, or hands you a PR number/URL.
+---
+
+# PR Review
+
+Produce a structured, comment-ready review of a pull request in `wnorowskie/family-recipe`. Anchor feedback in the linked issue's acceptance criteria and the repo's documented conventions — not generic code-review platitudes.
+
+## Resolving the target PR
+
+Accept any of: PR number (`12`), full URL, or branch name. If the user gave none, default to the PR for the current branch.
+
+```bash
+gh pr view --json number,title,body,headRefName,baseRefName,author,state,url
+```
+
+If no PR exists for the current branch, stop and tell the user — do not guess.
+
+## Step 1 — Fetch in parallel
+
+Make these calls in a single message:
+
+- `mcp__github__pull_request_read` (or `gh pr view <N> --json number,title,body,headRefName,baseRefName,author,state,url,commits,files`) — PR metadata + commits + files
+- `gh pr diff <N>` — full diff
+- `gh pr view <N> --comments` — existing review comments (avoid duplicating prior feedback)
+
+## Step 2 — Resolve linked issues
+
+Parse the PR body for `Closes #N`, `Fixes #N`, `Resolves #N`. Also extract the issue number from the branch name pattern `{type}/{N}/short-description`. Union both sets.
+
+For each issue, fetch via `mcp__github__issue_read` or `gh issue view <N> --json number,title,body,labels,milestone,state`. Extract:
+
+- The acceptance criteria / "Definition of done" section
+- `type:` label — must match the branch and PR title prefix
+- `phase:` and `area:` labels for context
+- Milestone — should match the issue's phase
+
+If the PR closes nothing, flag it: every PR in this repo should close an issue.
+
+## Step 3 — Convention checks
+
+Source of truth is [.github/GITHUB_GUIDE.md](../../../.github/GITHUB_GUIDE.md). Verify:
+
+| Check               | Rule                                                                                                                 |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Branch name         | `{type}/{N}/short-description` where `type` ∈ {`feature`, `research`, `chore`} and matches the issue's `type:` label |
+| PR title            | `{type}: {issue title} (#{N})` — type prefix matches the issue                                                       |
+| PR body             | Has `## Summary`, `## Closes` with `Closes #N`, `## Test notes`                                                      |
+| Commits             | Every commit on the branch matches `{type}: {description} (#{N})` and references the issue                           |
+| Research PRs        | Add a `docs/research/{topic}.md` that answers the questions listed in the issue                                      |
+| Direct main commits | None — work must merge via PR                                                                                        |
+
+Read [.github/TICKET_FORMAT.md](../../../.github/TICKET_FORMAT.md) only if the issue body looks malformed.
+
+## Step 4 — Review the diff
+
+For each acceptance criterion in the issue, mark **met / partial / missing** with a one-line justification grounded in a specific file:line.
+
+Then scan the diff for:
+
+- **Scope creep** — changes not traceable to the issue's acceptance criteria
+- **Missing scope** — acceptance criteria with no corresponding diff
+- **Bugs / correctness** — obvious logic errors, off-by-ones, unhandled error paths at system boundaries
+- **Security** — secrets in code, SQL injection, command injection, unauthenticated endpoints (relevant once `apps/api` exists)
+- **Tests** — for `feature` and `fix` PRs, are there tests? For `research` and `docs`, skip
+- **Dead code / over-engineering** — premature abstractions, unused exports, future-proofing
+- **Repo-specific** — tech stack matches the documented stack in `CLAUDE.md`; no YouTube ingestion; no live-analysis features in MVP; recall-over-precision for action proposal code
+- **Docs-only PRs** — factual accuracy, internal consistency, broken relative links
+
+## Step 5 — Output
+
+Print a single review in this exact shape. Do not wrap it in extra prose.
+
+```markdown
+# PR #<N> — <title>
+
+**Linked issue(s):** #<N> — <title>
+**Branch:** <branch> • **Author:** <author> • **Base:** <base>
+
+## Issue alignment
+
+- [criterion] — ✅ met · file:line
+- [criterion] — ⚠️ partial · file:line — <what's missing>
+- [criterion] — ❌ missing
+
+## Convention checks
+
+- Branch name: ✅ / ❌ <reason>
+- PR title: ✅ / ❌
+- PR body template: ✅ / ❌
+- Commit messages: ✅ / ❌ <which commits fail>
+- Closes link: ✅ / ❌
+
+## Code feedback
+
+- `path/to/file.ts:42` — <specific issue, with suggested fix if obvious>
+- ...
+
+## Out of scope / scope creep
+
+- <changes not covered by the issue, or note "none">
+
+## Suggested next steps
+
+- <ordered, concrete actions before merge — or "ready to merge">
+```
+
+After printing, ask the user whether to post the review:
+
+> Post this as a PR comment? (`gh pr comment <N> -F -` or `mcp__github__pull_request_review_write`)
+
+Do **not** post automatically — leave that as an explicit user decision.
+
+## Style rules
+
+- Be terse. Bullets, not paragraphs. No restating the diff back.
+- Every code-feedback bullet must cite `file:line`. If you can't, you don't have the evidence yet.
+- Mark certainty: distinguish "this is wrong" from "worth a second look."
+- Don't critique style choices the repo hasn't taken a position on.
+- Skip anything already covered in existing review comments.

--- a/.claude/skills/release-testing/SKILL.md
+++ b/.claude/skills/release-testing/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: release-testing
+description: Pre-merge verification for `develop → main` release PRs against the live dev Cloud Run deployment. Use whenever the user says `/release-testing`, "test the release PR", "verify develop→main", "smoke the dev deploy before shipping", or hands you a PR number/URL whose base branch is `main`. The skill fetches the release PR's commit range and linked issues, triages the cumulative diff into impact areas (UI, Next API, importer, Prisma schema, infra), confirms the dev Postgres is running, populates `.env.dev.local` from GSM, runs `npm run smoke:dev` end-to-end against the live dev deployment, adds targeted probes for any area the smoke script doesn't cover, and posts a structured markdown report as a PR comment. Paired with and complementary to the `test-pr` skill — that one verifies feature PRs against the local sandbox; this one verifies release PRs against the deployed artifact.
+---
+
+# release-testing — pre-merge smoke of a release PR against dev
+
+Runs the dev-deployment verification playbook ([docs/verification/dev-deployments.md](../../../docs/verification/dev-deployments.md)) against a specific `develop → main` PR, then reports back on the PR. The signal this produces is **"the deploy pipeline works for these changes"** — not "the code is correct" (that's what `/test-pr` + CI already established).
+
+## Scope boundary
+
+Local verification (the per-service playbooks) proves the code works as written. CI proves the type checker, tests, and docker build are happy. This skill proves the _next_ link: the `develop`-branch build, the Prisma migration against the real dev database, and the Cloud Run env-var wiring. Catching a bug here averts a broken `main` merge and a hasty rollback.
+
+## When to use this skill
+
+**Use it for:** PRs whose base branch is `main` (release PRs). The user typically opens these after a sprint of feature work has landed on `develop` and wants one more signal before cutting.
+
+**Do NOT use it for:**
+
+- Feature PRs targeting `develop` — use the `test-pr` skill instead.
+- Hotfix-to-`main` PRs — the feature-PR flow applies; don't run against the live dev service mid-incident.
+- Any PR where the dev Postgres has been paused for so long it's diverged from the `main` schema — run migrations first via the deploy workflow, then smoke.
+
+**Guardrail check.** If `baseRefName != main`, stop and tell the user this skill is for release PRs; hand off to `/test-pr`.
+
+## Inputs
+
+Accept any of:
+
+- PR number: `/release-testing 123`
+- PR URL: `/release-testing https://github.com/wnorowskie/family-recipe/pull/123`
+- No argument — default to the open PR whose head is `develop` and base is `main`; otherwise ask.
+
+## Prerequisites
+
+Before the first invocation, the user needs to have run through the one-time setup in [docs/verification/dev-deployments.md](../../../docs/verification/dev-deployments.md):
+
+1. `roles/iam.serviceAccountTokenCreator` on `family-recipe-deployer@`.
+2. `.env.dev.local` populated (URLs, SA, `CLAUDE_TEST_USER`).
+3. `CLAUDE_TEST_PASSWORD` either in `.env.dev.local` or fetched from GSM at session start.
+
+If any of these is missing, **stop and surface the exact `gcloud` one-liner to fix it** — don't try to skip around.
+
+## Workflow
+
+Run these steps in order. Produce a partial report with an honest "could not verify" section if a step blocks you; never fabricate a pass.
+
+### 1. Fetch the PR + commit range + linked issues
+
+```bash
+gh pr view <n> --json number,title,body,headRefName,baseRefName,state,isDraft,mergeable,url,files,commits
+gh pr diff <n>
+gh pr checks <n>
+```
+
+The body of a release PR usually lists the feature PRs it bundles (`#102, #104, #107…`). Fetch each one to understand the cumulative scope:
+
+```bash
+gh pr view 102 --json title,body,files
+```
+
+For each referenced issue (`Closes #N`, or issue numbers in the commit messages), read the acceptance criteria and map them to verification steps — same as `test-pr`, but across **all** commits in the range, not a single PR.
+
+### 2. Triage the cumulative diff into impact areas
+
+```bash
+gh pr diff <n> --name-only   # or: git diff --name-only origin/main...origin/develop
+```
+
+Map the file list to areas:
+
+| File glob                                                                  | Area     | Dev coverage                                                                                     |
+| -------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------ |
+| `src/app/api/**/route.ts`                                                  | Next API | **Covered by `smoke:dev`** (login + post + comment + reaction + cleanup)                         |
+| `src/app/**` (non-api), `src/components/**`                                | UI       | Partial — see "UI limitations" below                                                             |
+| `apps/recipe-url-importer/**`                                              | Importer | Manual `/version` probe (see step 5)                                                             |
+| `apps/api/**`                                                              | FastAPI  | Not deployed to dev yet — skip with a note                                                       |
+| `prisma/schema*.prisma`, `prisma/migrations/**`                            | Prisma   | Migration already ran during `deploy-dev.yml`; smoke writes exercise it                          |
+| `.github/workflows/deploy-*.yml`, `infra/**`                               | Infra    | **Inspect the workflow diff carefully** — a change here changes the pipeline you're about to use |
+| `scripts/smoke-dev.sh`, `docs/verification/dev-deployments.md`, this skill | Tooling  | Self-test: run the skill against itself                                                          |
+
+### 3. Confirm the dev deployment is actually for the release SHA
+
+```bash
+# The latest revision should have been built from the head of `develop`.
+REV=$(gcloud run services describe family-recipe-dev \
+  --project family-recipe-dev --region us-east1 \
+  --format='value(status.traffic[0].revisionName)')
+# Cloud Run revisions are named like family-recipe-dev-00051-cv6 — the SHA
+# is visible in the Cloud Console or via:
+gcloud run revisions describe "$REV" \
+  --project family-recipe-dev --region us-east1 \
+  --format='value(spec.containers[0].image)'
+```
+
+The image tag is the commit SHA. Compare to `git rev-parse origin/develop`. If they don't match, the deploy workflow is still running or failed — check `gh run list --workflow=deploy-dev.yml` before continuing; running the smoke against a stale revision tests the wrong artifact.
+
+### 4. Confirm infrastructure state
+
+```bash
+# Is the dev Postgres running?
+gcloud sql instances describe family-recipe-dev \
+  --project family-recipe-dev \
+  --format='value(state,settings.activationPolicy)'
+# Want: RUNNABLE ALWAYS
+```
+
+If the instance is stopped (`STOPPED NEVER`), start it:
+
+```bash
+gcloud sql instances patch family-recipe-dev \
+  --project family-recipe-dev --activation-policy=ALWAYS --quiet
+# Patch returns in ~15s, but the instance takes an additional ~2–3 min
+# to come up. Poll `gcloud sql instances describe ...` until state is
+# `RUNNABLE ALWAYS` before running the smoke — /api/health fails fast
+# against a still-starting DB and wastes a review iteration.
+```
+
+### 5. Run the smoke script
+
+```bash
+# From repo root, with .env.dev.local populated
+npm run smoke:dev
+```
+
+The script is in [scripts/smoke-dev.sh](../../../scripts/smoke-dev.sh). All-green exit 0 = Next.js dev service auth + DB round-trip + Post/Comment/Reaction writes + cascade delete all work on the **live revision**.
+
+For areas the smoke script doesn't cover, add these probes (mint tokens per audience — don't reuse across services):
+
+```bash
+source .env.dev.local
+
+# Importer — different audience
+IMP_TOKEN=$(gcloud auth print-identity-token \
+  --impersonate-service-account="$DEV_DEPLOYER_SA" \
+  --audiences="$DEV_IMPORTER_URL")
+curl -sS -H "Authorization: Bearer $IMP_TOKEN" "$DEV_IMPORTER_URL/version"
+# → {"service":"recipe-url-importer","version":"...","git_sha":"..."}
+
+# Read-only Next probes (reuse the smoke script's login flow if you need
+# a session; otherwise just check unauthenticated gating)
+NEXT_TOKEN=$(gcloud auth print-identity-token \
+  --impersonate-service-account="$DEV_DEPLOYER_SA" \
+  --audiences="$DEV_NEXT_URL")
+curl -sS -H "Authorization: Bearer $NEXT_TOKEN" -w 'HTTP %{http_code}\n' \
+  "$DEV_NEXT_URL/api/timeline"   # expect 401 without session cookie
+```
+
+### 6. UI verification — limitations and options
+
+Dev Cloud Run runs `--no-allow-unauthenticated`, so a browser cannot load the UI directly: every request (including CSS/JS chunks) needs a Bearer ID token, and browsers don't attach auth headers to subresource loads. Options, in order of preference:
+
+1. **Trust local Playwright** — if local `npm run test:e2e` (or Playwright MCP against `localhost:3000` with the sandbox stack) passed against the release branch, that's the strongest UI signal available today.
+2. **HTML-grep via curl** — fetch a key page as raw HTML and grep for expected strings. This misses hydration bugs but catches "server-rendered output changed unexpectedly":
+   ```bash
+   curl -sS -H "Authorization: Bearer $NEXT_TOKEN" -b /tmp/fr-dev-cookies.txt \
+     "$DEV_NEXT_URL/timeline" | grep -c "<title>"   # expect ≥1
+   ```
+3. **Skip honestly.** If the release includes hydration-sensitive UI changes and neither option 1 nor 2 is sufficient, the report's "Could not verify" section names it.
+
+Improving dev UI coverage (auth-injecting proxy, IAP, or a signed-URL wrapper) is tracked separately — don't try to build it inside the skill.
+
+### 7. Clean up
+
+The smoke script cleans up its own test post via an EXIT trap. The only leftover is `/tmp/fr-dev-cookies.txt` — harmless; leave it or `rm -f` it. Do **not** stop the dev DB at the end unless the user asks; other sessions may need it.
+
+### 8. Post the report
+
+The deliverable is a markdown comment on the release PR. Use the template below. Post it with:
+
+```bash
+gh pr comment <n> --body-file /tmp/release-report.md
+```
+
+## Hard guardrails
+
+Absolute. Violating any of these turns the skill into a liability:
+
+- **Never run against prod.** `main`-branch Cloud Run is for the real family. The skill's URLs are the dev ones, hard-coded; don't swap them to prod because "there's no dev yet for X".
+- **Never skip the `baseRefName == main` check.** Running release-testing against a feature PR pollutes dev with writes meant for the sandbox; hand off to `/test-pr` instead.
+- **Never mint a fake ID token or re-use a stale one across audiences.** The `--audiences` flag must match the target Cloud Run URL exactly; a token for `$DEV_NEXT_URL` will 401 against `$DEV_IMPORTER_URL`.
+- **Never suppress a non-zero smoke exit.** If `npm run smoke:dev` exits non-zero, that's the headline of the report — capture the failing step and stop. Cleanup already ran via the trap.
+- **Never stop the dev DB as a "tidy up" step.** Leaving it running is the default; stopping disrupts the next session and costs a 60s restart.
+- **Never invent endpoints.** If a probe returns 404, first verify the endpoint exists in the source (`grep -rn "app.get\|@app.post\|export const POST" apps/recipe-url-importer/src/ src/app/api/`). The importer's `/healthz` returned 404 during this skill's construction because the deployed revision didn't include it yet — the skill probes `/version` instead, which both code and the live revision have.
+- **Never paper over a missing prerequisite.** If `roles/iam.serviceAccountTokenCreator` isn't granted or `.env.dev.local` isn't populated, stop and surface the exact command from [dev-deployments.md](../../../docs/verification/dev-deployments.md). Silent fallbacks lead to later confusion.
+
+## Report template
+
+Paste-ready GitHub comment. Adjust the bullets to what was actually run.
+
+````markdown
+## Release Verification — <PR title> (#<n>)
+
+**Base:** `main` ← **head:** `develop` (sha `<short-sha>`)
+**Dev revision tested:** `<family-recipe-dev-000NN-xxx>` (image sha `<short>`)
+**CI on `develop`:** <green/red summary>
+
+### Cumulative scope
+
+- <one-liner per feature PR bundled in this release — `#102 feat: …`>
+- Areas touched: <Next API / UI / Importer / Prisma / Infra>
+
+### Dev smoke (`npm run smoke:dev`)
+
+```
+PASS  mint Bearer ID token
+PASS  GET /api/health → 200
+PASS  POST /api/auth/login → 200
+PASS  POST /api/posts → 201
+PASS  POST /api/posts/:id/comments → 201
+PASS  POST /api/reactions → 200
+PASS  GET /api/posts/:id → 200 (comments=1, reactions=1)
+PASS  DELETE /api/posts/:id → 200
+PASS  GET /api/posts/:id after delete → 404
+```
+
+_(or paste the failure line + stderr if any step failed)_
+
+### Additional probes
+
+- **Importer `/version`**: `{"service":"recipe-url-importer","version":"...","git_sha":"<sha>"}` ✅
+- **Timeline unauth gating**: `401` ✅ / `200` ❌ (leak!)
+- **HTML-grep /timeline**: found `<title>` ✅ / markup changed ❌
+
+### Infrastructure
+
+- Dev Postgres state: `RUNNABLE ALWAYS` ✅
+- Deployed revision matches `develop` HEAD: ✅ / ❌ (`<revision-sha>` vs `<develop-sha>`)
+- Deploy workflow (`deploy-dev.yml`) modified in this range: yes → inspected diff / no
+
+### Could not verify
+
+- <explicit list — e.g., "hydration-sensitive UI changes in `src/components/CommentThread.tsx`: dev ingress prevents browser loads; local Playwright was green on the release branch">
+
+### Recommendation
+
+**SHIP** — smoke green, invariants hold, deploy pipeline healthy.
+_(or)_ **HOLD** — <one-line reason with link to failing step or bad diff>.
+_(or)_ **BLOCKED** — <what's missing: DB stopped and won't start, deploy workflow red, secret missing>.
+
+---
+
+Posted by `/release-testing` · [skill source](.claude/skills/release-testing/SKILL.md) · [playbook](docs/verification/dev-deployments.md)
+````
+
+## When this skill runs against a different repo
+
+This one is intentionally not portable. The fixed URLs, SA names, GSM secret IDs, and smoke-script contract all live in `family-recipe-dev` and the `develop → main` branch convention. If you find yourself wanting to reuse this elsewhere, **copy it and adapt** — don't try to parameterize it into a one-size-fits-all dev-smoke skill. The test-pr skill's "when this runs against a different repo" section is a better model for that.

--- a/.claude/skills/test-pr/SKILL.md
+++ b/.claude/skills/test-pr/SKILL.md
@@ -1,0 +1,265 @@
+---
+name: test-pr
+description: End-to-end pull-request verification against a repo's local playbooks. Use whenever the user says `/test-pr`, "test this PR", "verify PR #N", "check PR before merge", "is this branch ready to ship", or hands you a PR number/URL and wants pre-merge signal beyond CI. The skill fetches the PR and linked issues, triages the diff into impact areas (UI, Next API, FastAPI, Prisma schema, recipe importer, infra), brings up the repo's local sandbox stack, runs the right verification layer per area (L0 curl, L1 real browser, L2 Playwright MCP), checks repo-specific invariants (family-scoping, dual-Prisma-schema lockstep, auth wrappers), and produces a structured markdown review report ready to paste into a PR comment. Trigger this even when the user doesn't explicitly say "skill" — any ask that maps to "verify a PR before merge" qualifies.
+---
+
+# test-pr — end-to-end PR verification
+
+Runs the repo's pre-merge verification playbooks against a specific PR and produces a structured, paste-ready markdown report. Built around the family-recipe repo's three-layer verification model (L0/L1/L2) but designed to degrade gracefully for repos without those playbooks.
+
+## When to use this skill
+
+**Use it for:** feature PRs headed for `develop` where the user wants more confidence than CI alone — a real run-through of the affected flows with cookies, data, and a browser where appropriate.
+
+**Do NOT use it for:**
+
+- Release PRs (`develop → main`) — those are the repo owner's call and go through a different review path.
+- Drive-by "does this look right" code reviews — use a code-review skill for that; this one runs the app.
+- PRs you can't check out locally — tell the user to `gh pr checkout <n>` first.
+
+## Inputs
+
+Accept any of:
+
+- PR number: `/test-pr 102`
+- PR URL: `/test-pr https://github.com/owner/repo/pull/102`
+- Branch name: `/test-pr feature/42/foo` — diff against `develop`
+- No argument — default to the current branch's open PR if one exists; otherwise ask.
+
+## Workflow
+
+Run these steps in order. Stop early and produce a partial report if a step reveals you cannot verify the PR (e.g., no local stack, no browser). Do **not** fabricate a pass — the "Could not verify" section is a first-class part of the report.
+
+### 1. Fetch the PR and its linked issues
+
+```bash
+gh pr view <n> --json number,title,body,headRefName,baseRefName,state,isDraft,mergeable,url,files
+gh pr diff <n>
+gh pr checks <n>
+```
+
+Parse the PR body for issue references (`Closes #42`, `#42`, etc.) and fetch each one:
+
+```bash
+gh issue view 42 --json title,body,labels
+```
+
+The issue's **Acceptance Criteria** (or **Tasks** for chore tickets) tell you what "done" looks like for this PR — map each criterion to a verification step.
+
+**Guardrail check.** If `baseRefName == main`, this is a release PR. Stop and tell the user this skill is for feature PRs targeting `develop`.
+
+### 2. Triage the diff into impact areas
+
+A PR can span multiple areas. Pick the union of playbooks.
+
+| File glob                                          | Area     | Playbook (in repo)                         |
+| -------------------------------------------------- | -------- | ------------------------------------------ |
+| `src/app/api/**/route.ts`                          | Next API | `docs/verification/next-api.md`            |
+| `src/app/**` (non-api), `src/components/**`        | UI       | `docs/verification/ui.md`                  |
+| `apps/api/**` (routers, schemas, deps)             | FastAPI  | `docs/verification/fastapi.md`             |
+| `apps/recipe-url-importer/**`                      | Importer | `docs/verification/recipe-url-importer.md` |
+| `prisma/schema*.prisma`, `prisma/migrations/**`    | Prisma   | `docs/verification/prisma.md`              |
+| `.github/workflows/**`, `terraform/**`, `infra/**` | Infra    | Inspect only — do not execute.             |
+| `__tests__/**`, `apps/*/tests/**`                  | Tests    | Run the affected suite; no playbook.       |
+
+**Read the matching playbook(s) from the repo before running commands.** Script names, ports, and flags drift over time; the playbooks in `docs/verification/` are the source of truth for commands. This SKILL.md is the source of truth for the _workflow_ and _invariants_.
+
+### 3. Check CI before re-running anything locally
+
+```bash
+gh pr checks <n>
+```
+
+Green `typecheck`/`lint`/`test`/`build` means skip those locally. Investigate any red check first — a CI failure is cheaper to fix than a local repro.
+
+### 4. Bring up the local sandbox
+
+Only if the diff touches runtime code. Docs-only PRs skip to step 7 (invariant checks) and step 10 (report).
+
+Always the sandbox — never the dev Postgres a real family is testing against:
+
+```bash
+scripts/local-stack-up.sh
+```
+
+This is idempotent. It creates a sandbox Postgres on `:5434`, runs Prisma generate + push + seed, generates the Python Prisma client for FastAPI, and writes `.env.sandbox`. It never mutates `.env` or `.env.local`.
+
+Start only the services the diff needs:
+
+```bash
+# Next (always if src/ or prisma/ changed)
+scripts/with-local-stack.sh npm run dev &
+until curl -sf http://localhost:3000 >/dev/null; do sleep 0.5; done
+
+# FastAPI (if apps/api/ changed OR doing a contract-parity check)
+scripts/with-local-stack.sh bash -c '
+  source apps/api/.venv/bin/activate
+  uvicorn apps.api.src.main:app --port 8000
+' &
+
+# Recipe importer (if apps/recipe-url-importer/ changed)
+cd apps/recipe-url-importer && source .venv/bin/activate && \
+  PYTHONPATH=src uvicorn --app-dir src recipe_url_importer.app:app --port 8001 &
+cd ../..
+```
+
+Port collision: FastAPI and the importer both default to `:8000`. Pick different ports (as shown) if both are needed.
+
+### 5. Log in once; reuse the cookie
+
+Never mint JWTs or fake cookies. The real login path exercises bcrypt verify + `jose` JWT signing + cookie issuance — that's part of what we're verifying.
+
+```bash
+COOKIES=$(scripts/claude-login.sh)                               # Next :3000
+COOKIES_API=$(COOKIES=/tmp/fastapi-cookies.txt \
+              scripts/claude-login.sh --host http://localhost:8000)  # FastAPI
+```
+
+The script reads `CLAUDE_TEST_USER` / `CLAUDE_TEST_PASSWORD` from `.env.local` or `.env.sandbox` (written by step 4). Same JWT cookie works against both services if `JWT_SECRET` matches.
+
+### 6. Run the right verification layer
+
+Pick the lowest layer that gives enough signal. Stack only when one isn't enough.
+
+**L0 — `curl` against the running service.** Use for:
+
+- API routes: unauthenticated (expect 401), authenticated happy path (expect shape matching the Zod output or consumer), validation error (expect 400 with `VALIDATION_ERROR` code), cross-family guard for by-id lookups (log in as a different-family user → expect 404, not 200).
+- Server components: `curl -s http://localhost:3000/<path>` and grep for the expected strings.
+- Auth gating: `curl -I` without cookie should 307 to `/login?redirect=...`.
+
+**L1 — real browser.** Required (not optional) for:
+
+- `'use client'` components with state, effects, or event handlers
+- Forms (validation, submission, redirect)
+- Photo upload round-trips (`<input type=file>` + preview + submit)
+- Navigation via `router.replace`, `router.refresh`, `<Link>` prefetch
+- Any acceptance criterion that includes "looks right" or "renders correctly"
+
+Prefer `claude --chrome` if the session has it. Fall back to Playwright MCP (the repo's `.mcp.json` autoinstalls it — approve on first use). Use `browser_navigate` → `browser_snapshot` (accessibility tree — token-cheap) → `browser_take_screenshot` only when the snapshot misses the visual.
+
+**Contract parity.** When the same endpoint changed on both Next and FastAPI:
+
+```bash
+NEXT=http://localhost:3000
+API=http://localhost:8000
+diff <(curl -s -b "$COOKIES" "$NEXT/api/<resource>" | jq -S .) \
+     <(curl -s -b "$COOKIES" "$API/<resource>" | jq -S .)
+```
+
+**Watch the prefix mismatch:** FastAPI mounts routers with **no** `/api/` prefix; Next uses `/api/*`. A non-empty diff is a parity bug unless the PR is intentionally breaking parity (call this out in the report if so).
+
+### 7. Check the repo-specific invariants
+
+These fail silently at runtime — there's no type error, no red test, just wrong behavior in prod. Grep for each one on every PR that touches the relevant area.
+
+- **Family-scoping.** Any new Prisma query on `Post`, `Comment`, `Reaction`, `Favorite`, `CookedEvent`, or `Notification` must filter by `familySpaceId`. Missing filter = cross-family data leak. Grep the diff: `grep -n familySpaceId <changed-handler-files>`. If a new query lacks it, **fail the review** — this is not a lint suggestion.
+- **Auth wrapping.** New `src/app/api/**` handlers must be wrapped in `withAuth` / `withRole` from `src/lib/apiAuth.ts`. FastAPI equivalents must use `require_user` / `require_admin` from `apps/api/src/dependencies.py`. Never parse the cookie inline.
+- **Validation source.** New Zod schemas live in `src/lib/validation.ts`, not inline in the route handler.
+- **Error response source.** Errors use helpers from `src/lib/apiErrors.ts` (`validationError`, `notFoundError`, etc.) — not ad-hoc `NextResponse.json({ error: ... })`.
+- **Dual Prisma schemas in lockstep.** Any field / model / relation added to `prisma/schema.postgres.node.prisma` must also appear in `prisma/schema.postgres.prisma` with the same shape and `@map(...)` column name. SQLite was dropped in #80 — **do not** suggest `file:./prisma/dev.db` as a fallback. A third schema should not reappear.
+- **Photo storage.** DB stores opaque `storageKey` values, never rendered URLs. For any new upload path, confirm (a) the file landed in `public/uploads/<key>` on disk (runner has `UPLOADS_BUCKET` unset), and (b) the Prisma row has a non-null `*StorageKey`.
+- **Rate limiter.** New auth-sensitive routes should apply the LRU rate limiter from `src/lib/rateLimit.ts`. Not every route needs it; login, signup, and write-heavy routes do.
+
+### 8. Run the affected test suites
+
+```bash
+npm test                                                            # Next changes
+cd apps/api && source .venv/bin/activate && pytest && cd ../..      # FastAPI
+cd apps/recipe-url-importer && source .venv/bin/activate && \
+  PYTHONPATH=src pytest && cd ../..                                 # Importer
+```
+
+If any suite fails against the PR branch, capture the first failing output and stop — that's the blocker, everything else is noise until it's green.
+
+### 9. Tear down
+
+```bash
+lsof -ti :3000 | xargs -r kill -9 2>/dev/null
+lsof -ti :8000 | xargs -r kill -9 2>/dev/null
+lsof -ti :8001 | xargs -r kill -9 2>/dev/null
+# Keep the sandbox volume unless the user asked for a full reset:
+# scripts/local-stack-down.sh          # stop container, keep volume
+# scripts/local-stack-down.sh --purge  # drop volume too
+```
+
+### 10. Produce the report
+
+See the template below. This is the deliverable — it should be directly paste-able into a PR review comment.
+
+## Hard guardrails
+
+These are absolute. A skill that violates any of these becomes net-negative:
+
+- **Never verify against real dev Postgres.** Always the sandbox via `scripts/local-stack-up.sh`. Real family members are testing on dev — corrupting their data is worse than skipping verification.
+- **Never mint JWTs or cookies by hand.** Always the real login route via `scripts/claude-login.sh`. The login flow is part of what we're verifying.
+- **Never run destructive git operations** as part of verification — no `push --force`, no `reset --hard`, no `branch -D`. This skill is read-only from git's perspective; it can `gh pr checkout` into a clean worktree but nothing that rewrites history.
+- **Never claim UI success from `curl` alone on a hydrated page.** Pre-hydration HTML isn't the user experience. If no browser is available, the report says "could not verify interactively" — don't paper over it.
+- **Never suggest SQLite.** `file:./prisma/dev.db` was removed in #80; this repo is Postgres-only. Offering it as a fallback sends future agents down a dead-end.
+- **Family-scoping grep is mandatory** on any PR that adds a DB query on a scopeable model. Skipping it once lets the next cross-family bug through.
+- **Never run this skill against a release PR** (`develop → main`) as if it were a feature PR. Release verification is a separate workflow.
+
+If the session can't run a required tool (no Docker for the sandbox, no browser for L1), the "Could not verify" section of the report must call it out. A partial report with honest gaps is strictly better than a full report with fabricated passes.
+
+## Report template
+
+Produce the report in GitHub-flavored markdown. Use `<details>` for long command output so the summary stays scannable. This is the exact shape — deviate only if the user asks for a different format.
+
+````markdown
+## PR Verification — <title> (#<n>)
+
+**Branch:** `<head>` → `<base>` · **Linked issue:** #<issue-n> · **CI:** <green/red summary from `gh pr checks`>
+
+### Impact summary
+
+- <one bullet per affected area — UI / Next API / FastAPI / Prisma / importer / infra>
+- <what the PR is trying to do, in one line>
+
+### Verification performed
+
+- **Next API — `/api/<resource>`**: L0 curl — 401 unauth ✅, 200 authed ✅, 400 on bad payload ✅, 404 cross-family ✅
+- **UI — `/<path>`**: L1 Playwright — form submits, redirect lands at `/<target>`, screenshot attached
+- **Contract parity** (if both backends changed): diff clean ✅ / differs ❌ (include the diff)
+- **Tests**: `npm test` → 46 suites, 0 failures; FastAPI `pytest` → 41 tests, 0 failures
+- **Issue acceptance criteria**: <one line per criterion — met / not-met / not-verifiable-here>
+
+<details><summary>Command log</summary>
+
+```bash
+# Exact commands run, with output snippets
+```
+
+</details>
+
+### Invariants
+
+- Family-scoping on new queries: ✅ / ❌ (list offending files if ❌)
+- `withAuth` / `withRole` wrapping on new handlers: ✅ / ❌ / N/A
+- Dual Prisma-schema lockstep: ✅ / ❌ / N/A
+- Validation from `src/lib/validation.ts`: ✅ / ❌ / N/A
+- Error helpers from `src/lib/apiErrors.ts`: ✅ / ❌ / N/A
+- Photo storage uses `storageKey`, not URL: ✅ / ❌ / N/A
+
+### Could not verify
+
+- <explicit list — e.g., "photo upload round-trip: no browser available this session"; "GCS signed-URL path: no `UPLOADS_BUCKET` bucket in local env"; "post-deploy smoke: skill doesn't touch deploy pipeline">
+
+### Regressions or open questions
+
+- <anything surprising surfaced by the run — unrelated failures, flaky tests, docs out of date with code>
+
+### Recommendation
+
+**PASS** — verified end-to-end, invariants hold, tests green; ready to merge.
+_(or)_ **NEEDS CHANGES** — <one-line reason, with link to offending file/line>.
+_(or)_ **BLOCKED** — <what's missing: CI red, local stack down, acceptance criterion untestable here>.
+````
+
+## When this skill runs against a different repo
+
+If `docs/verification/README.md` doesn't exist, this skill is being run outside the family-recipe repo it was shaped for. Degrade gracefully:
+
+1. Read the repo's `CLAUDE.md`, `README.md`, and `CONTRIBUTING.md` for verification conventions.
+2. Ask the user for the entry-point command to start the app and the login method; don't guess.
+3. Drop the family-recipe-specific invariants (family-scoping, dual-Prisma, `withAuth`) from the invariant-check section — they're repo-specific.
+4. Keep the workflow (fetch PR → triage diff → pick layer → check CI → run tests → produce report). That part is portable.
+5. Flag prominently in the report that repo-specific invariants were skipped.

--- a/.env.dev.local.example
+++ b/.env.dev.local.example
@@ -1,0 +1,21 @@
+# .env.dev.local — inputs for scripts/smoke-dev.sh and the /release-testing
+# skill. Copy to `.env.dev.local` (gitignored via the existing `.env*.local`
+# pattern) and populate. See docs/verification/dev-deployments.md for the
+# one-time setup and GSM fetch commands.
+
+# --- Dev Cloud Run URLs (match .github/workflows/deploy-dev.yml) ---
+DEV_NEXT_URL="https://family-recipe-dev-894181878182.us-east1.run.app"
+DEV_IMPORTER_URL="https://recipe-importer-dev-894181878182.us-east1.run.app"
+# FastAPI is not yet deployed to dev — add DEV_API_URL here when it ships.
+
+# --- Service account to impersonate for Cloud Run ID tokens ---
+# Your user needs `roles/iam.serviceAccountTokenCreator` on this SA. The
+# one-time grant command is in docs/verification/dev-deployments.md.
+DEV_DEPLOYER_SA="family-recipe-deployer@family-recipe-dev.iam.gserviceaccount.com"
+
+# --- Seeded claude-test user on the dev DB ---
+CLAUDE_TEST_USER="claude-test"
+# Never commit the password. Populate by appending the line below (the
+# playbook has the one-liner), pasting the fetched value directly, or
+# `export CLAUDE_TEST_PASSWORD=...` in the session shell.
+# CLAUDE_TEST_PASSWORD="<gcloud secrets versions access latest --secret family-recipe-dev-claude-test-password --project family-recipe-dev>"

--- a/.gitignore
+++ b/.gitignore
@@ -130,10 +130,11 @@ __pycache__/
 .husky/_
 
 # CLAUDE
-# Local-only bits — never commit.
+# Local-only state — never commit.
 /.claude/settings.local.json
 /.claude/scheduled_tasks.lock
 /.claude/worktrees/
-# /.claude/skills/ is versioned. Individual skills are tracked by
-# explicit `git add .claude/skills/<name>/` — personal skills dropped
-# into that directory stay untracked until you opt in.
+# Everything else under /.claude/ is NOT ignored. Project skills live in
+# /.claude/skills/<name>/ and are versioned (add them with `git add`).
+# For personal skills that shouldn't ship in the repo, put them in your
+# user-scope dir (~/.claude/skills/<name>/) rather than the project one.

--- a/.gitignore
+++ b/.gitignore
@@ -128,4 +128,10 @@ __pycache__/
 .husky/_
 
 # CLAUDE
-/.claude
+# Local-only bits — never commit.
+/.claude/settings.local.json
+/.claude/scheduled_tasks.lock
+/.claude/worktrees/
+# /.claude/skills/ is versioned. Individual skills are tracked by
+# explicit `git add .claude/skills/<name>/` — personal skills dropped
+# into that directory stay untracked until you opt in.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,8 @@ The pre-commit hook runs `type-check` + `lint-staged`; nothing else is automatic
 
 Always finish with `npm test` (the pre-commit hook doesn't run it). If the session can't run a tool a change needs (e.g., no browser for a hydration-sensitive UI change), say so in the PR body — don't claim UI success from `curl` alone.
 
+**Before merging a `develop → main` release PR**, also run the dev-deployment playbook at [docs/verification/dev-deployments.md](docs/verification/dev-deployments.md) — it exercises the live Cloud Run build, migration, and env wiring that local verification can't catch. Check whether the dev Postgres is running first (it can be manually stopped between sessions); the playbook has the `gcloud sql instances` commands. The [`/release-testing`](.claude/skills/release-testing/SKILL.md) skill drives this end-to-end and posts results back on the PR.
+
 ## Branches and releases
 
 - `main` = **production**. `develop` = **dev environment**.

--- a/docs/verification/README.md
+++ b/docs/verification/README.md
@@ -8,6 +8,15 @@ Decision rationale and tool alternatives: [docs/research/claude-local-verificati
 
 **Before opening any PR.** The pre-commit hook runs `type-check` + `lint-staged`; nothing else is automatic. Verification catches what the type checker can't: wrong response shapes, broken gating, silent 500s, hydration bugs, cross-family data leaks.
 
+## Local vs dev deployment
+
+| Stage                           | Target                                          | Playbook                                 |
+| ------------------------------- | ----------------------------------------------- | ---------------------------------------- |
+| Feature branch → `develop` PR   | **Local** (the service(s) touched in the diff)  | The per-service playbooks below          |
+| **`develop → main` release PR** | **Dev deployment** (`develop` branch Cloud Run) | [dev-deployments.md](dev-deployments.md) |
+
+Local catches "did my code work?"; dev catches "did the build+migrate+deploy pipeline work?". Run local for every branch; add dev before merging a release. The `/release-testing` skill automates the dev step.
+
 ## The three layers
 
 Pick the lowest layer that gives enough signal for the change. Stack layers only when a single one is insufficient.

--- a/docs/verification/dev-deployments.md
+++ b/docs/verification/dev-deployments.md
@@ -1,0 +1,191 @@
+# Dev Deployment Verification
+
+Exercise the live `develop`-branch Cloud Run deployment before merging a `develop → main` release PR. Local verification covers the code under change; this playbook covers the **deployed artifact** — that nothing broke in the build, Prisma migration, or Cloud Run env-var wiring between last green local run and production.
+
+Dev is Eric's personal sandbox. Writes are fair game; the script cleans up after itself.
+
+## When to run this
+
+| You are…                                                                | Use                                                                                                                                                             |
+| ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Changing code in this branch                                            | Local playbook for the thing you touched — [ui.md](ui.md), [next-api.md](next-api.md), [prisma.md](prisma.md), [recipe-url-importer.md](recipe-url-importer.md) |
+| **About to open / merge a `develop → main` PR**                         | **This playbook** plus the `/release-testing` skill                                                                                                             |
+| Debugging a dev-only regression (e.g. GCS, Cloud SQL proxy, deploy env) | This playbook                                                                                                                                                   |
+
+**Rule of thumb:** local catches "did my code work?"; dev catches "did the build+migrate+deploy pipeline work?". Run local first, then this, and don't skip either for a release.
+
+## Dev infrastructure reference
+
+| Thing                     | Value                                                                               |
+| ------------------------- | ----------------------------------------------------------------------------------- |
+| GCP project               | `family-recipe-dev`                                                                 |
+| Region                    | `us-east1`                                                                          |
+| Next.js Cloud Run         | `family-recipe-dev` → `https://family-recipe-dev-894181878182.us-east1.run.app`     |
+| Recipe importer Cloud Run | `recipe-importer-dev` → `https://recipe-importer-dev-894181878182.us-east1.run.app` |
+| FastAPI                   | not yet deployed to dev                                                             |
+| Cloud SQL instance        | `family-recipe-dev` (`family-recipe-dev:us-east1:family-recipe-dev`)                |
+| Runtime SA                | `family-recipe-runner@family-recipe-dev.iam.gserviceaccount.com`                    |
+| Deployer SA               | `family-recipe-deployer@family-recipe-dev.iam.gserviceaccount.com`                  |
+
+Both Cloud Run services run with `--no-allow-unauthenticated` + `--ingress all`, so every request needs a Bearer ID token from an account with `roles/run.invoker`.
+
+## One-time setup
+
+### 1. Grant yourself tokenCreator on the deployer SA
+
+The deployer SA already has `roles/run.invoker` on both dev services (it's how CI's smoke check works). We give your user identity the ability to mint ID tokens on its behalf:
+
+```bash
+gcloud iam service-accounts add-iam-policy-binding \
+  family-recipe-deployer@family-recipe-dev.iam.gserviceaccount.com \
+  --project family-recipe-dev \
+  --member="user:$(gcloud config get-value account)" \
+  --role="roles/iam.serviceAccountTokenCreator"
+```
+
+The binding takes 10–30 seconds to propagate.
+
+### 2. Populate `.env.dev.local`
+
+```bash
+cp .env.dev.local.example .env.dev.local
+# The URLs and SA are already filled in. Append the claude-test password:
+echo "CLAUDE_TEST_PASSWORD=$(gcloud secrets versions access latest \
+  --secret family-recipe-dev-claude-test-password \
+  --project family-recipe-dev)" >> .env.dev.local
+```
+
+`.env.dev.local` is gitignored via the existing `.env*.local` pattern.
+
+### 3. Confirm the auth path end-to-end
+
+```bash
+source .env.dev.local
+TOKEN=$(gcloud auth print-identity-token \
+  --impersonate-service-account="$DEV_DEPLOYER_SA" \
+  --audiences="$DEV_NEXT_URL")
+curl -sS -o /dev/null -w 'HTTP %{http_code}\n' \
+  -H "Authorization: Bearer $TOKEN" "$DEV_NEXT_URL/api/health"
+# Expect: HTTP 200
+```
+
+If you get 403, the tokenCreator grant from step 1 hasn't propagated yet — wait 30s and retry.
+
+## Start / stop the dev Postgres instance
+
+The Cloud SQL instance is declared `activation_policy = ALWAYS` in Terraform, so it normally stays running. Stop it manually to cut cost during long breaks; start it before a smoke run.
+
+```bash
+# Check current state
+gcloud sql instances describe family-recipe-dev \
+  --project family-recipe-dev \
+  --format='value(state,settings.activationPolicy)'
+# → RUNNABLE ALWAYS (running) or STOPPED NEVER (stopped)
+
+# Stop (idle savings)
+gcloud sql instances patch family-recipe-dev \
+  --project family-recipe-dev \
+  --activation-policy=NEVER --quiet
+# Patch returns in ~15s; state becomes STOPPED NEVER.
+
+# Start
+gcloud sql instances patch family-recipe-dev \
+  --project family-recipe-dev \
+  --activation-policy=ALWAYS --quiet
+# Patch waits for the operation to complete (~30s–2min); when the
+# command returns, the instance is RUNNABLE and the smoke will pass its
+# /api/health step.
+```
+
+**Other paused resources.** Both Cloud Run services have `min_instance_count=0` — they cold-start on first request (~3–5s overhead) and idle down automatically. No explicit action required; just tolerate the first-request latency.
+
+## Run the smoke check
+
+```bash
+npm run smoke:dev
+```
+
+What this does (see [scripts/smoke-dev.sh](../../scripts/smoke-dev.sh)):
+
+1. Mints a Bearer ID token via deployer-SA impersonation.
+2. GET `/api/health` — confirms ingress auth + DB connectivity.
+3. POST `/api/auth/login` with ID-token Bearer + claude-test credentials → session cookie.
+4. POST `/api/posts` (multipart) — creates a tagged test post.
+5. POST `/api/posts/:id/comments` (multipart) — adds a comment.
+6. POST `/api/reactions` (JSON) — adds a reaction.
+7. GET `/api/posts/:id` — confirms comment + reaction are visible.
+8. DELETE `/api/posts/:id` — cascade-removes comment + reaction + post.
+9. GET `/api/posts/:id` — confirms 404.
+
+Exit 0 = all green. Any non-zero exit runs the cleanup trap so no test post is left behind.
+
+## Manual probes
+
+When you need to hit a specific endpoint the smoke script doesn't cover, mint the token once and reuse it:
+
+```bash
+source .env.dev.local
+TOKEN=$(gcloud auth print-identity-token \
+  --impersonate-service-account="$DEV_DEPLOYER_SA" \
+  --audiences="$DEV_NEXT_URL")
+
+# Cookie-jar login (for endpoints that need the session)
+rm -f /tmp/fr-dev-cookies.txt
+curl -sS -o /dev/null \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -c /tmp/fr-dev-cookies.txt \
+  -d "$(jq -cn --arg u "$CLAUDE_TEST_USER" --arg p "$CLAUDE_TEST_PASSWORD" \
+        '{emailOrUsername:$u,password:$p}')" \
+  "$DEV_NEXT_URL/api/auth/login"
+
+# Example: list timeline
+curl -sS -H "Authorization: Bearer $TOKEN" -b /tmp/fr-dev-cookies.txt \
+  "$DEV_NEXT_URL/api/timeline" | jq '.timelineEvents | length'
+```
+
+**Importer probe** (separate audience, same deployer SA):
+
+```bash
+IMP_TOKEN=$(gcloud auth print-identity-token \
+  --impersonate-service-account="$DEV_DEPLOYER_SA" \
+  --audiences="$DEV_IMPORTER_URL")
+curl -sS -H "Authorization: Bearer $IMP_TOKEN" "$DEV_IMPORTER_URL/version"
+# → {"service":"recipe-url-importer","version":"0.1.0","git_sha":"..."}
+```
+
+Each Cloud Run service is a distinct audience — mint a new token per host.
+
+## Gotchas
+
+- **`curl -F` interprets `;` in values** as a content-type delimiter and silently truncates the payload. Use `curl --form-string` for `multipart/form-data` JSON payloads (the smoke script does; so must your manual probes).
+- **ID tokens are audience-scoped.** The token minted for `$DEV_NEXT_URL` will 401 against `$DEV_IMPORTER_URL`. Mint one per service.
+- **The cookie jar's `session` cookie is tied to the Next.js host.** Reusing the same jar across Next + importer requests is harmless (the importer ignores cookies) but don't expect it to carry identity.
+- **Rate limits are per-runtime-instance.** If the dev Cloud Run service has been warm, prior traffic counts against your quota. A 429 on `/api/posts` means either a bug or you genuinely sent too many — re-run after ~60s.
+- **`claude-test` lives alongside real family data.** Its posts are family-scoped to the real `Wnorowski Family Recipe` space, so family members _can_ see the smoke post during its short lifetime. Keep run times short; always let the script clean up.
+
+## Seeding / rotating the `claude-test` user
+
+The user was seeded once via Cloud SQL Auth Proxy + `npm run db:seed` with `CLAUDE_TEST_PASSWORD` sourced from `family-recipe-dev-claude-test-password`. Re-run only to rotate the password or recreate after a DB reset:
+
+```bash
+# Start the Auth Proxy on a free local port
+cloud-sql-proxy family-recipe-dev:us-east1:family-recipe-dev --port 5435 &
+PROXY_PID=$!
+
+# Fetch creds from GSM
+DB_PASSWORD=$(gcloud secrets versions access latest \
+  --secret family-recipe-dev-db-password --project family-recipe-dev)
+CLAUDE_PW=$(gcloud secrets versions access latest \
+  --secret family-recipe-dev-claude-test-password --project family-recipe-dev)
+
+# Seed (idempotent; upserts by email)
+DATABASE_URL="postgresql://family_app:${DB_PASSWORD}@127.0.0.1:5435/family_recipe_dev?sslmode=disable" \
+CLAUDE_TEST_PASSWORD="$CLAUDE_PW" \
+NODE_ENV=development \
+npm run db:seed
+
+kill $PROXY_PID
+```
+
+To rotate the password, add a new version to the GSM secret, re-run the block above, and update any shell/`.env.dev.local` copies.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "db:generate": "prisma generate --schema prisma/schema.postgres.node.prisma",
     "db:push": "prisma db push --schema prisma/schema.postgres.node.prisma",
     "db:studio": "prisma studio --schema prisma/schema.postgres.node.prisma",
-    "db:seed": "tsx prisma/seed.ts"
+    "db:seed": "tsx prisma/seed.ts",
+    "smoke:dev": "scripts/smoke-dev.sh"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/smoke-dev.sh
+++ b/scripts/smoke-dev.sh
@@ -54,7 +54,12 @@ if [[ -f "$ENV_FILE" ]]; then
     value="${value#\"}"
     case "$key" in
       DEV_NEXT_URL|DEV_DEPLOYER_SA|CLAUDE_TEST_USER|CLAUDE_TEST_PASSWORD)
-        eval "if [[ -z \"\${$key:-}\" ]]; then export $key=\"\$value\"; fi"
+        # Indirect expansion + printf -v avoids eval — a value containing
+        # $(…) or backticks won't execute during load.
+        if [[ -z "${!key:-}" ]]; then
+          printf -v "$key" '%s' "$value"
+          export "$key"
+        fi
         ;;
     esac
   done < "$ENV_FILE"

--- a/scripts/smoke-dev.sh
+++ b/scripts/smoke-dev.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+#
+# smoke-dev.sh — end-to-end smoke check against the dev Cloud Run deployment.
+#
+# What it does:
+#   1. mints a Bearer ID token by impersonating the deployer SA
+#   2. logs in as the `claude-test` seed user (ID-token Bearer + JSON body)
+#   3. exercises a write path: create a post, comment on it, react, re-read
+#   4. cleans up the test post (cascade deletes comment + reaction)
+#   5. confirms the post is gone
+#
+# Usage:
+#   scripts/smoke-dev.sh                 # uses .env.dev.local if present
+#   scripts/smoke-dev.sh --host <url>    # override Next.js base URL
+#
+# Required env (from .env.dev.local or shell):
+#   DEV_NEXT_URL                         Cloud Run URL for family-recipe-dev
+#   DEV_DEPLOYER_SA                      Service account to impersonate for ID token
+#   CLAUDE_TEST_USER                     Seeded claude-test username
+#   CLAUDE_TEST_PASSWORD                 Fetched from family-recipe-dev-claude-test-password
+#
+# Exit codes:
+#   0 — all steps green
+#   1 — any step failed (test post, if created, is always cleaned up)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ENV_FILE="${REPO_ROOT}/.env.dev.local"
+
+HOST_OVERRIDE=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --host)
+      HOST_OVERRIDE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      sed -n '2,23p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Load .env.dev.local without clobbering already-set vars.
+if [[ -f "$ENV_FILE" ]]; then
+  while IFS='=' read -r key value; do
+    [[ -z "$key" || "$key" =~ ^# ]] && continue
+    value="${value%\"}"
+    value="${value#\"}"
+    case "$key" in
+      DEV_NEXT_URL|DEV_DEPLOYER_SA|CLAUDE_TEST_USER|CLAUDE_TEST_PASSWORD)
+        eval "if [[ -z \"\${$key:-}\" ]]; then export $key=\"\$value\"; fi"
+        ;;
+    esac
+  done < "$ENV_FILE"
+fi
+
+HOST="${HOST_OVERRIDE:-${DEV_NEXT_URL:-}}"
+DEPLOYER_SA="${DEV_DEPLOYER_SA:-}"
+USER="${CLAUDE_TEST_USER:-claude-test}"
+PASSWORD="${CLAUDE_TEST_PASSWORD:-}"
+
+for var in HOST DEPLOYER_SA PASSWORD; do
+  if [[ -z "${!var:-}" ]]; then
+    echo "Missing required env: $var (set in .env.dev.local or shell)" >&2
+    exit 1
+  fi
+done
+
+COOKIES="${COOKIES:-/tmp/fr-dev-cookies.txt}"
+BODY_FILE="${BODY_FILE:-/tmp/fr-dev-body.json}"
+rm -f "$COOKIES" "$BODY_FILE"
+
+# Colored output when attached to a TTY.
+if [[ -t 1 ]]; then
+  GREEN=$'\e[32m' RED=$'\e[31m' YELLOW=$'\e[33m' RESET=$'\e[0m'
+else
+  GREEN='' RED='' YELLOW='' RESET=''
+fi
+
+pass() { echo "${GREEN}PASS${RESET}  $1"; }
+fail() { echo "${RED}FAIL${RESET}  $1" >&2; }
+note() { echo "${YELLOW}INFO${RESET}  $1"; }
+
+# Cleanup runs on any exit path so a mid-flight failure doesn't leave a
+# test post behind in dev.
+CREATED_POST_ID=""
+cleanup() {
+  local rc=$?
+  if [[ -n "$CREATED_POST_ID" ]]; then
+    note "cleaning up test post $CREATED_POST_ID"
+    local del_status
+    del_status=$(curl -sS -o /dev/null -w '%{http_code}' -X DELETE \
+      -H "Authorization: Bearer $TOKEN" \
+      -b "$COOKIES" \
+      "$HOST/api/posts/$CREATED_POST_ID" || echo "000")
+    if [[ "$del_status" == "200" ]]; then
+      pass "cleanup: post $CREATED_POST_ID deleted"
+    else
+      fail "cleanup: post $CREATED_POST_ID delete returned HTTP $del_status"
+      rc=1
+    fi
+  fi
+  rm -f "$BODY_FILE"
+  exit "$rc"
+}
+trap cleanup EXIT
+
+note "dev host: $HOST"
+note "impersonating: $DEPLOYER_SA"
+
+# --- Step 1: mint ID token --------------------------------------------------
+TOKEN=$(gcloud auth print-identity-token \
+  --impersonate-service-account="$DEPLOYER_SA" \
+  --audiences="$HOST" 2>/tmp/fr-dev-mint.err) || {
+    fail "mint ID token (check roles/iam.serviceAccountTokenCreator on $DEPLOYER_SA)"
+    cat /tmp/fr-dev-mint.err >&2
+    exit 1
+  }
+pass "mint Bearer ID token (len=${#TOKEN})"
+
+# --- Step 2: health probe ---------------------------------------------------
+HEALTH_STATUS=$(curl -sS -o "$BODY_FILE" -w '%{http_code}' \
+  -H "Authorization: Bearer $TOKEN" \
+  "$HOST/api/health")
+if [[ "$HEALTH_STATUS" != "200" ]]; then
+  fail "GET /api/health → HTTP $HEALTH_STATUS"
+  head -c 400 "$BODY_FILE" >&2; echo >&2
+  exit 1
+fi
+pass "GET /api/health → 200"
+
+# --- Step 3: login ----------------------------------------------------------
+LOGIN_BODY=$(jq -n --arg u "$USER" --arg p "$PASSWORD" \
+  '{emailOrUsername: $u, password: $p}')
+LOGIN_STATUS=$(curl -sS -o "$BODY_FILE" -w '%{http_code}' \
+  -c "$COOKIES" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "$LOGIN_BODY" \
+  "$HOST/api/auth/login")
+if [[ "$LOGIN_STATUS" != "200" ]]; then
+  fail "POST /api/auth/login → HTTP $LOGIN_STATUS"
+  head -c 400 "$BODY_FILE" >&2; echo >&2
+  exit 1
+fi
+if ! grep -q $'\tsession\t' "$COOKIES"; then
+  fail "login returned 200 but no session cookie was set"
+  exit 1
+fi
+pass "POST /api/auth/login → 200 (session cookie set)"
+
+# --- Step 4: create test post (multipart; title + caption, no photo) --------
+# Timestamp+PID tag so concurrent runs (or leftover rows from a crash prior
+# to this version) are trivially distinguishable.
+POST_TAG="smoke-dev-$(date -u +%Y%m%dT%H%M%SZ)-$$"
+POST_PAYLOAD=$(jq -cn --arg title "claude smoke-dev test ($POST_TAG)" \
+  --arg caption "automated — auto-deleted by scripts/smoke-dev.sh" \
+  '{title: $title, caption: $caption}')
+# --form-string (not -F) — otherwise curl treats `;` in the value as a
+# Content-Type delimiter and truncates the payload.
+CREATE_STATUS=$(curl -sS -o "$BODY_FILE" -w '%{http_code}' \
+  -H "Authorization: Bearer $TOKEN" \
+  -b "$COOKIES" \
+  --form-string "payload=$POST_PAYLOAD" \
+  "$HOST/api/posts")
+if [[ "$CREATE_STATUS" != "201" ]]; then
+  fail "POST /api/posts → HTTP $CREATE_STATUS"
+  head -c 400 "$BODY_FILE" >&2; echo >&2
+  exit 1
+fi
+CREATED_POST_ID=$(jq -r '.post.id' < "$BODY_FILE")
+if [[ -z "$CREATED_POST_ID" || "$CREATED_POST_ID" == "null" ]]; then
+  fail "create returned 201 but no post.id in body"
+  head -c 400 "$BODY_FILE" >&2; echo >&2
+  exit 1
+fi
+pass "POST /api/posts → 201 (id=$CREATED_POST_ID)"
+
+# --- Step 5: create comment -------------------------------------------------
+COMMENT_PAYLOAD=$(jq -cn '{text: "smoke-dev comment — safe to ignore"}')
+COMMENT_STATUS=$(curl -sS -o "$BODY_FILE" -w '%{http_code}' \
+  -H "Authorization: Bearer $TOKEN" \
+  -b "$COOKIES" \
+  --form-string "payload=$COMMENT_PAYLOAD" \
+  "$HOST/api/posts/$CREATED_POST_ID/comments")
+if [[ "$COMMENT_STATUS" != "201" ]]; then
+  fail "POST /api/posts/:id/comments → HTTP $COMMENT_STATUS"
+  head -c 400 "$BODY_FILE" >&2; echo >&2
+  exit 1
+fi
+COMMENT_ID=$(jq -r '.comment.id' < "$BODY_FILE")
+pass "POST /api/posts/:id/comments → 201 (id=$COMMENT_ID)"
+
+# --- Step 6: add reaction ---------------------------------------------------
+REACT_PAYLOAD=$(jq -n --arg id "$CREATED_POST_ID" \
+  '{targetType: "post", targetId: $id, emoji: "👍"}')
+REACT_STATUS=$(curl -sS -o "$BODY_FILE" -w '%{http_code}' \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -b "$COOKIES" \
+  -d "$REACT_PAYLOAD" \
+  "$HOST/api/reactions")
+if [[ "$REACT_STATUS" != "200" ]]; then
+  fail "POST /api/reactions → HTTP $REACT_STATUS"
+  head -c 400 "$BODY_FILE" >&2; echo >&2
+  exit 1
+fi
+REACT_COUNT=$(jq -r '.reactions | length' < "$BODY_FILE")
+if [[ "$REACT_COUNT" -lt 1 ]]; then
+  fail "reactions response empty after POST"
+  exit 1
+fi
+pass "POST /api/reactions → 200 (summary size=$REACT_COUNT)"
+
+# --- Step 7: re-read post; confirm comment + reaction present --------------
+READ_STATUS=$(curl -sS -o "$BODY_FILE" -w '%{http_code}' \
+  -H "Authorization: Bearer $TOKEN" \
+  -b "$COOKIES" \
+  "$HOST/api/posts/$CREATED_POST_ID")
+if [[ "$READ_STATUS" != "200" ]]; then
+  fail "GET /api/posts/:id → HTTP $READ_STATUS"
+  exit 1
+fi
+COMMENT_COUNT=$(jq -r '.post.comments | length' < "$BODY_FILE")
+REACTION_TOTAL=$(jq -r '[.post.reactionSummary[].count] | add // 0' < "$BODY_FILE")
+if [[ "$COMMENT_COUNT" -lt 1 || "$REACTION_TOTAL" -lt 1 ]]; then
+  fail "post re-read: expected ≥1 comment and ≥1 reaction, got comments=$COMMENT_COUNT reactions=$REACTION_TOTAL"
+  exit 1
+fi
+pass "GET /api/posts/:id → 200 (comments=$COMMENT_COUNT, reactions=$REACTION_TOTAL)"
+
+# --- Step 8: delete (via trap) + confirm 404 --------------------------------
+# Run delete inline so we can then probe for the 404. Clear CREATED_POST_ID
+# so the trap doesn't try to delete a second time.
+DEL_STATUS=$(curl -sS -o /dev/null -w '%{http_code}' -X DELETE \
+  -H "Authorization: Bearer $TOKEN" \
+  -b "$COOKIES" \
+  "$HOST/api/posts/$CREATED_POST_ID")
+if [[ "$DEL_STATUS" != "200" ]]; then
+  fail "DELETE /api/posts/:id → HTTP $DEL_STATUS"
+  exit 1
+fi
+pass "DELETE /api/posts/:id → 200"
+
+RE_READ=$(curl -sS -o /dev/null -w '%{http_code}' \
+  -H "Authorization: Bearer $TOKEN" \
+  -b "$COOKIES" \
+  "$HOST/api/posts/$CREATED_POST_ID")
+if [[ "$RE_READ" != "404" ]]; then
+  fail "GET /api/posts/:id after delete → HTTP $RE_READ (expected 404)"
+  exit 1
+fi
+pass "GET /api/posts/:id after delete → 404 (cleanup confirmed)"
+
+CREATED_POST_ID=""
+echo
+echo "${GREEN}all checks passed${RESET}"


### PR DESCRIPTION
Closes #85.

## Summary
- Adds `scripts/smoke-dev.sh` + `npm run smoke:dev` — end-to-end login → create post → comment → react → re-read → delete flow against the dev Cloud Run deployment, with EXIT-trap cleanup so no orphan data survives a mid-run failure.
- Adds `docs/verification/dev-deployments.md` — the sanctioned playbook for one-time tokenCreator grant, `.env.dev.local` setup, dev Postgres start/stop (Terraform declares `ALWAYS` but Eric can manually pause), manual probes for both live Cloud Run services, and the known curl `-F` vs `--form-string` gotcha.
- Adds **`.claude/skills/release-testing/SKILL.md`** (project-level) — new `/release-testing` slash skill. Reads a `develop → main` PR, triages the cumulative diff into impact areas, confirms dev-deployment SHA matches `develop` HEAD, runs the smoke, layers targeted probes per area, and posts a structured report as a PR comment.
- Adds **`.claude/skills/test-pr/SKILL.md`** (project-level) — copy of the existing user-level `/test-pr` skill, so every clone gets the feature-PR verification workflow without depending on per-user `~/.claude/`. Paired with `/release-testing`: `/test-pr` for feature PRs → local sandbox; `/release-testing` for release PRs → dev deployment.
- Adds **`.claude/skills/pr-review/SKILL.md`** (project-level, commit `4ece69e`) — separately-authored `/pr-review` skill bundled with this PR so all three project-level skills land together. Ran against this very PR during review; output is the comment thread.
- Small wiring: new GSM secret `family-recipe-dev-claude-test-password`, `claude-test` user seeded into the dev DB, pointers from `CLAUDE.md` and `docs/verification/README.md`, `.env.dev.local.example` template, selective `.gitignore` tweak so project-level skills are addable (personal skills stay local until opted in).

## Verified against live dev
All of this was exercised end-to-end against the real dev deployment, not just locally:
- Fresh-shell run of `npm run smoke:dev` → all 9 steps green, cleanup confirmed via trailing 404.
- Bad-password path exits 1 with the API error body.
- `gcloud sql instances patch … --activation-policy=NEVER/ALWAYS` round-trips cleanly (state moves `RUNNABLE ALWAYS` → `STOPPED NEVER` → `RUNNABLE ALWAYS`).
- Importer `/version` probe verified (separate token audience).

One-time IAM action taken during development: Eric's user was granted `roles/iam.serviceAccountTokenCreator` on `family-recipe-deployer@family-recipe-dev`. This binding is orthogonal to the diff but is prerequisite for running the skill.

## Review feedback addressed (commit `984babb`)
- `scripts/smoke-dev.sh:57` — replaced `eval` env loader with bash indirect expansion + `printf -v`; a `.env.dev.local` line like `FOO="$(rm -rf ~)"` now lands as a literal string instead of executing during load. Verified both as an isolated test (command substitution did NOT execute) and with a full green `smoke:dev` run after the change.
- `.gitignore` — rewrote the CLAUDE comment to match what the rules actually do (only `settings.local.json` / `scheduled_tasks.lock` / `worktrees/` are ignored; everything else under `/.claude/` is tracked-on-`git add`), and added a pointer that personal-only skills belong in `~/.claude/skills/` rather than the project dir.

## Follow-ups filed
- #112 — enable browser-based UI smoke against dev (auth-injecting proxy or IAP) so `/release-testing` can do full Playwright against hydrated pages.
- #113 — importer `/healthz` returns Google-edge 404 on dev; skill uses `/version` as a workaround until fixed.
- Checkbox comment on #38 — extend `smoke-dev.sh` + `/release-testing` to cover FastAPI once it ships on dev.

## Scope notes
- FastAPI is not yet deployed to dev; the playbook + skill leave placeholders.
- Browser-based UI verification against dev is out of scope here (tracked by #112).
- This is a `develop`-targeting PR — `/release-testing` is meant to run against the next `develop → main` PR, which will be its first real exercise.

## Test plan
- [x] `npm run smoke:dev` from a fresh shell after populating `.env.dev.local` → exit 0, all steps PASS, no orphan post visible in the dev DB. *(Verified on commit `da3cfb2` and re-verified on `984babb` after the eval → printf -v change.)*
- [x] `CLAUDE_TEST_PASSWORD=wrong npm run smoke:dev` → exits 1 with a readable "INVALID_CREDENTIALS" message. *(Verified on `da3cfb2`.)*
- [x] Stop the dev DB (`gcloud sql instances patch … --activation-policy=NEVER --quiet`) and confirm `gcloud sql instances describe … --format='value(state,settings.activationPolicy)'` returns `STOPPED NEVER`. Start it again; confirm `RUNNABLE ALWAYS`. *(Verified on `da3cfb2`; round-trip took ~15s stop + ~90s start.)*
- [ ] Open a fresh Claude Code session in a clone of this branch and confirm both `/release-testing` and `/test-pr` appear as project-level skills (names should appear even if the user has no `~/.claude/skills/…`). *(Not run from this session; owner to verify after merge.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)