### PR TITLE
chore: wire Playwright e2e job into ci.yml (#102)

### DIFF
--- a/.github/GITHUB_GUIDE.md
+++ b/.github/GITHUB_GUIDE.md
@@ -139,7 +139,7 @@ Shared settings on both branches:
 - **Required approving reviews: 0** — as a solo maintainer, self-merge is allowed
 - **Admins not enforced** — the repo owner can bypass in genuine emergencies (use sparingly)
 
-Required status checks (from [ci.yml](workflows/ci.yml), the only workflow that runs on every PR): `typecheck`, `lint`, `test`, `build`, `container-scan`, `prisma-validate`, `dependency-scan`, `sast-semgrep`, `iac-scan`, `secrets-scan`. Job names in [api-ci.yml](workflows/api-ci.yml) and [recipe-url-importer-ci.yml](workflows/recipe-url-importer-ci.yml) are path-filtered, so they are **not** listed as required (a path-filtered required check that never runs would permanently block merges). They share names (`lint`, `typecheck`, etc.) with ci.yml jobs, so when they do run and fail, the shared-name required check fails too — effectively required when the relevant paths change.
+Required status checks (from [ci.yml](workflows/ci.yml), the only workflow that runs on every PR): `typecheck`, `lint`, `test`, `e2e`, `build`, `container-scan`, `prisma-validate`, `dependency-scan`, `sast-semgrep`, `iac-scan`, `secrets-scan`. Job names in [api-ci.yml](workflows/api-ci.yml) and [recipe-url-importer-ci.yml](workflows/recipe-url-importer-ci.yml) are path-filtered, so they are **not** listed as required (a path-filtered required check that never runs would permanently block merges). They share names (`lint`, `typecheck`, etc.) with ci.yml jobs, so when they do run and fail, the shared-name required check fails too — effectively required when the relevant paths change.
 
 Difference between branches:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,64 @@ jobs:
       - run: npm ci
       - run: npm run test
 
+  e2e:
+    runs-on: ubuntu-latest
+    needs: [test]
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: family_recipe_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/family_recipe_e2e
+      JWT_SECRET: ci-only-jwt-secret-not-for-production
+      FAMILY_MASTER_KEY: ci-only-family-master-key
+      CLAUDE_TEST_USER: claude-test
+      CLAUDE_TEST_PASSWORD: claude-test-password
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - name: Prisma generate + push
+        run: |
+          npm run db:generate
+          npm run db:push
+      - name: Seed with E2E fixtures
+        run: SEED_E2E=1 npm run db:seed
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+      - name: Install Playwright system deps (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+      - name: Run Playwright smoke suite
+        run: npm run test:e2e
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
   build:
     runs-on: ubuntu-latest
     needs: [test]

--- a/docs/verification/README.md
+++ b/docs/verification/README.md
@@ -8,6 +8,8 @@ Decision rationale and tool alternatives: [docs/research/claude-local-verificati
 
 **Before opening any PR.** The pre-commit hook runs `type-check` + `lint-staged`; nothing else is automatic. Verification catches what the type checker can't: wrong response shapes, broken gating, silent 500s, hydration bugs, cross-family data leaks.
 
+**What CI covers for you.** The `e2e` job in [ci.yml](../../.github/workflows/ci.yml) runs the Playwright smoke suite in [e2e/](../../e2e/) against an ephemeral Postgres + `next start` on every PR (fails uploads the `playwright-report/` artifact). That catches login + protected-route regressions automatically; the local playbooks below still cover everything the smoke suite doesn't yet.
+
 ## Local vs dev deployment
 
 | Stage                           | Target                                          | Playbook                                 |


### PR DESCRIPTION
Closes #102.

## Summary

- Adds an `e2e` job to [.github/workflows/ci.yml](.github/workflows/ci.yml) that boots `next start` against an ephemeral Postgres 16 service container, seeds with `SEED_E2E=1` (fixtures from #101), and runs the Playwright smoke suite in [e2e/](e2e/). Caches `~/.cache/ms-playwright` keyed on package-lock. Uploads `playwright-report/` as an artifact on failure (7-day retention).
- Adds `e2e` to the documented required-checks list in [.github/GITHUB_GUIDE.md](.github/GITHUB_GUIDE.md).
- References the new CI gate from [docs/verification/README.md](docs/verification/README.md) under "When to verify", so local playbooks don't have to rehash what CI now covers.

## Design notes

- **No browser cache-hit shortcut on the action**: the ticket mentioned `microsoft/playwright-github-action`, but that repo is archived. Using the modern equivalent (`actions/cache` on `~/.cache/ms-playwright` + `npx playwright install --with-deps` on miss, `npx playwright install-deps` on hit) gets the same behavior.
- **Reuses `playwright.config.ts`'s `webServer` block** — it already runs `npm run build && npm run start` locally, and since `PLAYWRIGHT_BASE_URL` is unset in CI, Playwright will spin up `next start` itself. No duplicate boot logic.
- **Env values are dev-only placeholders** — `JWT_SECRET` and `FAMILY_MASTER_KEY` are set inline (not secrets) because the job runs against an ephemeral container with no external access.

## Follow-ups not in this PR

- Branch protection on `develop` / `main` needs `e2e` added to required status checks after the first green run (owner-only change; doc update in GITHUB_GUIDE.md is in place to reflect the intended state).
- Post-deploy dev smoke (`PLAYWRIGHT_BASE_URL=$DEV_URL` + `@smoke` tag) is out of scope here — tracked separately per #112's auth-proxy work.

## Test plan

- [ ] `e2e` job runs green on this PR, wall-clock under 3 minutes
- [ ] On a throwaway follow-up PR: break `e2e/auth.spec.ts` → verify the job fails and `playwright-report/` artifact is downloadable
- [ ] After merge: repo owner adds `e2e` to required status checks on `develop` + `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)