### PR TITLE
chore: add prisma-drift-check to required status checks on develop/main (#118)

### DIFF
--- a/.github/GITHUB_GUIDE.md
+++ b/.github/GITHUB_GUIDE.md
@@ -139,7 +139,7 @@ Shared settings on both branches:
 - **Required approving reviews: 0** — as a solo maintainer, self-merge is allowed
 - **Admins not enforced** — the repo owner can bypass in genuine emergencies (use sparingly)
 
-Required status checks (from [ci.yml](workflows/ci.yml), the only workflow that runs on every PR): `typecheck`, `lint`, `test`, `e2e`, `build`, `container-scan`, `prisma-validate`, `dependency-scan`, `sast-semgrep`, `iac-scan`, `secrets-scan`. Job names in [api-ci.yml](workflows/api-ci.yml) and [recipe-url-importer-ci.yml](workflows/recipe-url-importer-ci.yml) are path-filtered, so they are **not** listed as required (a path-filtered required check that never runs would permanently block merges). They share names (`lint`, `typecheck`, etc.) with ci.yml jobs, so when they do run and fail, the shared-name required check fails too — effectively required when the relevant paths change.
+Required status checks (from [ci.yml](workflows/ci.yml), the only workflow that runs on every PR): `typecheck`, `lint`, `test`, `e2e`, `build`, `container-scan`, `prisma-validate`, `prisma-drift-check`, `dependency-scan`, `sast-semgrep`, `iac-scan`, `secrets-scan`. Job names in [api-ci.yml](workflows/api-ci.yml) and [recipe-url-importer-ci.yml](workflows/recipe-url-importer-ci.yml) are path-filtered, so they are **not** listed as required (a path-filtered required check that never runs would permanently block merges). They share names (`lint`, `typecheck`, etc.) with ci.yml jobs, so when they do run and fail, the shared-name required check fails too — effectively required when the relevant paths change.
 
 Difference between branches:
 


### PR DESCRIPTION
## Summary

- Adds `prisma-drift-check` to the required-status-checks list in [.github/GITHUB_GUIDE.md](.github/GITHUB_GUIDE.md) so the doc matches the intended branch-protection state.
- Branch-protection rules on `develop` and `main` are applied out-of-band via the REST API (per the pattern in #30). The PUT payload is prepared and the verification commands are listed below — I will execute the API change once this PR is reviewed / merged, so the doc and the live protection land together.

## Closes

Closes #118

## Test notes

### Before — current state (pulled via REST/GraphQL before this PR)

Both `develop` and `main` currently have the same 10 contexts (no `prisma-drift-check`):

```
typecheck, lint, test, build, container-scan,
prisma-validate, dependency-scan, sast-semgrep, iac-scan, secrets-scan
```

### After — planned API mutation

For each of `develop` and `main`, replay the full current protection config with one entry added to `required_status_checks.contexts`:

```bash
gh api -X PUT repos/wnorowskie/family-recipe/branches/develop/protection \
  --input - <<'JSON'
{
  "required_status_checks": {
    "strict": true,
    "contexts": [
      "typecheck","lint","test","build","container-scan",
      "prisma-validate","prisma-drift-check",
      "dependency-scan","sast-semgrep","iac-scan","secrets-scan"
    ]
  },
  "enforce_admins": false,
  "required_pull_request_reviews": {
    "dismiss_stale_reviews": false,
    "require_code_owner_reviews": false,
    "required_approving_review_count": 0
  },
  "restrictions": null,
  "required_linear_history": true,
  "allow_force_pushes": true,
  "allow_deletions": false,
  "block_creations": false,
  "required_conversation_resolution": true,
  "lock_branch": false,
  "allow_fork_syncing": false
}
JSON
```

`main` is the same payload except `"required_linear_history": false` (release PRs use merge commits — see GITHUB_GUIDE.md L146-147).

### Verification after API mutation

```bash
gh api graphql -f query='query { repository(owner:"wnorowskie", name:"family-recipe") { branchProtectionRules(first:10) { nodes { pattern requiredStatusCheckContexts } } } }' \
  | jq '.data.repository.branchProtectionRules.nodes'
# Expect: both develop and main list prisma-drift-check.
```

Smoke test the gate: a PR that deliberately breaks a Prisma `@db.*` annotation (so `prisma-drift-check` turns red) should have the merge button disabled until the check passes.

### Known pre-existing drift (out of scope)

While fetching current protection I noticed `e2e` is listed as required in GITHUB_GUIDE.md L142 but **is not** in the actual protection contexts on either branch. That predates this ticket — I left it untouched here. Happy to file a follow-up if you want it reconciled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)