### PR TITLE
chore(importer): drop dead IMPORTER_SERVICE_NAME env-var coupling (#125)

### DIFF
--- a/apps/recipe-url-importer/src/recipe_url_importer/app.py
+++ b/apps/recipe-url-importer/src/recipe_url_importer/app.py
@@ -9,7 +9,7 @@ from fastapi import Depends, FastAPI, HTTPException, Request, Response, status
 
 from . import __version__
 from .cache.memory_cache import MemoryCache
-from .config import Settings
+from .config import SERVICE_NAME, Settings
 from .exceptions import ImporterError, ParseFailed
 from .models import ErrorResponse, ParseRequest, ParseResponse, RecipeDraft
 from .parse.pipeline import run_pipeline
@@ -61,7 +61,7 @@ async def request_context_middleware(request: Request, call_next):
             logger,
             "request_complete",
             {
-                "service": settings.service_name,
+                "service": SERVICE_NAME,
                 "version": settings.service_version,
                 "request_id": request_id,
                 "correlation_id": correlation_id,
@@ -109,7 +109,7 @@ async def health():
 
 @app.get("/version")
 async def version():
-    return {"service": settings.service_name, "version": settings.service_version, "git_sha": settings.git_sha}
+    return {"service": SERVICE_NAME, "version": settings.service_version, "git_sha": settings.git_sha}
 
 
 @app.post("/v1/parse", response_model=ParseResponse)
@@ -148,7 +148,7 @@ async def parse_recipe(
         logger,
         "parse_complete",
         {
-            "service": settings.service_name,
+            "service": SERVICE_NAME,
             "version": settings.service_version,
             "request_id": request_id,
             "correlation_id": request.headers.get("x-correlation-id"),

--- a/apps/recipe-url-importer/src/recipe_url_importer/config.py
+++ b/apps/recipe-url-importer/src/recipe_url_importer/config.py
@@ -7,13 +7,14 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from . import __version__
 
+SERVICE_NAME = "recipe-url-importer"
+
 
 class Settings(BaseSettings):
     """Application configuration loaded from environment variables."""
 
     model_config = SettingsConfigDict(env_prefix="IMPORTER_", case_sensitive=False)
 
-    service_name: str = Field(default="recipe-url-importer")
     service_version: str = Field(default=__version__)
     git_sha: str = Field(default="dev")
 


### PR DESCRIPTION
## Summary

- Follow-up to #110/#124, which removed the unused `IMPORTER_SERVICE_NAME` env block from the importer's Terraform module. This PR removes the Pydantic side of the same dead coupling so the knob doesn't silently reappear via `env_prefix="IMPORTER_"`.
- Moves `service_name` off `Settings` in [apps/recipe-url-importer/src/recipe_url_importer/config.py](../blob/chore/125-drop-importer-service-name-env/apps/recipe-url-importer/src/recipe_url_importer/config.py) to a module-level `SERVICE_NAME = "recipe-url-importer"` constant; updates the 3 call sites in [apps/recipe-url-importer/src/recipe_url_importer/app.py](../blob/chore/125-drop-importer-service-name-env/apps/recipe-url-importer/src/recipe_url_importer/app.py) (request-complete log, `/version` response, parse-complete log). `/version` shape and the structured-log `"service"` key stay `"recipe-url-importer"`, so [SPEC.md](../blob/chore/125-drop-importer-service-name-env/apps/recipe-url-importer/SPEC.md) needs no change.

## Closes

Closes #125

## Test notes

- [x] `PYTHONPATH=src pytest` in `apps/recipe-url-importer/` — 4/4 pass
- [x] `IMPORTER_SERVICE_NAME=hijacked` no longer binds: `hasattr(Settings(), 'service_name')` is False; `service_name` absent from `Settings.model_fields`
- [x] `TestClient` `GET /version` returns `{"service": "recipe-url-importer", "version": "0.1.0", "git_sha": "dev"}` — unchanged from today
- [x] Structured `request_complete` log still emits `"service": "recipe-url-importer"` under the hijack env
- [x] Recipe URL Importer CI green on this PR ([run 24848255903](https://github.com/wnorowskie/family-recipe/actions/runs/24848255903))

🤖 Generated with [Claude Code](https://claude.com/claude-code)