### PR TITLE
chore: FastAPI OpenAPI snapshot diff in api-ci.yml (#108)

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -48,6 +48,35 @@ jobs:
       - run: pip install mypy==1.11.2
       - run: mypy src --ignore-missing-imports --show-error-codes --pretty
 
+  openapi-diff:
+    runs-on: ubuntu-latest
+    needs: [lint]
+    defaults:
+      run:
+        working-directory: apps/api
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: |
+            apps/api/requirements.txt
+            apps/api/requirements-dev.txt
+      - run: pip install --upgrade pip
+      - run: pip install -r requirements.txt
+      - name: Regenerate OpenAPI spec from app
+        run: python scripts/dump_openapi.py > /tmp/openapi.live.json
+      - name: Diff against committed snapshot
+        run: |
+          if ! diff -u openapi.snapshot.json /tmp/openapi.live.json; then
+            echo ""
+            echo "::error::FastAPI OpenAPI spec drifted from apps/api/openapi.snapshot.json."
+            echo "If the change is intentional, regenerate locally and commit:"
+            echo "  cd apps/api && python scripts/dump_openapi.py > openapi.snapshot.json"
+            exit 1
+          fi
+
   test:
     runs-on: ubuntu-latest
     needs: [lint, typecheck]

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -60,9 +60,7 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-          cache-dependency-path: |
-            apps/api/requirements.txt
-            apps/api/requirements-dev.txt
+          cache-dependency-path: apps/api/requirements.txt
       - run: pip install --upgrade pip
       - run: pip install -r requirements.txt
       - name: Regenerate OpenAPI spec from app

--- a/.prettierignore
+++ b/.prettierignore
@@ -16,6 +16,7 @@ prisma/*.db-journal
 # Ignore generated files
 *.tsbuildinfo
 next-env.d.ts
+apps/api/openapi.snapshot.json
 
 # Ignore lock files
 package-lock.json

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -35,6 +35,19 @@ npx prisma generate --schema ../../prisma/schema.postgres.prisma --generator cli
 
 `pytest tests/unit/` for unit tests, `pytest tests/integration/` for integration. CI runs both plus ruff, mypy, trivy, pip-audit, semgrep, gitleaks ([.github/workflows/api-ci.yml](../../.github/workflows/api-ci.yml)).
 
+## OpenAPI contract snapshot
+
+[openapi.snapshot.json](openapi.snapshot.json) is a committed copy of the FastAPI app's `/openapi.json`. The `openapi-diff` job in [api-ci.yml](../../.github/workflows/api-ci.yml) regenerates the spec on every PR and fails if it drifts from the snapshot. This catches accidental contract changes (renamed field, removed endpoint, altered status code) that unit tests would miss — and forces intentional changes to surface in PR review.
+
+When you change a router, schema, or anything else that affects the public contract, regenerate the snapshot in the same PR:
+
+```bash
+cd apps/api
+python scripts/dump_openapi.py > openapi.snapshot.json
+```
+
+The script stubs `prisma` in-process (no client generation or DB needed) and writes deterministic, sort-key JSON. Reviewers should treat snapshot diffs as the contract changelog.
+
 ## Verification
 
 Before opening a PR that touches this service, run the [FastAPI playbook](../../docs/verification/fastapi.md) — includes the curl+cookie loop, contract parity check against the Next mirror, and the local quality gates.

--- a/apps/api/openapi.snapshot.json
+++ b/apps/api/openapi.snapshot.json
@@ -1,0 +1,1690 @@
+{
+  "components": {
+    "schemas": {
+      "AuthResponse": {
+        "properties": {
+          "user": {
+            "$ref": "#/components/schemas/UserResponse"
+          }
+        },
+        "required": ["user"],
+        "title": "AuthResponse",
+        "type": "object"
+      },
+      "Body_create_comment_posts__post_id__comments_post": {
+        "properties": {
+          "payload": {
+            "title": "Payload",
+            "type": "string"
+          },
+          "photo": {
+            "anyOf": [
+              {
+                "format": "binary",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Photo"
+          }
+        },
+        "required": ["payload"],
+        "title": "Body_create_comment_posts__post_id__comments_post",
+        "type": "object"
+      },
+      "Body_create_post_posts_post": {
+        "properties": {
+          "payload": {
+            "title": "Payload",
+            "type": "string"
+          },
+          "photos": {
+            "items": {
+              "format": "binary",
+              "type": "string"
+            },
+            "title": "Photos",
+            "type": "array"
+          }
+        },
+        "required": ["payload"],
+        "title": "Body_create_post_posts_post",
+        "type": "object"
+      },
+      "Body_update_post_posts__post_id__put": {
+        "properties": {
+          "payload": {
+            "title": "Payload",
+            "type": "string"
+          },
+          "photos": {
+            "items": {
+              "format": "binary",
+              "type": "string"
+            },
+            "title": "Photos",
+            "type": "array"
+          }
+        },
+        "required": ["payload"],
+        "title": "Body_update_post_posts__post_id__put",
+        "type": "object"
+      },
+      "CookedRequest": {
+        "properties": {
+          "note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note"
+          },
+          "rating": {
+            "anyOf": [
+              {
+                "maximum": 5.0,
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rating"
+          }
+        },
+        "title": "CookedRequest",
+        "type": "object"
+      },
+      "FavoriteResponse": {
+        "properties": {
+          "favorited": {
+            "title": "Favorited",
+            "type": "boolean"
+          }
+        },
+        "required": ["favorited"],
+        "title": "FavoriteResponse",
+        "type": "object"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "title": "Detail",
+            "type": "array"
+          }
+        },
+        "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "LoginRequest": {
+        "properties": {
+          "emailOrUsername": {
+            "maxLength": 200,
+            "minLength": 3,
+            "title": "Emailorusername",
+            "type": "string"
+          },
+          "password": {
+            "maxLength": 200,
+            "minLength": 6,
+            "title": "Password",
+            "type": "string"
+          },
+          "rememberMe": {
+            "default": false,
+            "title": "Rememberme",
+            "type": "boolean"
+          }
+        },
+        "required": ["emailOrUsername", "password"],
+        "title": "LoginRequest",
+        "type": "object"
+      },
+      "ReactionRequest": {
+        "properties": {
+          "emoji": {
+            "maxLength": 10,
+            "minLength": 1,
+            "title": "Emoji",
+            "type": "string"
+          },
+          "targetId": {
+            "minLength": 1,
+            "title": "Targetid",
+            "type": "string"
+          },
+          "targetType": {
+            "pattern": "^(post|comment)$",
+            "title": "Targettype",
+            "type": "string"
+          }
+        },
+        "required": ["targetType", "targetId", "emoji"],
+        "title": "ReactionRequest",
+        "type": "object"
+      },
+      "SignupRequest": {
+        "properties": {
+          "email": {
+            "maxLength": 200,
+            "minLength": 3,
+            "title": "Email",
+            "type": "string"
+          },
+          "familyMasterKey": {
+            "maxLength": 200,
+            "minLength": 6,
+            "title": "Familymasterkey",
+            "type": "string"
+          },
+          "name": {
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
+          "password": {
+            "maxLength": 200,
+            "minLength": 6,
+            "title": "Password",
+            "type": "string"
+          },
+          "rememberMe": {
+            "default": false,
+            "title": "Rememberme",
+            "type": "boolean"
+          },
+          "username": {
+            "maxLength": 30,
+            "minLength": 3,
+            "pattern": "^[a-zA-Z0-9_]+$",
+            "title": "Username",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "email",
+          "username",
+          "password",
+          "familyMasterKey"
+        ],
+        "title": "SignupRequest",
+        "type": "object"
+      },
+      "UserResponse": {
+        "properties": {
+          "avatarUrl": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avatarurl"
+          },
+          "email": {
+            "title": "Email",
+            "type": "string"
+          },
+          "emailOrUsername": {
+            "title": "Emailorusername",
+            "type": "string"
+          },
+          "familySpaceId": {
+            "title": "Familyspaceid",
+            "type": "string"
+          },
+          "familySpaceName": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Familyspacename"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "role": {
+            "title": "Role",
+            "type": "string"
+          },
+          "username": {
+            "title": "Username",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "email",
+          "username",
+          "emailOrUsername",
+          "role",
+          "familySpaceId"
+        ],
+        "title": "UserResponse",
+        "type": "object"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "title": "Location",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        },
+        "required": ["loc", "msg", "type"],
+        "title": "ValidationError",
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "title": "Family Recipe API",
+    "version": "0.1.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/auth/login": {
+      "post": {
+        "operationId": "login_auth_login_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Login",
+        "tags": ["auth"]
+      }
+    },
+    "/auth/logout": {
+      "post": {
+        "operationId": "logout_auth_logout_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Logout Auth Logout Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Logout",
+        "tags": ["auth"]
+      }
+    },
+    "/auth/me": {
+      "get": {
+        "operationId": "me_auth_me_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Me",
+        "tags": ["auth"]
+      }
+    },
+    "/auth/signup": {
+      "post": {
+        "operationId": "signup_auth_signup_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SignupRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Signup",
+        "tags": ["auth"]
+      }
+    },
+    "/comments/{comment_id}": {
+      "delete": {
+        "operationId": "delete_comment_comments__comment_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "comment_id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "title": "Comment Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Comment",
+        "tags": ["comments"]
+      }
+    },
+    "/family/members": {
+      "get": {
+        "operationId": "list_members_family_members_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "List Members",
+        "tags": ["family"]
+      }
+    },
+    "/family/members/{user_id}": {
+      "delete": {
+        "operationId": "remove_member_family_members__user_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Remove Member",
+        "tags": ["family"]
+      }
+    },
+    "/health": {
+      "get": {
+        "operationId": "healthcheck_health_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Healthcheck Health Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Healthcheck",
+        "tags": ["health"]
+      }
+    },
+    "/me/favorites": {
+      "get": {
+        "operationId": "my_favorites_me_favorites_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "My Favorites",
+        "tags": ["me"]
+      }
+    },
+    "/me/password": {
+      "put": {
+        "operationId": "change_password_me_password_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Payload",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Change Password",
+        "tags": ["me"]
+      }
+    },
+    "/me/profile": {
+      "put": {
+        "operationId": "update_profile_me_profile_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Payload",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Profile",
+        "tags": ["me"]
+      }
+    },
+    "/posts": {
+      "post": {
+        "operationId": "create_post_posts_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_create_post_posts_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Post",
+        "tags": ["posts"]
+      }
+    },
+    "/posts/{post_id}": {
+      "delete": {
+        "operationId": "delete_post_posts__post_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "post_id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "title": "Post Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Post",
+        "tags": ["posts"]
+      },
+      "get": {
+        "operationId": "get_post_posts__post_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "post_id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "title": "Post Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "commentLimit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "title": "Commentlimit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "commentOffset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "title": "Commentoffset",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cookedLimit",
+            "required": false,
+            "schema": {
+              "default": 5,
+              "title": "Cookedlimit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cookedOffset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "title": "Cookedoffset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Post",
+        "tags": ["posts"]
+      },
+      "put": {
+        "operationId": "update_post_posts__post_id__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "post_id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "title": "Post Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_update_post_posts__post_id__put"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Post",
+        "tags": ["posts"]
+      }
+    },
+    "/posts/{post_id}/comments": {
+      "get": {
+        "operationId": "list_comments_posts__post_id__comments_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "post_id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "title": "Post Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Comments",
+        "tags": ["comments"]
+      },
+      "post": {
+        "operationId": "create_comment_posts__post_id__comments_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "post_id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "title": "Post Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_create_comment_posts__post_id__comments_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Comment",
+        "tags": ["comments"]
+      }
+    },
+    "/posts/{post_id}/cooked": {
+      "get": {
+        "operationId": "list_cooked_posts__post_id__cooked_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "post_id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "title": "Post Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Cooked",
+        "tags": ["posts"]
+      },
+      "post": {
+        "operationId": "log_cooked_posts__post_id__cooked_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "post_id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "title": "Post Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CookedRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Log Cooked",
+        "tags": ["posts"]
+      }
+    },
+    "/posts/{post_id}/favorite": {
+      "delete": {
+        "operationId": "unfavorite_post_posts__post_id__favorite_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "post_id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "title": "Post Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FavoriteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Unfavorite Post",
+        "tags": ["posts"]
+      },
+      "post": {
+        "operationId": "favorite_post_posts__post_id__favorite_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "post_id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "title": "Post Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FavoriteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Favorite Post",
+        "tags": ["posts"]
+      }
+    },
+    "/profile/cooked": {
+      "get": {
+        "operationId": "my_cooked_profile_cooked_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "My Cooked",
+        "tags": ["profile"]
+      }
+    },
+    "/profile/favorites": {
+      "get": {
+        "operationId": "my_favorites_profile_favorites_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "My Favorites",
+        "tags": ["profile"]
+      }
+    },
+    "/profile/posts": {
+      "get": {
+        "operationId": "my_posts_profile_posts_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "My Posts",
+        "tags": ["profile"]
+      }
+    },
+    "/reactions": {
+      "post": {
+        "operationId": "toggle_reaction_reactions_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReactionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Toggle Reaction",
+        "tags": ["reactions"]
+      }
+    },
+    "/recipes": {
+      "get": {
+        "operationId": "browse_recipes_recipes_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 200,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Q"
+            }
+          },
+          {
+            "in": "query",
+            "name": "course",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Course"
+            }
+          },
+          {
+            "in": "query",
+            "name": "tags",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Tags"
+            }
+          },
+          {
+            "in": "query",
+            "name": "difficulty",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Difficulty"
+            }
+          },
+          {
+            "in": "query",
+            "name": "authorId",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorid"
+            }
+          },
+          {
+            "in": "query",
+            "name": "totalTimeMin",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Totaltimemin"
+            }
+          },
+          {
+            "in": "query",
+            "name": "totalTimeMax",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Totaltimemax"
+            }
+          },
+          {
+            "in": "query",
+            "name": "servingsMin",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Servingsmin"
+            }
+          },
+          {
+            "in": "query",
+            "name": "servingsMax",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Servingsmax"
+            }
+          },
+          {
+            "in": "query",
+            "name": "ingredients",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Ingredients"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "default": "recent",
+              "pattern": "^(recent|alpha|rating)$",
+              "title": "Sort",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Browse Recipes",
+        "tags": ["recipes"]
+      }
+    },
+    "/tags": {
+      "get": {
+        "operationId": "list_tags_tags_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "List Tags",
+        "tags": ["tags"]
+      }
+    },
+    "/timeline": {
+      "get": {
+        "operationId": "get_timeline_timeline_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Timeline",
+        "tags": ["timeline"]
+      }
+    }
+  }
+}

--- a/apps/api/openapi.snapshot.json
+++ b/apps/api/openapi.snapshot.json
@@ -7,7 +7,9 @@
             "$ref": "#/components/schemas/UserResponse"
           }
         },
-        "required": ["user"],
+        "required": [
+          "user"
+        ],
         "title": "AuthResponse",
         "type": "object"
       },
@@ -30,7 +32,9 @@
             "title": "Photo"
           }
         },
-        "required": ["payload"],
+        "required": [
+          "payload"
+        ],
         "title": "Body_create_comment_posts__post_id__comments_post",
         "type": "object"
       },
@@ -49,7 +53,9 @@
             "type": "array"
           }
         },
-        "required": ["payload"],
+        "required": [
+          "payload"
+        ],
         "title": "Body_create_post_posts_post",
         "type": "object"
       },
@@ -68,7 +74,9 @@
             "type": "array"
           }
         },
-        "required": ["payload"],
+        "required": [
+          "payload"
+        ],
         "title": "Body_update_post_posts__post_id__put",
         "type": "object"
       },
@@ -109,7 +117,9 @@
             "type": "boolean"
           }
         },
-        "required": ["favorited"],
+        "required": [
+          "favorited"
+        ],
         "title": "FavoriteResponse",
         "type": "object"
       },
@@ -146,7 +156,10 @@
             "type": "boolean"
           }
         },
-        "required": ["emailOrUsername", "password"],
+        "required": [
+          "emailOrUsername",
+          "password"
+        ],
         "title": "LoginRequest",
         "type": "object"
       },
@@ -169,7 +182,11 @@
             "type": "string"
           }
         },
-        "required": ["targetType", "targetId", "emoji"],
+        "required": [
+          "targetType",
+          "targetId",
+          "emoji"
+        ],
         "title": "ReactionRequest",
         "type": "object"
       },
@@ -312,7 +329,11 @@
             "type": "string"
           }
         },
-        "required": ["loc", "msg", "type"],
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
         "title": "ValidationError",
         "type": "object"
       }
@@ -360,7 +381,9 @@
           }
         },
         "summary": "Login",
-        "tags": ["auth"]
+        "tags": [
+          "auth"
+        ]
       }
     },
     "/auth/logout": {
@@ -383,7 +406,9 @@
           }
         },
         "summary": "Logout",
-        "tags": ["auth"]
+        "tags": [
+          "auth"
+        ]
       }
     },
     "/auth/me": {
@@ -402,7 +427,9 @@
           }
         },
         "summary": "Me",
-        "tags": ["auth"]
+        "tags": [
+          "auth"
+        ]
       }
     },
     "/auth/signup": {
@@ -441,7 +468,9 @@
           }
         },
         "summary": "Signup",
-        "tags": ["auth"]
+        "tags": [
+          "auth"
+        ]
       }
     },
     "/comments/{comment_id}": {
@@ -480,7 +509,9 @@
           }
         },
         "summary": "Delete Comment",
-        "tags": ["comments"]
+        "tags": [
+          "comments"
+        ]
       }
     },
     "/family/members": {
@@ -497,7 +528,9 @@
           }
         },
         "summary": "List Members",
-        "tags": ["family"]
+        "tags": [
+          "family"
+        ]
       }
     },
     "/family/members/{user_id}": {
@@ -536,7 +569,9 @@
           }
         },
         "summary": "Remove Member",
-        "tags": ["family"]
+        "tags": [
+          "family"
+        ]
       }
     },
     "/health": {
@@ -559,7 +594,9 @@
           }
         },
         "summary": "Healthcheck",
-        "tags": ["health"]
+        "tags": [
+          "health"
+        ]
       }
     },
     "/me/favorites": {
@@ -608,7 +645,9 @@
           }
         },
         "summary": "My Favorites",
-        "tags": ["me"]
+        "tags": [
+          "me"
+        ]
       }
     },
     "/me/password": {
@@ -647,7 +686,9 @@
           }
         },
         "summary": "Change Password",
-        "tags": ["me"]
+        "tags": [
+          "me"
+        ]
       }
     },
     "/me/profile": {
@@ -686,7 +727,9 @@
           }
         },
         "summary": "Update Profile",
-        "tags": ["me"]
+        "tags": [
+          "me"
+        ]
       }
     },
     "/posts": {
@@ -723,7 +766,9 @@
           }
         },
         "summary": "Create Post",
-        "tags": ["posts"]
+        "tags": [
+          "posts"
+        ]
       }
     },
     "/posts/{post_id}": {
@@ -762,7 +807,9 @@
           }
         },
         "summary": "Delete Post",
-        "tags": ["posts"]
+        "tags": [
+          "posts"
+        ]
       },
       "get": {
         "operationId": "get_post_posts__post_id__get",
@@ -839,7 +886,9 @@
           }
         },
         "summary": "Get Post",
-        "tags": ["posts"]
+        "tags": [
+          "posts"
+        ]
       },
       "put": {
         "operationId": "update_post_posts__post_id__put",
@@ -886,7 +935,9 @@
           }
         },
         "summary": "Update Post",
-        "tags": ["posts"]
+        "tags": [
+          "posts"
+        ]
       }
     },
     "/posts/{post_id}/comments": {
@@ -945,7 +996,9 @@
           }
         },
         "summary": "List Comments",
-        "tags": ["comments"]
+        "tags": [
+          "comments"
+        ]
       },
       "post": {
         "operationId": "create_comment_posts__post_id__comments_post",
@@ -992,7 +1045,9 @@
           }
         },
         "summary": "Create Comment",
-        "tags": ["comments"]
+        "tags": [
+          "comments"
+        ]
       }
     },
     "/posts/{post_id}/cooked": {
@@ -1051,7 +1106,9 @@
           }
         },
         "summary": "List Cooked",
-        "tags": ["posts"]
+        "tags": [
+          "posts"
+        ]
       },
       "post": {
         "operationId": "log_cooked_posts__post_id__cooked_post",
@@ -1098,7 +1155,9 @@
           }
         },
         "summary": "Log Cooked",
-        "tags": ["posts"]
+        "tags": [
+          "posts"
+        ]
       }
     },
     "/posts/{post_id}/favorite": {
@@ -1139,7 +1198,9 @@
           }
         },
         "summary": "Unfavorite Post",
-        "tags": ["posts"]
+        "tags": [
+          "posts"
+        ]
       },
       "post": {
         "operationId": "favorite_post_posts__post_id__favorite_post",
@@ -1178,7 +1239,9 @@
           }
         },
         "summary": "Favorite Post",
-        "tags": ["posts"]
+        "tags": [
+          "posts"
+        ]
       }
     },
     "/profile/cooked": {
@@ -1230,7 +1293,9 @@
           }
         },
         "summary": "My Cooked",
-        "tags": ["profile"]
+        "tags": [
+          "profile"
+        ]
       }
     },
     "/profile/favorites": {
@@ -1282,7 +1347,9 @@
           }
         },
         "summary": "My Favorites",
-        "tags": ["profile"]
+        "tags": [
+          "profile"
+        ]
       }
     },
     "/profile/posts": {
@@ -1334,7 +1401,9 @@
           }
         },
         "summary": "My Posts",
-        "tags": ["profile"]
+        "tags": [
+          "profile"
+        ]
       }
     },
     "/reactions": {
@@ -1371,7 +1440,9 @@
           }
         },
         "summary": "Toggle Reaction",
-        "tags": ["reactions"]
+        "tags": [
+          "reactions"
+        ]
       }
     },
     "/recipes": {
@@ -1614,7 +1685,9 @@
           }
         },
         "summary": "Browse Recipes",
-        "tags": ["recipes"]
+        "tags": [
+          "recipes"
+        ]
       }
     },
     "/tags": {
@@ -1631,7 +1704,9 @@
           }
         },
         "summary": "List Tags",
-        "tags": ["tags"]
+        "tags": [
+          "tags"
+        ]
       }
     },
     "/timeline": {
@@ -1683,7 +1758,9 @@
           }
         },
         "summary": "Get Timeline",
-        "tags": ["timeline"]
+        "tags": [
+          "timeline"
+        ]
       }
     }
   }

--- a/apps/api/scripts/dump_openapi.py
+++ b/apps/api/scripts/dump_openapi.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Dump the FastAPI app's OpenAPI spec to stdout as deterministic JSON.
+
+Used by both local devs and CI to (re)generate apps/api/openapi.snapshot.json.
+The CI job in .github/workflows/api-ci.yml diffs this script's output against
+the committed snapshot; any drift fails the build.
+
+Stubs the `prisma` package so the spec can be dumped without a generated
+client or live database — same pattern as tests/conftest.py.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+def _stub_prisma() -> None:
+    if "prisma" in sys.modules:
+        return
+
+    mock = MagicMock()
+    mock.is_connected.return_value = False
+
+    prisma_stub = types.ModuleType("prisma")
+    prisma_stub.Prisma = lambda: mock  # type: ignore[attr-defined]
+
+    errors_stub = types.ModuleType("prisma.errors")
+    errors_stub.PrismaError = Exception  # type: ignore[attr-defined]
+
+    models_stub = types.ModuleType("prisma.models")
+
+    class _CookedEvent:
+        postId: str
+        rating: int | None
+
+        def __init__(self, postId: str = "", rating: int | None = None) -> None:
+            self.postId = postId
+            self.rating = rating
+
+    models_stub.CookedEvent = _CookedEvent  # type: ignore[attr-defined]
+
+    sys.modules["prisma"] = prisma_stub
+    sys.modules["prisma.errors"] = errors_stub
+    sys.modules["prisma.models"] = models_stub
+
+
+def main() -> int:
+    api_root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(api_root))
+
+    os.environ.setdefault("DATABASE_URL", "postgresql://snapshot:snapshot@localhost:5432/snapshot")
+    os.environ.setdefault("JWT_SECRET", "snapshot-secret-not-used")
+    os.environ.setdefault("ENVIRONMENT", "test")
+
+    _stub_prisma()
+
+    from src.main import app  # noqa: E402
+
+    spec = app.openapi()
+    json.dump(spec, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/api/scripts/dump_openapi.py
+++ b/apps/api/scripts/dump_openapi.py
@@ -33,6 +33,9 @@ def _stub_prisma() -> None:
 
     models_stub = types.ModuleType("prisma.models")
 
+    # `recipes.py` does `cast(List[CookedEvent], ...)` at module load,
+    # so this symbol must resolve to a real class — a MagicMock breaks
+    # the typing machinery during import.
     class _CookedEvent:
         postId: str
         rating: int | None


### PR DESCRIPTION
## Summary

- Add `openapi-diff` job to `api-ci.yml` that regenerates the FastAPI spec from the live app and diffs against a committed `apps/api/openapi.snapshot.json`. CI fails on any drift, with a copy-pasteable hint to regenerate the snapshot locally.
- New `apps/api/scripts/dump_openapi.py` stubs `prisma` in-process (same pattern as `tests/conftest.py`) and emits sort-key JSON, so snapshot generation needs neither a generated client nor a live database.
- Document the "regenerate the snapshot in the same PR" flow in `apps/api/CLAUDE.md`.
- Exempt the snapshot from prettier (`.prettierignore`) — pre-commit was reformatting the JSON and breaking the diff against the script's deterministic output.

## Closes

Closes #108

## Test notes

Verified locally:

```bash
cd apps/api && python scripts/dump_openapi.py > /tmp/spec.json
diff -u openapi.snapshot.json /tmp/spec.json   # no output, exit 0 — clean
```

To confirm CI fails loudly on drift, I synthesised a fake path into the live spec and re-ran the diff command from the workflow — it exits 1 with the unified diff printed and the actionable error message.

The script also passes the determinism check across two consecutive runs and `pytest` (306 tests) is unaffected.

## Follow-up (out of this PR)

The ticket suggests adding `openapi-diff` to required status checks on `develop` and `main` after the first green run lands. Per [.github/GITHUB_GUIDE.md](.github/GITHUB_GUIDE.md#L142), `api-ci.yml` jobs are path-filtered, so this would be effectively-required-when-relevant via the shared-name pattern, not strictly required. Repo owner call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)