### PR TITLE
chore: harden check-prisma-drift.sh (full failure logs + dev-DB guard) (#119)

### DIFF
--- a/scripts/check-prisma-drift.sh
+++ b/scripts/check-prisma-drift.sh
@@ -26,6 +26,25 @@ cd "$REPO_ROOT"
 
 : "${DATABASE_URL:?DATABASE_URL must point at a throwaway Postgres DB}"
 
+# Refuse obviously non-throwaway DBs. This script's first action is
+# `DROP SCHEMA public CASCADE`, so running it against the local dev DB or a
+# prod-shaped URL would wipe real data.
+URL_NO_QUERY="${DATABASE_URL%%\?*}"
+DB_NAME="${URL_NO_QUERY##*/}"
+BLOCKED_DBS=(
+  "family_recipe_dev"
+  "family_recipe_prod"
+  "family-recipe-prod"
+)
+for blocked in "${BLOCKED_DBS[@]}"; do
+  if [ "$DB_NAME" = "$blocked" ]; then
+    echo "ERROR: refusing to run against DATABASE_URL with db name '$DB_NAME'." >&2
+    echo "This script begins with 'DROP SCHEMA public CASCADE'. Point DATABASE_URL" >&2
+    echo "at a throwaway DB (e.g. drift_check) before re-running." >&2
+    exit 1
+  fi
+done
+
 SCHEMAS=(
   "prisma/schema.postgres.prisma"
   "prisma/schema.postgres.node.prisma"
@@ -63,8 +82,12 @@ while [ "${#PENDING[@]}" -gt 0 ]; do
       echo "  - $f" >&2
     done
     echo ""
-    echo "Re-running the first failing migration with output to surface the error:" >&2
-    npx --no-install prisma db execute --url "$DATABASE_URL" --file "${FAILED[0]}" >&2 || true
+    echo "Re-running each failing migration with output to surface the error(s):" >&2
+    for f in "${FAILED[@]}"; do
+      echo "" >&2
+      echo "--- $f ---" >&2
+      npx --no-install prisma db execute --url "$DATABASE_URL" --file "$f" >&2 || true
+    done
     exit 1
   fi
   PENDING=(${FAILED[@]+"${FAILED[@]}"})


### PR DESCRIPTION
## Summary

- Loop over all failing migrations on the retry-plateau branch and re-run each with output to stderr, so multi-stuck cases surface every error instead of only `FAILED[0]`.
- Add a guard that refuses known non-throwaway DB names (`family_recipe_dev`, `family_recipe_prod`, `family-recipe-prod`) before any SQL runs. The script starts with `DROP SCHEMA public CASCADE`, so a misconfigured `DATABASE_URL` would wipe the local dev DB. Parses `DATABASE_URL` by stripping the query string first so Cloud-SQL-style `?host=/cloudsql/...` URLs don't mask the db name.

## Closes

Closes #119

## Test notes

Verified locally against a throwaway Postgres (`postgres:16` in Docker on :55437, `drift_check` DB):

- **Guard — blocked names:** `DATABASE_URL=.../family_recipe_dev`, `.../family_recipe_prod?sslmode=disable`, and `.../family_recipe_prod?host=/cloudsql/PROJECT:REGION:family-recipe-prod` all exit 1 with the guard message before any SQL executes.
- **Guard — allowed name:** `DATABASE_URL=.../drift_check` passes the guard silently and proceeds (failing later only because the DB isn't reachable in the probe).
- **Green path:** full run against a live `drift_check` Postgres applies all 7 existing migrations (incl. the known pass-2 deferred `add_feedback_submissions`) and reports both schemas matching.
- **Multi-failure plateau:** temporarily added two mutually-referencing migrations (`29990101000000_broken_one`, `29990101000001_broken_two`). Output listed both under the plateau header and printed each one's `Error: P1014` under its own `--- path ---` banner; old behavior would have shown only the first. Broken migrations removed before commit — `git status` clean aside from the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)