### PR TITLE
fix(importer): rename /healthz to /health to avoid GFE edge interception (#113)

### DIFF
--- a/.claude/skills/release-testing/SKILL.md
+++ b/.claude/skills/release-testing/SKILL.md
@@ -73,7 +73,7 @@ Map the file list to areas:
 | -------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------ |
 | `src/app/api/**/route.ts`                                                  | Next API | **Covered by `smoke:dev`** (login + post + comment + reaction + cleanup)                         |
 | `src/app/**` (non-api), `src/components/**`                                | UI       | Partial — see "UI limitations" below                                                             |
-| `apps/recipe-url-importer/**`                                              | Importer | Manual `/version` probe (see step 5)                                                             |
+| `apps/recipe-url-importer/**`                                              | Importer | Manual `/health` probe (see step 5)                                                              |
 | `apps/api/**`                                                              | FastAPI  | Not deployed to dev yet — skip with a note                                                       |
 | `prisma/schema*.prisma`, `prisma/migrations/**`                            | Prisma   | Migration already ran during `deploy-dev.yml`; smoke writes exercise it                          |
 | `.github/workflows/deploy-*.yml`, `infra/**`                               | Infra    | **Inspect the workflow diff carefully** — a change here changes the pipeline you're about to use |
@@ -134,8 +134,8 @@ source .env.dev.local
 IMP_TOKEN=$(gcloud auth print-identity-token \
   --impersonate-service-account="$DEV_DEPLOYER_SA" \
   --audiences="$DEV_IMPORTER_URL")
-curl -sS -H "Authorization: Bearer $IMP_TOKEN" "$DEV_IMPORTER_URL/version"
-# → {"service":"recipe-url-importer","version":"...","git_sha":"..."}
+curl -sS -H "Authorization: Bearer $IMP_TOKEN" "$DEV_IMPORTER_URL/health"
+# → {"status":"ok"}
 
 # Read-only Next probes (reuse the smoke script's login flow if you need
 # a session; otherwise just check unauthenticated gating)
@@ -181,7 +181,7 @@ Absolute. Violating any of these turns the skill into a liability:
 - **Never mint a fake ID token or re-use a stale one across audiences.** The `--audiences` flag must match the target Cloud Run URL exactly; a token for `$DEV_NEXT_URL` will 401 against `$DEV_IMPORTER_URL`.
 - **Never suppress a non-zero smoke exit.** If `npm run smoke:dev` exits non-zero, that's the headline of the report — capture the failing step and stop. Cleanup already ran via the trap.
 - **Never stop the dev DB as a "tidy up" step.** Leaving it running is the default; stopping disrupts the next session and costs a 60s restart.
-- **Never invent endpoints.** If a probe returns 404, first verify the endpoint exists in the source (`grep -rn "app.get\|@app.post\|export const POST" apps/recipe-url-importer/src/ src/app/api/`). The importer's `/healthz` returned 404 during this skill's construction because the deployed revision didn't include it yet — the skill probes `/version` instead, which both code and the live revision have.
+- **Never invent endpoints.** If a probe returns 404, first verify the endpoint exists in the source (`grep -rn "app.get\|@app.post\|export const POST" apps/recipe-url-importer/src/ src/app/api/`). One non-obvious trap: Google Frontend on `*.run.app` blackholes the exact path `/healthz` at the edge — a 404 there with no `server: Google Frontend` header means the request never reached the container. The importer's health endpoint is `/health`.
 - **Never paper over a missing prerequisite.** If `roles/iam.serviceAccountTokenCreator` isn't granted or `.env.dev.local` isn't populated, stop and surface the exact command from [dev-deployments.md](../../../docs/verification/dev-deployments.md). Silent fallbacks lead to later confusion.
 
 ## Report template
@@ -218,7 +218,7 @@ _(or paste the failure line + stderr if any step failed)_
 
 ### Additional probes
 
-- **Importer `/version`**: `{"service":"recipe-url-importer","version":"...","git_sha":"<sha>"}` ✅
+- **Importer `/health`**: `{"status":"ok"}` ✅
 - **Timeline unauth gating**: `401` ✅ / `200` ❌ (leak!)
 - **HTML-grep /timeline**: found `<title>` ✅ / markup changed ❌
 

--- a/apps/recipe-url-importer/CLAUDE.md
+++ b/apps/recipe-url-importer/CLAUDE.md
@@ -7,6 +7,7 @@ Standalone Python service that fetches a public recipe URL and returns a normali
 - **No database access.** This service only reads URLs from the public internet. Don't import Prisma here; don't add DB-backed features.
 - **Called by the Next backend**, not the browser directly. The client lives in [src/lib/recipeImporter.ts](../../src/lib/recipeImporter.ts). Authentication in production is via Cloud Run OIDC (only the main API service account is invoker).
 - **Stateless aside from caching.** The optional response cache and per-IP / per-domain rate limits are in-process — fine for a single Cloud Run instance, would need redis if scaled.
+- **Health endpoint is `/health`, not `/healthz`.** Google Frontend on `*.run.app` blackholes the exact lowercase path `/healthz` at the edge — the request never reaches the container, so the endpoint is unreachable regardless of what's registered in FastAPI. Any other casing/suffix passes through. See #113.
 
 ## Module layout
 

--- a/apps/recipe-url-importer/SPEC.md
+++ b/apps/recipe-url-importer/SPEC.md
@@ -167,7 +167,7 @@ Includes `request_id` echoed back for support/correlation.
 - `HEURISTIC_EXTRACTION_USED`
 
 **Health Endpoint**
-GET `/healthz`
+GET `/health`
 
 - 200 OK if service is healthy
 

--- a/apps/recipe-url-importer/src/recipe_url_importer/app.py
+++ b/apps/recipe-url-importer/src/recipe_url_importer/app.py
@@ -102,8 +102,8 @@ async def http_exception_handler(request: Request, exc: HTTPException):
     )
 
 
-@app.get("/healthz")
-async def healthz():
+@app.get("/health")
+async def health():
     return {"status": "ok"}
 
 


### PR DESCRIPTION
Closes #113.

## Summary

The importer's `/healthz` endpoint returned an HTML 404 from the Google Frontend on the live dev deployment — the request never reached the Cloud Run container. Reproduced and isolated to a platform-level behavior on `*.run.app`: Google Frontend blackholes the exact lowercase path `/healthz` at the edge. Every other variant (`/health`, `/Healthz`, `/healthzz`, `/healthz/`) passes through to FastAPI, and the same behavior reproduces on the Next Cloud Run service — so it's not importer-specific and not a stale build.

Fix: rename the route to `/health`, matching the existing convention in `apps/api/src/routers/health.py` and `src/app/api/health/route.ts`. The `/healthz` name was the outlier.

## Investigation (before vs after)

Against the live dev importer (before rename):

```
GET /healthz → HTTP 404, content-type: text/html, content-length: 1568
  ↳ No `server: Google Frontend` header, no `x-cloud-trace-context` → edge 404
GET /version → HTTP 200, server: Google Frontend, x-cloud-trace-context present
GET /Healthz → HTTP 404, content-type: application/json, content-length: 22
  ↳ `server: Google Frontend` present → FastAPI's 404
```

Same edge-level 404 reproduces on `$DEV_NEXT_URL/healthz` too — confirming GFE, not the container.

## Changes

- `apps/recipe-url-importer/src/recipe_url_importer/app.py` — rename route handler `/healthz` → `/health`
- `apps/recipe-url-importer/SPEC.md` — update behavior contract
- `apps/recipe-url-importer/CLAUDE.md` — landmine note so a future session doesn't re-introduce `/healthz`
- `.claude/skills/release-testing/SKILL.md` — probe `/health` (step 5, triage table, report template); the ""Never invent endpoints"" guardrail now explains the GFE reservation so the next session recognizes the symptom

## Test plan

Local verification run in this worktree:

- [x] `PYTHONPATH=src pytest` → 4 passed
- [x] `ruff check .` → all checks pass
- [x] Started local uvicorn, confirmed `/health` → 200 `{""status"":""ok""}`, `/healthz` → FastAPI 404 (expected), `/version` → 200
- [ ] **Post-merge live verification:** once `deploy-dev.yml` ships a new revision, run `curl -sS -D - "$DEV_IMPORTER_URL/health"` with impersonated token — expect 200 + `server: Google Frontend`. If that's green, this unblocks removing the `/version`-workaround references that remain implied in older commits.

mypy could not run locally (not installed in either venv); CI's importer workflow will cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)