### PR TITLE
chore: CI regression guard for Prisma schema ↔ migrations drift (#99)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,35 @@ jobs:
         env:
           DATABASE_URL: postgresql://user:pass@localhost:5432/db
 
+  prisma-drift-check:
+    runs-on: ubuntu-latest
+    needs: [typecheck]
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: drift_check
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/drift_check
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - name: Replay prisma/migrations and diff against both schemas
+        run: scripts/check-prisma-drift.sh
+
   dependency-scan:
     runs-on: ubuntu-latest
     needs: [typecheck]

--- a/docs/verification/prisma.md
+++ b/docs/verification/prisma.md
@@ -100,8 +100,11 @@ npm run db:seed
 npm run type-check                   # catches TS client drift
 npx prisma validate --schema prisma/schema.postgres.prisma
 npx prisma format --check prisma/schema.postgres.prisma   # CI runs this
+npm run db:drift-check               # replays migrations, diffs vs both schemas (CI-enforced)
 npm test
 ```
+
+`db:drift-check` needs a throwaway Postgres — set `DATABASE_URL` to a DB you don't care about (not `family_recipe_dev`). In CI, the `prisma-drift-check` job spins up a fresh `postgres:16` service container for this.
 
 If FastAPI tests also exist for the affected model:
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "db:push": "prisma db push --schema prisma/schema.postgres.node.prisma",
     "db:studio": "prisma studio --schema prisma/schema.postgres.node.prisma",
     "db:seed": "tsx prisma/seed.ts",
+    "db:drift-check": "scripts/check-prisma-drift.sh",
     "smoke:dev": "scripts/smoke-dev.sh"
   },
   "dependencies": {

--- a/prisma/CLAUDE.md
+++ b/prisma/CLAUDE.md
@@ -45,6 +45,22 @@ Setting `SEED_E2E=1` (alongside the default non-prod `NODE_ENV`) adds a determin
 
 All upserts keyed on the deterministic IDs, so re-running `SEED_E2E=1 npm run db:seed` does not duplicate rows. Specs assert by ID or content (`E2E Seed Post`, etc.). Ignored when `NODE_ENV=production` or `SEED_E2E` is unset.
 
+## Drift check (CI-enforced)
+
+Every PR runs [scripts/check-prisma-drift.sh](../scripts/check-prisma-drift.sh) via the `prisma-drift-check` job in [ci.yml](../.github/workflows/ci.yml). The script replays `prisma/migrations/` into a throwaway Postgres, then runs `prisma migrate diff` against both Postgres schemas. A non-empty diff in either direction fails the job, which is how we enforce the two-schemas-in-lockstep rule (and catches missing `@db.Timestamptz(6)`, forgotten `@default(now())`, divergent cascade actions, index-name mismatches, etc.).
+
+To reproduce locally:
+
+```bash
+# any throwaway Postgres; `public` schema is dropped/recreated by the script
+DATABASE_URL=postgresql://family_app:dev-only-password@localhost:5434/drift_check \
+  npm run db:drift-check
+```
+
+When CI fails, the diff is printed as SQL — apply the suggested fix to whichever side is wrong (usually the schema, sometimes a follow-up migration).
+
+**Migration apply order**: the script applies migrations lexicographically with a retry pass, so a migration that references tables created by a later-named migration (e.g. `20250225210000_add_feedback_submissions` referencing `users`/`family_spaces` from `20251130224838_add_recipe_courses`) still applies. If you add a new migration that only works after a later one, it'll apply on pass 2. A migration that can't apply after any number of passes — a genuine error — fails the job with the underlying Postgres error.
+
 ## Schema gotchas
 
 - **Field naming**: TypeScript camelCase (`familySpaceId`) maps to snake_case columns (`@map("family_space_id")`). Always set both when adding fields.

--- a/prisma/migrations/20260422000000_align_notifications_fk_and_indexes/migration.sql
+++ b/prisma/migrations/20260422000000_align_notifications_fk_and_indexes/migration.sql
@@ -1,0 +1,41 @@
+-- Align live schema with Prisma-generated DDL so `prisma migrate diff` is empty.
+-- The two sources of drift this migration clears:
+--   1. 14 pre-Prisma indexes still named `idx_*` from 20251205094500_add_core_indexes;
+--      Prisma generates `<table>_<cols>_idx` names for the equivalent `@@index([...])`.
+--   2. notifications FKs created in 20251223150000_add_notifications as a single
+--      multi-clause ALTER TABLE without `ON UPDATE CASCADE` and in a different
+--      order than the Prisma schema; Prisma's default is `ON UPDATE CASCADE` and
+--      its canonical order follows the relation declaration order in the model.
+
+-- RenameIndex
+ALTER INDEX "idx_comments_post_created" RENAME TO "comments_post_id_created_at_idx";
+ALTER INDEX "idx_cooked_events_post" RENAME TO "cooked_events_post_id_idx";
+ALTER INDEX "idx_cooked_events_user" RENAME TO "cooked_events_user_id_idx";
+ALTER INDEX "idx_family_memberships_family" RENAME TO "family_memberships_family_space_id_idx";
+ALTER INDEX "idx_favorites_post" RENAME TO "favorites_post_id_idx";
+ALTER INDEX "idx_favorites_user" RENAME TO "favorites_user_id_idx";
+ALTER INDEX "idx_post_photos_post" RENAME TO "post_photos_post_id_idx";
+ALTER INDEX "idx_post_tags_post" RENAME TO "post_tags_post_id_idx";
+ALTER INDEX "idx_post_tags_tag" RENAME TO "post_tags_tag_id_idx";
+ALTER INDEX "idx_posts_author" RENAME TO "posts_author_id_idx";
+ALTER INDEX "idx_posts_family_created" RENAME TO "posts_family_space_id_created_at_idx";
+ALTER INDEX "idx_reactions_comment" RENAME TO "reactions_comment_id_idx";
+ALTER INDEX "idx_reactions_post" RENAME TO "reactions_post_id_idx";
+ALTER INDEX "idx_reactions_target" RENAME TO "reactions_target_type_target_id_idx";
+
+-- Recreate notifications FKs in the Prisma-canonical order with ON UPDATE CASCADE.
+-- Primary keys are text cuids and never update in practice, so the ON UPDATE
+-- change is inert for this table; we set it to match the schema for drift purity.
+ALTER TABLE "notifications" DROP CONSTRAINT "notifications_recipient_id_fkey";
+ALTER TABLE "notifications" DROP CONSTRAINT "notifications_actor_id_fkey";
+ALTER TABLE "notifications" DROP CONSTRAINT "notifications_post_id_fkey";
+ALTER TABLE "notifications" DROP CONSTRAINT "notifications_comment_id_fkey";
+ALTER TABLE "notifications" DROP CONSTRAINT "notifications_cooked_event_id_fkey";
+ALTER TABLE "notifications" DROP CONSTRAINT "notifications_family_space_id_fkey";
+
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_recipient_id_fkey" FOREIGN KEY ("recipient_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_actor_id_fkey" FOREIGN KEY ("actor_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_post_id_fkey" FOREIGN KEY ("post_id") REFERENCES "posts"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_comment_id_fkey" FOREIGN KEY ("comment_id") REFERENCES "comments"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_cooked_event_id_fkey" FOREIGN KEY ("cooked_event_id") REFERENCES "cooked_events"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_family_space_id_fkey" FOREIGN KEY ("family_space_id") REFERENCES "family_spaces"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/scripts/check-prisma-drift.sh
+++ b/scripts/check-prisma-drift.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# check-prisma-drift.sh — replays prisma/migrations into a throwaway Postgres and
+# fails if `prisma migrate diff` against either Postgres schema produces SQL.
+#
+# Used by the `prisma-drift-check` CI job and runnable locally:
+#
+#   DATABASE_URL=postgresql://user:pass@localhost:5432/drift \
+#     scripts/check-prisma-drift.sh
+#
+# The DB pointed at by DATABASE_URL is reset to an empty `public` schema by the
+# script, so point it at a throwaway DB — never the local dev DB.
+#
+# Migration apply order is lexicographic with a retry pass: if a migration fails
+# (typically because it references a table created in a later-named migration),
+# it's deferred and retried after the rest have applied. This tolerates the one
+# known out-of-order dependency in this repo (20250225210000_add_feedback_submissions
+# references users/family_spaces from 20251130224838_add_recipe_courses).
+#
+# Only Node + the Prisma CLI are required; no local `psql` dependency.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+: "${DATABASE_URL:?DATABASE_URL must point at a throwaway Postgres DB}"
+
+SCHEMAS=(
+  "prisma/schema.postgres.prisma"
+  "prisma/schema.postgres.node.prisma"
+)
+
+# Reset public schema so replays start from empty state. We intentionally don't
+# drop the DB itself — the caller owns that lifecycle.
+printf 'DROP SCHEMA IF EXISTS public CASCADE;\nCREATE SCHEMA public;\n' \
+  | npx --no-install prisma db execute --url "$DATABASE_URL" --stdin >/dev/null
+
+# Collect migration files in lexicographic order (bash 3-safe, macOS-friendly).
+PENDING=()
+while IFS= read -r line; do
+  PENDING+=("$line")
+done < <(find prisma/migrations -mindepth 2 -name migration.sql | sort)
+
+# Iterate retry passes until either everything is applied or no forward progress
+# is made. A single stuck migration yields a non-empty PENDING and non-zero exit.
+PASS=1
+while [ "${#PENDING[@]}" -gt 0 ]; do
+  FAILED=()
+  PROGRESS=0
+  for f in "${PENDING[@]}"; do
+    if npx --no-install prisma db execute --url "$DATABASE_URL" --file "$f" >/dev/null 2>&1; then
+      echo "pass $PASS: applied $f"
+      PROGRESS=1
+    else
+      FAILED+=("$f")
+    fi
+  done
+  if [ "$PROGRESS" -eq 0 ]; then
+    echo ""
+    echo "ERROR: Could not apply the following migrations after $((PASS - 1)) passes:" >&2
+    for f in "${FAILED[@]}"; do
+      echo "  - $f" >&2
+    done
+    echo ""
+    echo "Re-running the first failing migration with output to surface the error:" >&2
+    npx --no-install prisma db execute --url "$DATABASE_URL" --file "${FAILED[0]}" >&2 || true
+    exit 1
+  fi
+  PENDING=(${FAILED[@]+"${FAILED[@]}"})
+  PASS=$((PASS + 1))
+done
+
+echo ""
+echo "All migrations applied. Diffing against Prisma schemas..."
+echo ""
+
+DRIFT=0
+for schema in "${SCHEMAS[@]}"; do
+  echo "=== prisma migrate diff vs $schema ==="
+  # --exit-code: 0=no diff, 2=diff found. 1 is reserved for errors.
+  set +e
+  OUT=$(npx --no-install prisma migrate diff \
+    --from-url "$DATABASE_URL" \
+    --to-schema-datamodel "$schema" \
+    --script \
+    --exit-code 2>&1)
+  code=$?
+  set -e
+  if [ "$code" -eq 0 ]; then
+    echo "OK — migrations match $schema."
+  elif [ "$code" -eq 2 ]; then
+    echo "DRIFT — migrations do not match $schema. Suggested fix:"
+    echo ""
+    echo "$OUT"
+    echo ""
+    DRIFT=1
+  else
+    echo "prisma migrate diff failed with exit code $code:" >&2
+    echo "$OUT" >&2
+    exit 1
+  fi
+  echo ""
+done
+
+if [ "$DRIFT" -ne 0 ]; then
+  echo "ERROR: Prisma schema(s) are drifting from prisma/migrations/." >&2
+  echo "Update the schema(s) or add a follow-up migration so the diff is empty." >&2
+  exit 1
+fi
+
+echo "All Prisma schemas match the migration history."


### PR DESCRIPTION
## Summary

Closes #99. Adds a `prisma-drift-check` CI job that replays `prisma/migrations/` into a throwaway `postgres:16` and fails if `prisma migrate diff` against either Postgres schema produces SQL. Catches missing `@db.Timestamptz(6)`, forgotten `@default(now())`, divergent cascade actions, or any other schema ↔ migration divergence before prod-migration review.

- **New migration** — `20260422000000_align_notifications_fk_and_indexes` clears the pre-existing cosmetic baseline drift (14 pre-Prisma `idx_*` names + notifications FKs created without `ON UPDATE CASCADE` and in non-canonical order). Forward-only, transactional, low-risk — rename 14 indexes (metadata only) + drop/re-add 6 FKs on `notifications` (small/new table, PKs are cuids so `ON UPDATE` is inert in practice).
- **Script** — [scripts/check-prisma-drift.sh](./scripts/check-prisma-drift.sh) uses `prisma db execute` (no `psql` dependency). Lex-order apply with a retry pass so the one known out-of-order reference (`20250225210000_add_feedback_submissions` → `users`/`family_spaces` from `20251130224838_add_recipe_courses`) still resolves.
- **CI** — new `prisma-drift-check` job needs `typecheck`, spins up a fresh postgres service, runs the script.
- **Docs** — [prisma/CLAUDE.md](./prisma/CLAUDE.md) explains the check + how to reproduce locally; [docs/verification/prisma.md](./docs/verification/prisma.md) adds `npm run db:drift-check` to the PR checklist.

## Blast radius

- On merge, `prisma migrate deploy` runs the cleanup migration against dev Cloud SQL. Renames + FK reorder only — no data touched.
- Branch protection required-checks list does not yet include `prisma-drift-check`; the job will run on this PR but won't be *required* until you add it (REST API, per [.github/GITHUB_GUIDE.md](./.github/GITHUB_GUIDE.md#L142-L143)).

## Test plan

- [x] Green path: clean tree → both schemas diff-empty (`npm run db:drift-check` locally)
- [x] Red path (schema regression): removed `@db.Timestamptz(6)` from a notifications field → check fails with a precise `ALTER TABLE ... SET DATA TYPE TIMESTAMP(3);` suggestion. Restored.
- [x] `npm run type-check` green
- [x] `npm run lint` green
- [x] `npx prisma validate` green (both schemas)
- [x] `npm test` — 963 passed
- [x] CI — confirm new `prisma-drift-check` job goes green on this PR
- [ ] After merge, confirm dev `prisma migrate deploy` applies the cleanup migration cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)