### PR TITLE
chore: SEED_E2E=1 deterministic fixtures in prisma/seed.ts (#101)

### DIFF
--- a/docs/verification/next-api.md
+++ b/docs/verification/next-api.md
@@ -30,6 +30,16 @@ The script reads `CLAUDE_TEST_USER` / `CLAUDE_TEST_PASSWORD` from env or `.env.l
 
 Reuse with `-b "$COOKIES"` on every subsequent call. Failure modes: `401` invalid credentials (re-run `npm run db:seed`), `403` no membership, `429` rate-limited.
 
+### Deterministic fixtures for Playwright (`SEED_E2E=1`)
+
+When you need the full timeline population a browser smoke run asserts against (one post, one comment, one reaction, one recipe, one cooked event, one notification — all with known IDs / titles), set the flag on top of the normal seed:
+
+```bash
+SEED_E2E=1 npm run db:seed
+```
+
+Idempotent — re-running won't duplicate rows. See [prisma/CLAUDE.md](../../prisma/CLAUDE.md#seed_e2e1--playwright-fixture-bundle) for the list of IDs and titles.
+
 ## Invariants every handler must preserve
 
 Grep the diff and confirm each of these is still true:

--- a/prisma/CLAUDE.md
+++ b/prisma/CLAUDE.md
@@ -28,8 +28,22 @@ The `DATABASE_URL` env var picks the connection. `PRISMA_SCHEMA` is read by Pris
 - Creates one `FamilySpace` if none exists, hashing `FAMILY_MASTER_KEY` (or generating one and **printing it** — save the output).
 - Loads the curated tag catalog (diet/allergen/heat/flavor/cuisine).
 - Will not overwrite an existing family or rotate the master key.
+- Skipped in `NODE_ENV=production`: seeds the `claude-test` dev user (credentials from `CLAUDE_TEST_USER` / `CLAUDE_TEST_PASSWORD`, defaults in [seed.ts](seed.ts)).
 
 To rotate the master key, do it manually via the DB — there is no API for it.
+
+### `SEED_E2E=1` — Playwright fixture bundle
+
+Setting `SEED_E2E=1` (alongside the default non-prod `NODE_ENV`) adds a deterministic fixture set on top of the baseline seed, for the Playwright smoke suite (#58 / #102):
+
+- one post (`id='e2e-post-001'`, title `E2E Seed Post`) authored by `claude-test`
+- one comment on that post (`id='e2e-comment-001'`)
+- one reaction on that post (`id='e2e-reaction-001'`, emoji `❤️`)
+- one recipe post (`id='e2e-recipe-001'`, title `E2E Seed Recipe`, `hasRecipeDetails=true`) with `RecipeDetails`
+- one cooked event against the recipe (`id='e2e-cooked-001'`, rating 5)
+- one notification for `claude-test` (`id='e2e-notification-001'`, type `comment`)
+
+All upserts keyed on the deterministic IDs, so re-running `SEED_E2E=1 npm run db:seed` does not duplicate rows. Specs assert by ID or content (`E2E Seed Post`, etc.). Ignored when `NODE_ENV=production` or `SEED_E2E` is unset.
 
 ## Schema gotchas
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -84,13 +84,16 @@ async function main() {
     familySpaceId = existingFamily.id;
   }
 
-  await seedTestUser(familySpaceId);
+  const testUserId = await seedTestUser(familySpaceId);
+  if (testUserId) {
+    await seedE2EFixtures(familySpaceId, testUserId);
+  }
 }
 
-async function seedTestUser(familySpaceId: string) {
+async function seedTestUser(familySpaceId: string): Promise<string | null> {
   if (process.env.NODE_ENV === 'production') {
     console.log('⏭️  Skipping claude-test user (NODE_ENV=production)');
-    return;
+    return null;
   }
 
   const username =
@@ -126,6 +129,119 @@ async function seedTestUser(familySpaceId: string) {
   });
 
   console.log(`🧪 Seeded claude-test user (username="${username}")`);
+  return user.id;
+}
+
+// Deterministic fixture IDs — Playwright specs assert by content/ID.
+const E2E_POST_ID = 'e2e-post-001';
+const E2E_COMMENT_ID = 'e2e-comment-001';
+const E2E_REACTION_ID = 'e2e-reaction-001';
+const E2E_RECIPE_POST_ID = 'e2e-recipe-001';
+const E2E_RECIPE_DETAILS_ID = 'e2e-recipe-details-001';
+const E2E_COOKED_EVENT_ID = 'e2e-cooked-001';
+const E2E_NOTIFICATION_ID = 'e2e-notification-001';
+
+async function seedE2EFixtures(familySpaceId: string, userId: string) {
+  if (process.env.SEED_E2E !== '1') return;
+  if (process.env.NODE_ENV === 'production') {
+    console.log('⏭️  Skipping E2E fixtures (NODE_ENV=production)');
+    return;
+  }
+
+  const postData = {
+    familySpaceId,
+    authorId: userId,
+    title: 'E2E Seed Post',
+    caption: 'Deterministic post for Playwright smoke suite',
+    hasRecipeDetails: false,
+  };
+  await prisma.post.upsert({
+    where: { id: E2E_POST_ID },
+    update: postData,
+    create: { id: E2E_POST_ID, ...postData },
+  });
+
+  const commentData = {
+    postId: E2E_POST_ID,
+    authorId: userId,
+    text: 'E2E seed comment',
+  };
+  await prisma.comment.upsert({
+    where: { id: E2E_COMMENT_ID },
+    update: commentData,
+    create: { id: E2E_COMMENT_ID, ...commentData },
+  });
+
+  const reactionData = {
+    targetType: 'post',
+    targetId: E2E_POST_ID,
+    userId,
+    emoji: '❤️',
+    postId: E2E_POST_ID,
+  };
+  await prisma.reaction.upsert({
+    where: { id: E2E_REACTION_ID },
+    update: reactionData,
+    create: { id: E2E_REACTION_ID, ...reactionData },
+  });
+
+  const recipePostData = {
+    familySpaceId,
+    authorId: userId,
+    title: 'E2E Seed Recipe',
+    caption: 'Deterministic recipe for Playwright smoke suite',
+    hasRecipeDetails: true,
+  };
+  await prisma.post.upsert({
+    where: { id: E2E_RECIPE_POST_ID },
+    update: recipePostData,
+    create: { id: E2E_RECIPE_POST_ID, ...recipePostData },
+  });
+
+  const recipeDetailsData = {
+    postId: E2E_RECIPE_POST_ID,
+    ingredients: '1 cup flour\n1 cup sugar',
+    steps: '1. Mix.\n2. Bake at 350F for 20 minutes.',
+    totalTime: 30,
+    servings: 4,
+    difficulty: 'easy',
+  };
+  await prisma.recipeDetails.upsert({
+    where: { id: E2E_RECIPE_DETAILS_ID },
+    update: recipeDetailsData,
+    create: { id: E2E_RECIPE_DETAILS_ID, ...recipeDetailsData },
+  });
+
+  const cookedEventData = {
+    postId: E2E_RECIPE_POST_ID,
+    userId,
+    rating: 5,
+    note: 'E2E seed cooked event',
+  };
+  await prisma.cookedEvent.upsert({
+    where: { id: E2E_COOKED_EVENT_ID },
+    update: cookedEventData,
+    create: { id: E2E_COOKED_EVENT_ID, ...cookedEventData },
+  });
+
+  // V1 only seeds one user, so actor == recipient here. The DB allows it;
+  // UI business logic that filters self-notifications is validated in tests,
+  // not at seed time.
+  const notificationData = {
+    familySpaceId,
+    recipientId: userId,
+    actorId: userId,
+    type: 'comment',
+    postId: E2E_POST_ID,
+    commentId: E2E_COMMENT_ID,
+  };
+  await prisma.notification.upsert({
+    where: { id: E2E_NOTIFICATION_ID },
+    update: notificationData,
+    create: { id: E2E_NOTIFICATION_ID, ...notificationData },
+  });
+
+  console.log('🧪 Seeded E2E fixtures (SEED_E2E=1)');
 }
 
 function generateMasterKey() {


### PR DESCRIPTION
## Summary

- Opt-in `SEED_E2E=1` branch in `prisma/seed.ts` creates a deterministic fixture bundle on top of the baseline seed: one post + comment + reaction, one recipe + `RecipeDetails` + cooked event, and one notification — all with hard-coded IDs (`e2e-post-001`, `e2e-comment-001`, etc.) so Playwright specs can assert by content and re-runs don't duplicate rows.
- Gated alongside the existing `NODE_ENV=production` guard; without the flag the seed behaves exactly as before (`users=1`, `tags=31`, all fixture tables empty).
- Flag documented in `prisma/CLAUDE.md` and `docs/verification/next-api.md`.

## Closes

Closes #101

## Test notes

Verified against a fresh sandbox Postgres (`scripts/local-stack-down.sh --purge && scripts/local-stack-up.sh`):

1. **No flag, fresh DB** → `users=1 tags=31 posts=0 comments=0 reactions=0 recipe_details=0 cooked_events=0 notifications=0` (unchanged baseline).
2. **First `SEED_E2E=1 npm run db:seed`** → `posts=2 comments=1 reactions=1 recipe_details=1 cooked_events=1 notifications=1` (2 posts = 1 regular + 1 recipe).
3. **Second `SEED_E2E=1 npm run db:seed`** → identical counts (idempotent via deterministic-ID upserts).
4. `npm run type-check`, `npm run lint`, `npm test` (963 tests across 46 suites) all green.

Notes:
- Notification has `actorId == recipientId` since V1 only seeds one user. The DB allows it; UI-layer self-notification filtering is covered in app tests, not at seed time.
- Unblocks #102 (Playwright job in `ci.yml`), which needs this fixture set to assert against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)