### PR TITLE
feat(e2e): signup smoke flow (#106)

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -2,7 +2,19 @@
 
 Playwright smoke suite. Picked in [docs/research/automated-testing.md](../docs/research/automated-testing.md) ([#58](https://github.com/wnorowskie/family-recipe/issues/58)).
 
-This directory currently contains **one** PoC flow — login + protected-route gating. The full suite lands in follow-up tickets (see the research doc for the list).
+This directory currently contains:
+
+- [auth.spec.ts](auth.spec.ts) — login + protected-route gating (PoC flow from #58).
+- [signup.spec.ts](signup.spec.ts) — signup via family master key (#106). Tagged `@smoke @destructive`; CI-only (see [Tags](#tags)).
+
+Further smoke flows land in follow-up tickets (see the research doc for the list).
+
+## Tags
+
+Specs use Playwright test tags to steer grep filters:
+
+- `@smoke` — included in the smoke subset.
+- `@destructive` — creates/mutates data that persists beyond the test (e.g. a new user row). Run in the CI job against the ephemeral Postgres, but **invert** in the post-deploy grep (#107) so we don't accumulate rows against the live dev DB.
 
 ## Run locally
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -37,6 +37,8 @@ Headed / debug:
 npm run test:e2e:ui   # Playwright UI mode
 ```
 
+> **Heads up — signup rate limit.** `signup.spec.ts` hits `/api/auth/signup`, capped at 3/IP/hour by [src/lib/rateLimit.ts](../src/lib/rateLimit.ts). CI gets a fresh in-process limiter cache per run, but local re-runs inside the same hour will start returning 429. If you're iterating, `npx playwright test e2e/auth.spec.ts` only, or restart the dev server to clear the LRU.
+
 ## Run against a deployed URL
 
 Set `PLAYWRIGHT_BASE_URL`; the `webServer` block is skipped:

--- a/e2e/signup.spec.ts
+++ b/e2e/signup.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '@playwright/test';
+
+const MASTER_KEY = process.env.FAMILY_MASTER_KEY;
+
+/**
+ * Smoke flow for #106 — the only e2e coverage of the master-key bcrypt verify
+ * path. Starts logged-out, submits the signup form through the UI, and asserts
+ * a session cookie is set and /timeline renders.
+ *
+ * Destructive: creates a real user row. Tagged `@destructive` so #107's
+ * post-deploy smoke grep can invert it — this test is CI-only (ephemeral DB).
+ *
+ * Unlike the other smoke flows this one does NOT use storageState — it
+ * deliberately boots from a fresh, unauthenticated context.
+ */
+test(
+  'signup via master key unlocks /timeline',
+  { tag: ['@smoke', '@destructive'] },
+  async ({ page, context }) => {
+    test.skip(
+      !MASTER_KEY,
+      'FAMILY_MASTER_KEY must be set for the signup flow (see ci.yml for the CI value)'
+    );
+
+    const stamp = Date.now();
+    const username = `e2e_signup_${stamp}`;
+    const email = `e2e-signup-${stamp}@example.local`;
+    const password = 'e2e-signup-password';
+
+    await page.goto('/signup');
+    await expect(page).toHaveURL(/\/signup(\?|$)/);
+
+    await page.getByLabel('Name', { exact: true }).fill('E2E Signup User');
+    await page.getByLabel('Email', { exact: true }).fill(email);
+    await page.getByLabel('Username', { exact: true }).fill(username);
+    await page.getByLabel('Password', { exact: true }).fill(password);
+    await page
+      .getByLabel('Family Master Key', { exact: true })
+      .fill(MASTER_KEY!);
+
+    await page.getByRole('button', { name: /create account/i }).click();
+
+    await page.waitForURL(/\/timeline$/, { timeout: 10_000 });
+    await expect(page).toHaveURL(/\/timeline$/);
+
+    const cookies = await context.cookies();
+    const session = cookies.find((c) => c.name === 'session');
+    expect(session?.value).toBeTruthy();
+  }
+);

--- a/e2e/signup.spec.ts
+++ b/e2e/signup.spec.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'crypto';
 import { expect, test } from '@playwright/test';
 
 const MASTER_KEY = process.env.FAMILY_MASTER_KEY;
@@ -22,7 +23,7 @@ test(
       'FAMILY_MASTER_KEY must be set for the signup flow (see ci.yml for the CI value)'
     );
 
-    const stamp = Date.now();
+    const stamp = `${Date.now()}_${randomBytes(3).toString('hex')}`;
     const username = `e2e_signup_${stamp}`;
     const email = `e2e-signup-${stamp}@example.local`;
     const password = 'e2e-signup-password';
@@ -45,6 +46,7 @@ test(
 
     const cookies = await context.cookies();
     const session = cookies.find((c) => c.name === 'session');
-    expect(session?.value).toBeTruthy();
+    // JWTs signed with jose always start with the base64-encoded header `eyJ`.
+    expect(session?.value).toMatch(/^eyJ/);
   }
 );


### PR DESCRIPTION
Closes #106.

## Summary

- Adds [e2e/signup.spec.ts](e2e/signup.spec.ts) — first real e2e coverage of the family-master-key bcrypt verify path. Drives the signup form through the UI, asserts redirect to `/timeline` and a `session` cookie.
- Tagged `{ tag: ['@smoke', '@destructive'] }`; the `@destructive` tag is the hook #107's post-deploy grep will invert (spec writes a real user row, so it stays CI-only against the ephemeral Postgres).
- Updates [e2e/README.md](e2e/README.md) to document the new spec and the `@destructive` convention.

No workflow changes needed — CI already exports `FAMILY_MASTER_KEY` for the `e2e` job in [.github/workflows/ci.yml](.github/workflows/ci.yml#L62).

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 963/963 pass
- [x] Full e2e suite against local build (`auth.spec.ts` + `signup.spec.ts`) — both pass
- [x] Regression probe: submit an intentionally wrong master key → `waitForURL(/\/timeline$/)` times out with a clear screenshot + error-context artifact. Signal is surgical (bounded to 10s).
- [ ] CI `e2e` job passes on push

## Notes

- Uses `Date.now()`-suffixed username/email to avoid collisions across retries.
- Signup rate-limit is 3/IP/hour; CI gets a fresh limiter cache per run (retries=1 ⇒ worst case 2 attempts, under the limit). Local re-runs inside the same hour will hit the wall — expected for a destructive spec.
- Not using `storageState` — this spec deliberately boots from an unauthenticated context to exercise the bcrypt verify path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)