### PR TITLE
feat(e2e): cooked-event smoke flow (#105)

### DIFF
--- a/e2e/cooked-event.spec.ts
+++ b/e2e/cooked-event.spec.ts
@@ -1,0 +1,54 @@
+import { randomBytes } from 'crypto';
+import { expect, test } from '@playwright/test';
+
+/**
+ * Smoke flow for #105 — log a cooked event against the seeded recipe via the
+ * UI and assert it renders on the recipe detail page AND on /timeline. This
+ * is the only e2e coverage of the V1-differentiating timeline union in
+ * [src/lib/timeline-data.ts], exercising the POST handler in
+ * [src/app/api/posts/[postId]/cooked/route.ts] and the `cooked_logged` render
+ * path in [src/components/timeline/TimelineCard.tsx].
+ *
+ * Uses the shared `claude-test` storageState from global-setup.ts so the spec
+ * starts already authenticated, and the deterministic seed recipe (id
+ * `e2e-recipe-001`) from `SEED_E2E=1` in prisma/seed.ts.
+ *
+ * Each run appends a new cooked event — the note carries a unique stamp so
+ * assertions can't collide with the seeded cooked event or prior runs.
+ */
+
+test.use({ storageState: 'e2e/.auth/claude-test.json' });
+
+const RECIPE_POST_ID = 'e2e-recipe-001';
+const COOKED_RATING = 5;
+
+test(
+  'logged cooked event renders on recipe detail and timeline',
+  { tag: ['@smoke'] },
+  async ({ page }) => {
+    const note = `E2E cooked note ${Date.now()}_${randomBytes(3).toString('hex')}`;
+
+    await page.goto(`/posts/${RECIPE_POST_ID}`);
+    await expect(page).toHaveURL(new RegExp(`/posts/${RECIPE_POST_ID}$`));
+
+    await page.getByRole('button', { name: /^cooked this!$/i }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByRole('button', { name: `${COOKED_RATING} ★` }).click();
+    await dialog.getByLabel(/notes/i).fill(note);
+    await dialog.getByRole('button', { name: /save cooked event/i }).click();
+
+    await expect(dialog).toBeHidden();
+
+    // Recent cooks on detail renders the note plain; the timeline card wraps
+    // it in smart quotes (see TimelineCard.tsx).
+    await expect(page.getByText(note, { exact: true })).toBeVisible();
+
+    await page.goto('/timeline');
+    await expect(page).toHaveURL(/\/timeline$/);
+
+    await expect(page.getByText(`“${note}”`)).toBeVisible();
+  }
+);


### PR DESCRIPTION
## Summary

- Adds `e2e/cooked-event.spec.ts` tagged `@smoke` — logs a cooked event against the seeded recipe (`e2e-recipe-001`) via the UI, then asserts the new entry renders on the recipe detail page AND on /timeline.
- Only e2e coverage of the V1-differentiating timeline union in [src/lib/timeline-data.ts](src/lib/timeline-data.ts). Exercises the POST handler in [src/app/api/posts/[postId]/cooked/route.ts](src/app/api/posts/[postId]/cooked/route.ts) and the `cooked_logged` render branch in [src/components/timeline/TimelineCard.tsx](src/components/timeline/TimelineCard.tsx) end-to-end.
- Uses the shared `claude-test` storageState (same pattern as `post-with-photo.spec.ts`). Note carries a unique per-run stamp so assertions can't collide with the seeded cooked event or prior runs.

## Closes

Closes #105

## Test notes

- Local run against seeded Postgres:
  - `scripts/local-stack-up.sh`
  - `SEED_E2E=1 scripts/with-local-stack.sh npm run db:seed`
  - `scripts/with-local-stack.sh npx playwright test e2e/cooked-event.spec.ts` → passes (~0.6s)
- Regression verified: short-circuited the `cookedEvent.findMany` branch in [src/lib/timeline-data.ts](src/lib/timeline-data.ts) (forced `cookedEvents` to `[]`). Detail-page assertion still passed (that state is updated from the POST response, not timeline-data), and only the `/timeline` assertion failed — confirming the spec is the one enforcing timeline-union coverage end-to-end. Sabotage reverted before commit.
- `npm run type-check`, `npm run lint`, `npm test` (46 suites / 963 tests) all green.
- Per the ticket, this spec joins the `@smoke` grep and will be picked up by #107's post-deploy smoke step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)