### PR TITLE
feat(e2e): comment+reaction smoke flow (#104)

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -7,6 +7,8 @@ This directory currently contains:
 - [auth.spec.ts](auth.spec.ts) — login + protected-route gating (PoC flow from #58).
 - [signup.spec.ts](signup.spec.ts) — signup via family master key (#106). Tagged `@smoke @destructive`; CI-only (see [Tags](#tags)).
 - [post-with-photo.spec.ts](post-with-photo.spec.ts) — create a post with a photo upload (#103). Tagged `@smoke`; uses shared storageState (see [Authentication](#authentication)).
+- [cooked-event.spec.ts](cooked-event.spec.ts) — log a cooked event against the seeded recipe (#105). Tagged `@smoke`; uses shared storageState.
+- [comment-reaction.spec.ts](comment-reaction.spec.ts) — comment + react on the seeded post and verify the author's notification (#104). Tagged `@smoke`; uses shared storageState, plus a fresh context signed in as the seeded `e2e-author` for the notification assertion.
 
 Further smoke flows land in follow-up tickets (see the research doc for the list).
 

--- a/e2e/comment-reaction.spec.ts
+++ b/e2e/comment-reaction.spec.ts
@@ -21,9 +21,10 @@ import { expect, test } from '@playwright/test';
 test.use({ storageState: 'e2e/.auth/claude-test.json' });
 
 const POST_ID = 'ce2epost001';
-// Fresh emoji — the seed already has ❤️ from claude-test, so clicking ❤️
-// would toggle it off. 🔥 starts at 0 and goes to 1.
+// Fresh emoji — the seed has ❤️ from claude-test, so clicking ❤️ would
+// toggle it off. 🔥 is un-seeded.
 const REACTION_EMOJI = '🔥';
+// Must match the second user seeded by `SEED_E2E=1` in prisma/seed.ts.
 const E2E_AUTHOR_USER = 'e2e-author';
 const E2E_AUTHOR_PASSWORD = 'e2e-author-password';
 
@@ -49,25 +50,29 @@ test(
     const reactionsSection = page
       .getByRole('heading', { name: 'Reactions', exact: true })
       .locator('xpath=ancestor::section[1]');
-    await reactionsSection
-      .getByRole('button', { name: REACTION_EMOJI })
-      .click();
+    const reactionPill = reactionsSection.getByText(`${REACTION_EMOJI}1`, {
+      exact: false,
+    });
 
-    // Badges render as `<emoji> <count>` inside a pill span. Assert the 🔥
-    // pill appears in the Reactions section with a count of 1.
-    await expect(
-      reactionsSection.getByText(`${REACTION_EMOJI}1`, { exact: false })
-    ).toBeVisible();
+    // POST /api/reactions is a toggle, not additive. A CI retry (retries: 1
+    // in playwright.config) reuses the seeded DB — if a prior attempt left
+    // 🔥 on, clicking again would toggle it OFF and the assertion below
+    // would fail deterministically. Click only when the pill is absent so
+    // the end state is always "🔥 reacted".
+    if ((await reactionPill.count()) === 0) {
+      await reactionsSection
+        .getByRole('button', { name: REACTION_EMOJI })
+        .click();
+    }
+    await expect(reactionPill).toBeVisible();
 
     await page.reload();
     await expect(page.getByText(commentText, { exact: true })).toBeVisible();
-    const reactionsSectionAfterReload = page
-      .getByRole('heading', { name: 'Reactions', exact: true })
-      .locator('xpath=ancestor::section[1]');
     await expect(
-      reactionsSectionAfterReload.getByText(`${REACTION_EMOJI}1`, {
-        exact: false,
-      })
+      page
+        .getByRole('heading', { name: 'Reactions', exact: true })
+        .locator('xpath=ancestor::section[1]')
+        .getByText(`${REACTION_EMOJI}1`, { exact: false })
     ).toBeVisible();
 
     // Log in as the post author in a fresh context so we can inspect their

--- a/e2e/comment-reaction.spec.ts
+++ b/e2e/comment-reaction.spec.ts
@@ -1,0 +1,103 @@
+import { randomBytes } from 'crypto';
+import { expect, test } from '@playwright/test';
+
+/**
+ * Smoke flow for #104 — comment + react on a seeded post as `claude-test`,
+ * assert both land on the post detail page, and assert the resulting comment
+ * notification surfaces for the post author (`e2e-author`) on /notifications.
+ *
+ * Covers the social loop from [docs/research/automated-testing.md]:
+ * POST /api/posts/[postId]/comments, the `Reaction` polymorphism in
+ * POST /api/reactions (toggle path in [src/app/api/reactions/route.ts]),
+ * and the notification write-through in [src/lib/notifications.ts] (which
+ * filters self-actions, hence the two-user seed).
+ *
+ * The main flow uses the shared `claude-test` storageState from
+ * global-setup.ts; the notification assertion signs in as `e2e-author` via a
+ * fresh context. Both users live in the same FamilySpace via
+ * [prisma/seed.ts] `SEED_E2E=1` fixtures.
+ */
+
+test.use({ storageState: 'e2e/.auth/claude-test.json' });
+
+const POST_ID = 'ce2epost001';
+// Fresh emoji — the seed already has ❤️ from claude-test, so clicking ❤️
+// would toggle it off. 🔥 starts at 0 and goes to 1.
+const REACTION_EMOJI = '🔥';
+const E2E_AUTHOR_USER = 'e2e-author';
+const E2E_AUTHOR_PASSWORD = 'e2e-author-password';
+
+test(
+  'comment + reaction on a post persist and notify the author',
+  { tag: ['@smoke'] },
+  async ({ page, browser }) => {
+    const stamp = `${Date.now()}_${randomBytes(3).toString('hex')}`;
+    const commentText = `E2E comment ${stamp}`;
+
+    await page.goto(`/posts/${POST_ID}`);
+    await expect(page).toHaveURL(new RegExp(`/posts/${POST_ID}$`));
+
+    await page.getByPlaceholder('Share your thoughts').fill(commentText);
+    await page.getByRole('button', { name: /^post comment$/i }).click();
+
+    const commentLocator = page.getByText(commentText, { exact: true });
+    await expect(commentLocator).toBeVisible();
+
+    // The 🔥 button appears both in the post-level Reactions section and on
+    // every comment card. Scope via the heading's ancestor section so we hit
+    // the post-target code path.
+    const reactionsSection = page
+      .getByRole('heading', { name: 'Reactions', exact: true })
+      .locator('xpath=ancestor::section[1]');
+    await reactionsSection
+      .getByRole('button', { name: REACTION_EMOJI })
+      .click();
+
+    // Badges render as `<emoji> <count>` inside a pill span. Assert the 🔥
+    // pill appears in the Reactions section with a count of 1.
+    await expect(
+      reactionsSection.getByText(`${REACTION_EMOJI}1`, { exact: false })
+    ).toBeVisible();
+
+    await page.reload();
+    await expect(page.getByText(commentText, { exact: true })).toBeVisible();
+    const reactionsSectionAfterReload = page
+      .getByRole('heading', { name: 'Reactions', exact: true })
+      .locator('xpath=ancestor::section[1]');
+    await expect(
+      reactionsSectionAfterReload.getByText(`${REACTION_EMOJI}1`, {
+        exact: false,
+      })
+    ).toBeVisible();
+
+    // Log in as the post author in a fresh context so we can inspect their
+    // notifications page. Using context.request rather than the UI login form
+    // keeps the flow tight — the signup/login UI is exercised in auth.spec.
+    const authorContext = await browser.newContext();
+    try {
+      const loginResponse = await authorContext.request.post(
+        '/api/auth/login',
+        {
+          data: {
+            emailOrUsername: E2E_AUTHOR_USER,
+            password: E2E_AUTHOR_PASSWORD,
+            rememberMe: false,
+          },
+        }
+      );
+      expect(loginResponse.ok(), 'e2e-author login').toBeTruthy();
+
+      const authorPage = await authorContext.newPage();
+      await authorPage.goto('/notifications');
+      await expect(authorPage).toHaveURL(/\/notifications$/);
+
+      // The notification body wraps comment text in smart quotes (see
+      // NotificationCard.tsx), matching the render on TimelineCard.
+      await expect(
+        authorPage.getByText(`“${commentText}”`, { exact: true })
+      ).toBeVisible();
+    } finally {
+      await authorContext.close();
+    }
+  }
+);

--- a/e2e/cooked-event.spec.ts
+++ b/e2e/cooked-event.spec.ts
@@ -19,7 +19,7 @@ import { expect, test } from '@playwright/test';
 
 test.use({ storageState: 'e2e/.auth/claude-test.json' });
 
-const RECIPE_POST_ID = 'e2e-recipe-001';
+const RECIPE_POST_ID = 'ce2erecipe001';
 const COOKED_RATING = 5;
 
 test(

--- a/prisma/CLAUDE.md
+++ b/prisma/CLAUDE.md
@@ -36,12 +36,15 @@ To rotate the master key, do it manually via the DB — there is no API for it.
 
 Setting `SEED_E2E=1` (alongside the default non-prod `NODE_ENV`) adds a deterministic fixture set on top of the baseline seed, for the Playwright smoke suite (#58 / #102):
 
-- one post (`id='e2e-post-001'`, title `E2E Seed Post`) authored by `claude-test`
-- one comment on that post (`id='e2e-comment-001'`)
-- one reaction on that post (`id='e2e-reaction-001'`, emoji `❤️`)
-- one recipe post (`id='e2e-recipe-001'`, title `E2E Seed Recipe`, `hasRecipeDetails=true`) with `RecipeDetails`
-- one cooked event against the recipe (`id='e2e-cooked-001'`, rating 5)
-- one notification for `claude-test` (`id='e2e-notification-001'`, type `comment`)
+- a second user `e2e-author` (email `e2e-author@example.local`, password `e2e-author-password`) in the same family space, so `claude-test` can act on a post they didn't author — [src/lib/notifications.ts](../src/lib/notifications.ts) filters self-notifications, which would otherwise suppress comment/reaction delivery in the smoke suite
+- one post (`id='ce2epost001'`, title `E2E Seed Post`) authored by `e2e-author`
+- one comment on that post (`id='ce2ecomment001'`) by `claude-test`
+- one reaction on that post (`id='ce2ereaction001'`, emoji `❤️`) by `claude-test`
+- one recipe post (`id='ce2erecipe001'`, title `E2E Seed Recipe`, `hasRecipeDetails=true`) authored by `claude-test`, with `RecipeDetails`
+- one cooked event against the recipe (`id='ce2ecooked001'`, rating 5) by `claude-test`
+- one notification for `e2e-author` (`id='ce2enotif001'`, type `comment`, actor `claude-test`)
+
+Fixture IDs are shaped to pass Zod's `.cuid()` check — route handlers that validate postId/commentId as CUIDs reject hyphenated IDs like `e2e-post-001`.
 
 All upserts keyed on the deterministic IDs, so re-running `SEED_E2E=1 npm run db:seed` does not duplicate rows. Specs assert by ID or content (`E2E Seed Post`, etc.). Ignored when `NODE_ENV=production` or `SEED_E2E` is unset.
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -132,14 +132,25 @@ async function seedTestUser(familySpaceId: string): Promise<string | null> {
   return user.id;
 }
 
-// Deterministic fixture IDs — Playwright specs assert by content/ID.
-const E2E_POST_ID = 'e2e-post-001';
-const E2E_COMMENT_ID = 'e2e-comment-001';
-const E2E_REACTION_ID = 'e2e-reaction-001';
-const E2E_RECIPE_POST_ID = 'e2e-recipe-001';
-const E2E_RECIPE_DETAILS_ID = 'e2e-recipe-details-001';
-const E2E_COOKED_EVENT_ID = 'e2e-cooked-001';
-const E2E_NOTIFICATION_ID = 'e2e-notification-001';
+// Deterministic fixture IDs — Playwright specs assert by ID. Shaped to pass
+// Zod's `.cuid()` check (starts with 'c', 9+ alphanumeric chars) so they're
+// accepted by route handlers that validate postId/commentId as CUIDs — see
+// [src/lib/validation.ts] postIdParamSchema, commentIdParamSchema.
+const E2E_POST_ID = 'ce2epost001';
+const E2E_COMMENT_ID = 'ce2ecomment001';
+const E2E_REACTION_ID = 'ce2ereaction001';
+const E2E_RECIPE_POST_ID = 'ce2erecipe001';
+const E2E_RECIPE_DETAILS_ID = 'ce2erd001';
+const E2E_COOKED_EVENT_ID = 'ce2ecooked001';
+const E2E_NOTIFICATION_ID = 'ce2enotif001';
+
+// Second E2E user so `claude-test` can act on a post they didn't author — the
+// `Notification` flow (#104) filters self-actions in [src/lib/notifications.ts],
+// so without two users the comment/reaction smoke can't verify delivery.
+const E2E_AUTHOR_USERNAME = 'e2e-author';
+const E2E_AUTHOR_EMAIL = 'e2e-author@example.local';
+const E2E_AUTHOR_NAME = 'E2E Author';
+const E2E_AUTHOR_PASSWORD = 'e2e-author-password';
 
 async function seedE2EFixtures(familySpaceId: string, userId: string) {
   if (process.env.SEED_E2E !== '1') return;
@@ -148,9 +159,33 @@ async function seedE2EFixtures(familySpaceId: string, userId: string) {
     return;
   }
 
+  const authorPasswordHash = await bcrypt.hash(E2E_AUTHOR_PASSWORD, 10);
+  const author = await prisma.user.upsert({
+    where: { email: E2E_AUTHOR_EMAIL },
+    update: { passwordHash: authorPasswordHash, name: E2E_AUTHOR_NAME },
+    create: {
+      email: E2E_AUTHOR_EMAIL,
+      username: E2E_AUTHOR_USERNAME,
+      name: E2E_AUTHOR_NAME,
+      passwordHash: authorPasswordHash,
+    },
+  });
+
+  await prisma.familyMembership.upsert({
+    where: {
+      familySpaceId_userId: { familySpaceId, userId: author.id },
+    },
+    update: {},
+    create: {
+      familySpaceId,
+      userId: author.id,
+      role: 'member',
+    },
+  });
+
   const postData = {
     familySpaceId,
-    authorId: userId,
+    authorId: author.id,
     title: 'E2E Seed Post',
     caption: 'Deterministic post for Playwright smoke suite',
     hasRecipeDetails: false,
@@ -224,12 +259,9 @@ async function seedE2EFixtures(familySpaceId: string, userId: string) {
     create: { id: E2E_COOKED_EVENT_ID, ...cookedEventData },
   });
 
-  // V1 only seeds one user, so actor == recipient here. The DB allows it;
-  // UI business logic that filters self-notifications is validated in tests,
-  // not at seed time.
   const notificationData = {
     familySpaceId,
-    recipientId: userId,
+    recipientId: author.id,
     actorId: userId,
     type: 'comment',
     postId: E2E_POST_ID,


### PR DESCRIPTION
## Summary

- Adds `e2e/comment-reaction.spec.ts` — the fourth core smoke flow from #58. Comments on `ce2epost001`, toggles a 🔥 reaction, reloads to confirm persistence, then logs in as the post author in a fresh context and asserts the comment notification surfaces on `/notifications`.
- Reshapes the `SEED_E2E=1` fixture bundle: adds a second user (`e2e-author`) as the author of `e2e-post-001`, and updates the seed so `claude-test` is the commenter/reactor/notification actor. Without two users the whole flow is suppressed — `createCommentNotification` / `upsertReactionNotification` in `src/lib/notifications.ts` filter self-actions (`recipientId === actorId`).
- Renames the deterministic fixture IDs to CUID-shape strings (`ce2epost001`, `ce2ecomment001`, ...). The old `e2e-*-001` IDs were silently rejected by `/api/posts/[postId]/comments` because `postIdParamSchema` in `src/lib/validation.ts` enforces `.cuid()`. `cooked-event.spec.ts` is updated to track the rename.

## Closes

Closes #104

## Test notes

- `scripts/with-local-stack.sh bash -c 'SEED_E2E=1 npm run db:seed'` then `scripts/with-local-stack.sh npm run test:e2e` — all 5 specs pass (auth, signup, post-with-photo, cooked-event, comment-reaction).
- `npm run type-check`, `npm run lint`, `npm test` — all green (963 Jest tests pass).
- Edge cases exercised:
  - Smart-quote wrap on the notification card body (`"{commentText}"`) matches `NotificationCard.tsx` render.
  - 🔥 picked as the reaction emoji because ❤️ is already seeded from `claude-test`, and clicking ❤️ would toggle it off (`/api/reactions` is a toggle, not additive).
  - Post-level vs. comment-level reaction buttons disambiguated by scoping from the `Reactions` heading via `xpath=ancestor::section[1]`.
- CI fresh DB is deterministic; local re-runs without reseed leave stale 🔥/comment rows and will fail on the toggle-off path — `TRUNCATE ... CASCADE` + reseed between iterations, same pattern as the other `@smoke` specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)