### PR TITLE
feat: auth-injecting proxy for browser-based dev UI smoke (#112)

### DIFF
--- a/.claude/skills/release-testing/SKILL.md
+++ b/.claude/skills/release-testing/SKILL.md
@@ -146,19 +146,20 @@ curl -sS -H "Authorization: Bearer $NEXT_TOKEN" -w 'HTTP %{http_code}\n' \
   "$DEV_NEXT_URL/api/timeline"   # expect 401 without session cookie
 ```
 
-### 6. UI verification — limitations and options
+### 6. UI verification via the auth-injecting proxy
 
-Dev Cloud Run runs `--no-allow-unauthenticated`, so a browser cannot load the UI directly: every request (including CSS/JS chunks) needs a Bearer ID token, and browsers don't attach auth headers to subresource loads. Options, in order of preference:
+Dev Cloud Run runs `--no-allow-unauthenticated`, so a browser can't load the UI directly: every request (including CSS/JS subresources) needs a Bearer ID token, and browsers don't attach auth headers to subresource loads. The fix is the local auth-injecting proxy ([scripts/dev-auth-proxy.ts](../../../scripts/dev-auth-proxy.ts)) — it mints an impersonated ID token on every forwarded request and strips `Secure` from Set-Cookie so the session cookie survives the localhost hop.
 
-1. **Trust local Playwright** — if local `npm run test:e2e` (or Playwright MCP against `localhost:3000` with the sandbox stack) passed against the release branch, that's the strongest UI signal available today.
-2. **HTML-grep via curl** — fetch a key page as raw HTML and grep for expected strings. This misses hydration bugs but catches "server-rendered output changed unexpectedly":
-   ```bash
-   curl -sS -H "Authorization: Bearer $NEXT_TOKEN" -b /tmp/fr-dev-cookies.txt \
-     "$DEV_NEXT_URL/timeline" | grep -c "<title>"   # expect ≥1
-   ```
-3. **Skip honestly.** If the release includes hydration-sensitive UI changes and neither option 1 nor 2 is sufficient, the report's "Could not verify" section names it.
+Run the Playwright suite against the live dev deployment through the proxy:
 
-Improving dev UI coverage (auth-injecting proxy, IAP, or a signed-URL wrapper) is tracked separately — don't try to build it inside the skill.
+```bash
+npm run test:e2e:dev
+# → starts proxy on :3100, runs `playwright test`, tears down the proxy on exit
+```
+
+If the release bundles hydration-sensitive UI changes, also load a key page manually via `npm run proxy:dev` + your browser at `http://localhost:3100/login` and exercise one interactive flow (e.g., post a comment). Include the outcome in the report.
+
+If the proxy itself fails to mint a token (check `lsof -nP -iTCP:3100` + proxy logs), the same root cause — missing `roles/iam.serviceAccountTokenCreator` — would have already blocked the smoke in step 5; don't invent a fallback. If Playwright isn't installed in this session (`npx playwright install chromium` hasn't run), say so in "Could not verify" rather than guessing the UI's state.
 
 ### 7. Clean up
 

--- a/.env.dev.local.example
+++ b/.env.dev.local.example
@@ -1,7 +1,8 @@
-# .env.dev.local — inputs for scripts/smoke-dev.sh and the /release-testing
-# skill. Copy to `.env.dev.local` (gitignored via the existing `.env*.local`
-# pattern) and populate. See docs/verification/dev-deployments.md for the
-# one-time setup and GSM fetch commands.
+# .env.dev.local — inputs for scripts/smoke-dev.sh, scripts/dev-auth-proxy.ts,
+# and the /release-testing skill. Copy to `.env.dev.local` (gitignored via the
+# existing `.env*.local` pattern) and populate. See
+# docs/verification/dev-deployments.md for the one-time setup and GSM fetch
+# commands.
 
 # --- Dev Cloud Run URLs (match .github/workflows/deploy-dev.yml) ---
 DEV_NEXT_URL="https://family-recipe-dev-894181878182.us-east1.run.app"
@@ -19,3 +20,6 @@ CLAUDE_TEST_USER="claude-test"
 # playbook has the one-liner), pasting the fetched value directly, or
 # `export CLAUDE_TEST_PASSWORD=...` in the session shell.
 # CLAUDE_TEST_PASSWORD="<gcloud secrets versions access latest --secret family-recipe-dev-claude-test-password --project family-recipe-dev>"
+
+# --- Optional: override port for scripts/dev-auth-proxy.ts (default 3100) ---
+# PROXY_PORT="3100"

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ test.db-journal
 /blob-report/
 /playwright/.cache/
 /e2e/.auth/
+/.playwright-mcp/
 
 # Next.js
 /.next/

--- a/docs/verification/dev-deployments.md
+++ b/docs/verification/dev-deployments.md
@@ -156,6 +156,27 @@ curl -sS -H "Authorization: Bearer $IMP_TOKEN" "$DEV_IMPORTER_URL/version"
 
 Each Cloud Run service is a distinct audience — mint a new token per host.
 
+## Browser UI smoke via the auth-injecting proxy
+
+`--no-allow-unauthenticated` dev Cloud Run blocks browsers from loading the UI directly: the initial HTML fetch works with an explicit `Authorization` header, but browsers don't attach auth headers to subresource requests (CSS, JS, images), so the page never hydrates. To reach `$DEV_NEXT_URL` from a real browser, point it at the local auth-injecting proxy ([scripts/dev-auth-proxy.ts](../../scripts/dev-auth-proxy.ts)):
+
+```bash
+npm run proxy:dev                     # foreground; Ctrl-C to stop
+# → http://localhost:3100 proxies to $DEV_NEXT_URL
+```
+
+The proxy mints an ID token by impersonating the deployer SA (same path as `smoke:dev`), attaches `Authorization: Bearer …` to every forwarded request, refreshes the token before it expires, and strips the `Secure` flag from Set-Cookie so the `session` cookie survives the plain-HTTP localhost hop. Now a browser at `http://localhost:3100/login` loads CSS/JS and hydrates normally.
+
+For an end-to-end Playwright run against the live dev deployment:
+
+```bash
+npm run test:e2e:dev                  # boots proxy → runs playwright → tears down
+npm run test:e2e:dev -- --ui          # headed Playwright UI, same proxy
+npm run test:e2e:dev -- e2e/auth.spec.ts
+```
+
+Prerequisites: the one-time setup above (`roles/iam.serviceAccountTokenCreator`, `.env.dev.local` populated). The wrapper forwards `CLAUDE_TEST_PASSWORD` to Playwright as `E2E_PASSWORD` automatically.
+
 ## Gotchas
 
 - **`curl -F` interprets `;` in values** as a content-type delimiter and silently truncates the payload. Use `curl --form-string` for `multipart/form-data` JSON payloads (the smoke script does; so must your manual probes).

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -35,6 +35,17 @@ E2E_USER=<user> E2E_PASSWORD=<pass> \
 npm run test:e2e
 ```
 
+### Against the `--no-allow-unauthenticated` dev deployment
+
+Browsers can't attach Bearer tokens to subresource loads, so Playwright must tunnel through the auth-injecting proxy ([scripts/dev-auth-proxy.ts](../scripts/dev-auth-proxy.ts)). The wrapper handles boot + teardown:
+
+```bash
+# Requires .env.dev.local populated — see docs/verification/dev-deployments.md
+npm run test:e2e:dev
+npm run test:e2e:dev -- --ui           # headed
+npm run test:e2e:dev -- e2e/auth.spec.ts
+```
+
 ## Credentials
 
 Defaults to the seeded `claude-test` user (see [prisma/seed.ts](../prisma/seed.ts)). Override via `E2E_USER` / `E2E_PASSWORD` env vars.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "db:studio": "prisma studio --schema prisma/schema.postgres.node.prisma",
     "db:seed": "tsx prisma/seed.ts",
     "db:drift-check": "scripts/check-prisma-drift.sh",
-    "smoke:dev": "scripts/smoke-dev.sh"
+    "smoke:dev": "scripts/smoke-dev.sh",
+    "proxy:dev": "tsx scripts/dev-auth-proxy.ts",
+    "test:e2e:dev": "scripts/test-e2e-dev.sh"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/dev-auth-proxy.ts
+++ b/scripts/dev-auth-proxy.ts
@@ -1,0 +1,274 @@
+#!/usr/bin/env tsx
+/*
+ * dev-auth-proxy.ts — localhost HTTP proxy that injects a fresh Cloud Run
+ * ID token on every outbound request, so a browser (or Playwright) can load
+ * the `--no-allow-unauthenticated` dev deployment end-to-end.
+ *
+ * Why this exists: dev Cloud Run requires a Bearer ID token on every request
+ * including CSS/JS/image subresources. Browsers won't attach `Authorization`
+ * headers to subresource loads, so the page never hydrates. This proxy mints
+ * a token by impersonating the deployer SA (same pattern as smoke-dev.sh) and
+ * attaches it to every forwarded request. It also strips `Secure` from
+ * Set-Cookie so the session cookie survives the plain-HTTP localhost hop.
+ *
+ * Usage:
+ *   npm run proxy:dev             # reads .env.dev.local, listens on :3100
+ *   PROXY_PORT=4000 npm run proxy:dev
+ *
+ * Required env (from .env.dev.local or the shell):
+ *   DEV_NEXT_URL                  upstream Cloud Run URL
+ *   DEV_DEPLOYER_SA               SA to impersonate for ID tokens
+ */
+import { spawn } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as https from 'node:https';
+import * as path from 'node:path';
+import { URL } from 'node:url';
+
+type TokenState = {
+  token: string;
+  mintedAt: number;
+  expiresAt: number;
+};
+
+const ENV_FILE = path.resolve(__dirname, '..', '.env.dev.local');
+const TOKEN_TTL_MS = 50 * 60 * 1000; // refresh a bit before Google's 1h cap
+const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
+
+loadEnvFile(ENV_FILE);
+
+const UPSTREAM_URL = requiredEnv('DEV_NEXT_URL');
+const DEPLOYER_SA = requiredEnv('DEV_DEPLOYER_SA');
+const PORT = Number(process.env.PROXY_PORT ?? 3100);
+
+const upstream = new URL(UPSTREAM_URL);
+if (upstream.protocol !== 'https:') {
+  throw new Error(`DEV_NEXT_URL must be https, got ${UPSTREAM_URL}`);
+}
+
+let tokenState: TokenState | null = null;
+let inflightMint: Promise<TokenState> | null = null;
+
+async function getToken(): Promise<string> {
+  const now = Date.now();
+  if (tokenState && now < tokenState.expiresAt - TOKEN_REFRESH_BUFFER_MS) {
+    return tokenState.token;
+  }
+  if (!inflightMint) {
+    inflightMint = mintToken().finally(() => {
+      inflightMint = null;
+    });
+  }
+  const next = await inflightMint;
+  tokenState = next;
+  return next.token;
+}
+
+function mintToken(): Promise<TokenState> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      'gcloud',
+      [
+        'auth',
+        'print-identity-token',
+        `--impersonate-service-account=${DEPLOYER_SA}`,
+        `--audiences=${UPSTREAM_URL}`,
+      ],
+      { stdio: ['ignore', 'pipe', 'pipe'] }
+    );
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => (stdout += chunk.toString()));
+    child.stderr.on('data', (chunk) => (stderr += chunk.toString()));
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject(
+          new Error(
+            `gcloud mint failed (exit ${code}); is roles/iam.serviceAccountTokenCreator granted on ${DEPLOYER_SA}?\n${stderr.trim()}`
+          )
+        );
+        return;
+      }
+      const token = stdout.trim();
+      if (!token) {
+        reject(new Error('gcloud returned empty token'));
+        return;
+      }
+      const mintedAt = Date.now();
+      resolve({ token, mintedAt, expiresAt: mintedAt + TOKEN_TTL_MS });
+    });
+  });
+}
+
+function rewriteSetCookie(values: string[]): string[] {
+  // Dev Cloud Run is https → cookies carry `Secure`, which makes browsers drop
+  // them on the plain-http localhost hop. Strip it here. Also drop any
+  // Domain= so the browser scopes the cookie to localhost automatically.
+  return values.map((value) =>
+    value
+      .split(';')
+      .map((part) => part.trim())
+      .filter((part) => part.length > 0)
+      .filter((part) => !/^secure$/i.test(part))
+      .filter((part) => !/^domain=/i.test(part))
+      .join('; ')
+  );
+}
+
+function rewriteLocation(location: string): string {
+  if (location.startsWith(upstream.origin)) {
+    return location.slice(upstream.origin.length) || '/';
+  }
+  return location;
+}
+
+function buildUpstreamHeaders(
+  incoming: http.IncomingHttpHeaders,
+  token: string
+): http.OutgoingHttpHeaders {
+  const headers: http.OutgoingHttpHeaders = {};
+  for (const [key, value] of Object.entries(incoming)) {
+    if (value === undefined) continue;
+    const k = key.toLowerCase();
+    // Hop-by-hop + ones we rewrite ourselves.
+    if (
+      k === 'host' ||
+      k === 'connection' ||
+      k === 'keep-alive' ||
+      k === 'proxy-authorization' ||
+      k === 'proxy-connection' ||
+      k === 'te' ||
+      k === 'trailer' ||
+      k === 'transfer-encoding' ||
+      k === 'upgrade' ||
+      k === 'authorization'
+    ) {
+      continue;
+    }
+    headers[k] = value;
+  }
+  headers['host'] = upstream.host;
+  headers['authorization'] = `Bearer ${token}`;
+  return headers;
+}
+
+const server = http.createServer(async (req, res) => {
+  const started = Date.now();
+  let token: string;
+  try {
+    token = await getToken();
+  } catch (err) {
+    res.statusCode = 502;
+    res.setHeader('content-type', 'text/plain; charset=utf-8');
+    res.end(
+      `dev-auth-proxy: could not mint ID token\n${(err as Error).message}\n`
+    );
+    console.error(`[proxy] token mint failed: ${(err as Error).message}`);
+    return;
+  }
+
+  const upstreamReq = https.request(
+    {
+      protocol: upstream.protocol,
+      host: upstream.hostname,
+      port: upstream.port || 443,
+      method: req.method,
+      path: req.url,
+      headers: buildUpstreamHeaders(req.headers, token),
+    },
+    (upstreamRes) => {
+      const headers = { ...upstreamRes.headers };
+      const rawCookies = upstreamRes.headers['set-cookie'];
+      if (Array.isArray(rawCookies) && rawCookies.length > 0) {
+        headers['set-cookie'] = rewriteSetCookie(rawCookies);
+      }
+      if (typeof headers['location'] === 'string') {
+        headers['location'] = rewriteLocation(headers['location']);
+      }
+      delete headers['strict-transport-security'];
+      res.writeHead(upstreamRes.statusCode ?? 502, headers);
+      upstreamRes.pipe(res);
+      upstreamRes.on('end', () => {
+        const ms = Date.now() - started;
+        console.log(
+          `[proxy] ${req.method} ${req.url} → ${upstreamRes.statusCode} (${ms}ms)`
+        );
+      });
+    }
+  );
+
+  upstreamReq.on('error', (err) => {
+    console.error(
+      `[proxy] upstream error for ${req.method} ${req.url}: ${err.message}`
+    );
+    if (!res.headersSent) {
+      res.statusCode = 502;
+      res.setHeader('content-type', 'text/plain; charset=utf-8');
+      res.end(`dev-auth-proxy: upstream error — ${err.message}\n`);
+    } else {
+      res.destroy(err);
+    }
+  });
+
+  req.pipe(upstreamReq);
+});
+
+function shutdown(signal: NodeJS.Signals) {
+  console.log(`[proxy] ${signal} received, shutting down`);
+  server.close(() => process.exit(0));
+  // Hard cap so a hung upstream connection doesn't block exit forever.
+  setTimeout(() => process.exit(0), 2000).unref();
+}
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
+
+// Pre-mint so the first page load doesn't pay the ~1s gcloud cost. Fail fast
+// here so a missing IAM grant surfaces before Playwright starts.
+getToken().then(
+  () =>
+    server.listen(PORT, '127.0.0.1', () => {
+      console.log(
+        `[proxy] listening on http://localhost:${PORT} → ${upstream.origin}`
+      );
+      console.log(`[proxy] impersonating ${DEPLOYER_SA}`);
+    }),
+  (err) => {
+    console.error(`[proxy] startup failed: ${(err as Error).message}`);
+    process.exit(1);
+  }
+);
+
+function requiredEnv(name: string): string {
+  const v = process.env[name];
+  if (!v || !v.trim()) {
+    console.error(
+      `[proxy] missing required env ${name} (populate .env.dev.local — see docs/verification/dev-deployments.md)`
+    );
+    process.exit(1);
+  }
+  return v.trim();
+}
+
+function loadEnvFile(filePath: string): void {
+  if (!fs.existsSync(filePath)) return;
+  const contents = fs.readFileSync(filePath, 'utf8');
+  for (const rawLine of contents.split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (process.env[key] === undefined) {
+      process.env[key] = value;
+    }
+  }
+}

--- a/scripts/dev-auth-proxy.ts
+++ b/scripts/dev-auth-proxy.ts
@@ -33,7 +33,11 @@ type TokenState = {
 };
 
 const ENV_FILE = path.resolve(__dirname, '..', '.env.dev.local');
-const TOKEN_TTL_MS = 50 * 60 * 1000; // refresh a bit before Google's 1h cap
+// Google ID tokens are valid for ~1h. These constants are our internal
+// staleness window (mintedAt + TOKEN_TTL_MS) and the buffer before that at
+// which we proactively refresh — so a mint happens every ~45 min, well
+// before the real expiry. Not the upstream TTL itself.
+const TOKEN_TTL_MS = 50 * 60 * 1000;
 const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 
 loadEnvFile(ENV_FILE);

--- a/scripts/test-e2e-dev.sh
+++ b/scripts/test-e2e-dev.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# test-e2e-dev.sh — run Playwright against the live dev Cloud Run deployment
+# via the auth-injecting proxy (scripts/dev-auth-proxy.ts).
+#
+# Pipeline: start proxy in background → wait for /api/health → export
+# PLAYWRIGHT_BASE_URL → run `playwright test` → tear down the proxy.
+#
+# Pass Playwright flags after `--`:
+#   scripts/test-e2e-dev.sh                  # full e2e suite
+#   scripts/test-e2e-dev.sh -- --ui          # headed
+#   scripts/test-e2e-dev.sh -- e2e/auth.spec.ts
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+ENV_FILE="${REPO_ROOT}/.env.dev.local"
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+fi
+
+PORT="${PROXY_PORT:-3100}"
+export PROXY_PORT="$PORT"
+PROXY_URL="http://localhost:${PORT}"
+
+LOG_DIR="${TMPDIR:-/tmp}"
+PROXY_LOG="${LOG_DIR}/dev-auth-proxy.log"
+
+# Pipe Playwright's default E2E creds through to the test run. The defaults
+# match prisma/seed.ts; only the password comes from .env.dev.local in dev.
+export E2E_USER="${E2E_USER:-${CLAUDE_TEST_USER:-claude-test}}"
+if [[ -z "${E2E_PASSWORD:-}" && -n "${CLAUDE_TEST_PASSWORD:-}" ]]; then
+  export E2E_PASSWORD="$CLAUDE_TEST_PASSWORD"
+fi
+
+PROXY_PID=""
+cleanup() {
+  local rc=$?
+  if [[ -n "$PROXY_PID" ]] && kill -0 "$PROXY_PID" 2>/dev/null; then
+    kill "$PROXY_PID" 2>/dev/null || true
+    wait "$PROXY_PID" 2>/dev/null || true
+  fi
+  exit "$rc"
+}
+trap cleanup EXIT
+
+npx tsx scripts/dev-auth-proxy.ts >"$PROXY_LOG" 2>&1 &
+PROXY_PID=$!
+
+echo "[test-e2e-dev] proxy PID=$PROXY_PID, logs → $PROXY_LOG"
+
+# Poll until the proxy's health probe succeeds; bail if the proxy crashed.
+for _ in $(seq 1 30); do
+  if ! kill -0 "$PROXY_PID" 2>/dev/null; then
+    echo "[test-e2e-dev] proxy exited before becoming ready:" >&2
+    cat "$PROXY_LOG" >&2
+    exit 1
+  fi
+  if curl -sf -o /dev/null "${PROXY_URL}/api/health"; then
+    break
+  fi
+  sleep 1
+done
+
+if ! curl -sf -o /dev/null "${PROXY_URL}/api/health"; then
+  echo "[test-e2e-dev] proxy never reached ${PROXY_URL}/api/health" >&2
+  cat "$PROXY_LOG" >&2
+  exit 1
+fi
+
+echo "[test-e2e-dev] proxy ready at ${PROXY_URL}; running Playwright…"
+
+export PLAYWRIGHT_BASE_URL="$PROXY_URL"
+
+# Everything after `--` forwards to playwright; nothing after `--` runs the
+# default suite.
+ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --)
+      shift
+      ARGS=("$@")
+      break
+      ;;
+    *)
+      ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+npx playwright test ${ARGS[@]+"${ARGS[@]}"}


### PR DESCRIPTION
## Summary

- **`scripts/dev-auth-proxy.ts`** — localhost HTTP proxy that mints a Cloud Run ID token via deployer-SA impersonation and attaches it to every forwarded request, with refresh-ahead-of-TTL logic and `Secure`-stripping on `Set-Cookie` so the session cookie survives the plain-HTTP localhost hop. Fixes the known `/release-testing` UI limitation (browsers don't attach `Authorization` headers to subresource requests).
- **`npm run test:e2e:dev`** — thin shell wrapper (`scripts/test-e2e-dev.sh`) that boots the proxy, waits for `/api/health`, runs `playwright test` with `PLAYWRIGHT_BASE_URL=http://localhost:3100`, and tears the proxy down on exit. Forwards extra Playwright flags after `--`.
- **`npm run proxy:dev`** — standalone foreground mode for interactive browsing. Point your browser at `http://localhost:3100/login` and hydration works normally.
- Updates [docs/verification/dev-deployments.md](docs/verification/dev-deployments.md) with the new browser-smoke flow and replaces the "UI limitations / HTML-grep fallback" section of the [release-testing skill](.claude/skills/release-testing/SKILL.md) with concrete browser-driven steps.

Closes #112 — Option 1 (local auth-injecting proxy). Option 2 (IAP on dev services) deferred as a follow-up if the proxy proves insufficient.

### Why a custom proxy instead of `gcloud run services proxy`

`gcloud run services proxy` exists but errors with `idtoken: unsupported credentials type` when its active credentials are impersonation-sourced — which is how this repo's smoke flow mints tokens. The alternatives were (a) grant `run.invoker` to user identities directly (broader IAM surface) or (b) accept a non-refreshing `--token`. Neither meets the acceptance criterion of auto-refresh without changing IAM. The custom proxy mirrors `smoke-dev.sh`'s impersonation pattern exactly, so operators need exactly the one grant (`roles/iam.serviceAccountTokenCreator`) that `/release-testing` already requires.

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [x] `npm test` — 963/963 pass
- [x] `npm run proxy:dev` + `curl http://localhost:3100/api/health` → HTTP 200 (upstream `/api/health` hit via injected Bearer token)
- [x] Unauth `curl http://localhost:3100/timeline` → 307 `Location: /login?redirect=%2Ftimeline` (proves Location rewrite strips the upstream origin)
- [x] `curl -c cookies.txt -d '{...}' http://localhost:3100/api/auth/login` → 200; cookie jar shows `session` with `FALSE` Secure flag (confirms `Secure` stripping)
- [x] Next.js static chunk fetched via proxy returns 200 (proves subresource auth works, i.e. the core hydration unblock)
- [x] `scripts/test-e2e-dev.sh` → Playwright `auth.spec.ts` passes against live dev (login unlocks protected `/timeline`)
- [x] Playwright MCP snapshot of `http://localhost:3100/login` shows hydrated form with interactive controls; the only console errors are the pre-existing 401 on `/api/auth/me` and 404 on `/favicon.ico` — neither proxy-related
- [x] Token refresh logic: `getToken()` checks `now < expiresAt - TOKEN_REFRESH_BUFFER_MS` on each request, concurrent refresh serialized via `inflightMint` promise mutex; mint failure fails loudly at startup and returns 502 (with stderr surfaced) if it fails mid-flight

### Not verified

- Actual clock-driven refresh after ~50 min — the refresh code path is readable in [scripts/dev-auth-proxy.ts:53-66](scripts/dev-auth-proxy.ts#L53-L66) and fails loudly on mint errors, but a full-TTL Playwright run wasn't exercised. A session running long enough for this to matter will notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)