### PR TITLE
chore: path-filter ci.yml jobs per surface (#129)

### DIFF
--- a/.github/GITHUB_GUIDE.md
+++ b/.github/GITHUB_GUIDE.md
@@ -122,7 +122,7 @@ Example: `feat: cooked-event reactions (#12)`
 
 ### CI gates on every PR
 
-`.github/workflows/ci.yml` runs typecheck, lint, tests, docker build, trivy scan, prisma validate, `npm audit`, dependency-review, semgrep, IaC scan, and gitleaks. Separate workflows run for [apps/api/](../apps/api/) and [apps/recipe-url-importer/](../apps/recipe-url-importer/). All must pass before merging.
+`.github/workflows/ci.yml` runs typecheck, lint, tests, docker build, trivy scan, prisma validate, `npm audit`, dependency-review, semgrep, IaC scan, and gitleaks. Jobs are per-surface path-filtered: each always runs so required-check contexts report, but the expensive steps short-circuit when the relevant surface (`next` / `prisma` / `infra`) didn't change — see [Branch protection](#branch-protection) below. Separate workflows run for [apps/api/](../apps/api/) and [apps/recipe-url-importer/](../apps/recipe-url-importer/). All must pass before merging.
 
 ---
 
@@ -139,7 +139,11 @@ Shared settings on both branches:
 - **Required approving reviews: 0** — as a solo maintainer, self-merge is allowed
 - **Admins not enforced** — the repo owner can bypass in genuine emergencies (use sparingly)
 
-Required status checks (from [ci.yml](workflows/ci.yml), the only workflow that runs on every PR): `typecheck`, `lint`, `test`, `e2e`, `build`, `container-scan`, `prisma-validate`, `prisma-drift-check`, `dependency-scan`, `sast-semgrep`, `iac-scan`, `secrets-scan`. Job names in [api-ci.yml](workflows/api-ci.yml) and [recipe-url-importer-ci.yml](workflows/recipe-url-importer-ci.yml) are path-filtered, so they are **not** listed as required (a path-filtered required check that never runs would permanently block merges). They share names (`lint`, `typecheck`, etc.) with ci.yml jobs, so when they do run and fail, the shared-name required check fails too — effectively required when the relevant paths change.
+Required status checks (all live in [ci.yml](workflows/ci.yml), which runs on every PR): `typecheck`, `lint`, `test`, `e2e`, `build`, `container-scan`, `prisma-validate`, `prisma-drift-check`, `dependency-scan`, `sast-semgrep`, `iac-scan`, `secrets-scan`.
+
+[ci.yml](workflows/ci.yml) uses a per-surface path filter: a top `changes` job computes `next` / `prisma` / `infra` booleans via `dorny/paths-filter`, and each downstream job wraps its expensive steps in an `if:` tied to the relevant flag. The job itself always runs (so the required-check context always reports), but when its surface is unchanged the steps short-circuit to a no-op `echo` and the job completes green. This is the "keep the required-check names attached to a job that always runs" pattern — a required check that never runs would permanently block merges, so we never let one go un-reported.
+
+[api-ci.yml](workflows/api-ci.yml) and [recipe-url-importer-ci.yml](workflows/recipe-url-importer-ci.yml) are workflow-level path-filtered (`on.pull_request.paths`), so they only fire when their owning surface changes. Their job names (`lint`, `typecheck`, `test`, etc.) overlap with ci.yml's by design: when they do run, the shared-name required checks must pass under both workflows for the PR to merge.
 
 Difference between branches:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,43 +5,109 @@ on:
     branches: [main, develop]
 
 jobs:
-  typecheck:
+  # Every job below is always queued so each required status check reports on
+  # every PR. `changes` computes per-surface flags; each job short-circuits to
+  # success when its surface is unchanged (see GITHUB_GUIDE.md#branch-protection).
+  changes:
     runs-on: ubuntu-latest
+    outputs:
+      next: ${{ steps.filter.outputs.next }}
+      prisma: ${{ steps.filter.outputs.prisma }}
+      infra: ${{ steps.filter.outputs.infra }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            next:
+              - 'src/**'
+              - '__tests__/**'
+              - 'e2e/**'
+              - 'prisma/**'
+              - 'public/**'
+              - 'scripts/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'tsconfig*.json'
+              - 'next.config.*'
+              - 'tailwind.config.*'
+              - 'postcss.config.*'
+              - 'jest.config.js'
+              - 'jest.setup.js'
+              - 'playwright.config.*'
+              - 'eslint.config.mjs'
+              - 'middleware.*'
+              - 'Dockerfile'
+              - '.dockerignore'
+              - '.github/workflows/ci.yml'
+            prisma:
+              - 'prisma/**'
+              - 'scripts/check-prisma-drift.sh'
+              - 'package.json'
+              - 'package-lock.json'
+              - '.github/workflows/ci.yml'
+            infra:
+              - 'infra/**'
+              - '.github/workflows/ci.yml'
+
+  typecheck:
+    runs-on: ubuntu-latest
+    needs: [changes]
+    steps:
+      - if: needs.changes.outputs.next == 'true'
+        uses: actions/checkout@v4
+      - if: needs.changes.outputs.next == 'true'
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
-      - run: npm ci
-      - run: npm run type-check
+      - if: needs.changes.outputs.next == 'true'
+        run: npm ci
+      - if: needs.changes.outputs.next == 'true'
+        run: npm run type-check
+      - if: needs.changes.outputs.next != 'true'
+        run: echo "::notice::Next.js surface unchanged; typecheck trivially passes."
 
   lint:
     runs-on: ubuntu-latest
+    needs: [changes]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - if: needs.changes.outputs.next == 'true'
+        uses: actions/checkout@v4
+      - if: needs.changes.outputs.next == 'true'
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
-      - run: npm ci
-      - run: npm run lint
+      - if: needs.changes.outputs.next == 'true'
+        run: npm ci
+      - if: needs.changes.outputs.next == 'true'
+        run: npm run lint
+      - if: needs.changes.outputs.next != 'true'
+        run: echo "::notice::Next.js surface unchanged; lint trivially passes."
 
   test:
     runs-on: ubuntu-latest
-    needs: [typecheck, lint]
+    needs: [changes, typecheck, lint]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - if: needs.changes.outputs.next == 'true'
+        uses: actions/checkout@v4
+      - if: needs.changes.outputs.next == 'true'
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
-      - run: npm ci
-      - run: npm run test
+      - if: needs.changes.outputs.next == 'true'
+        run: npm ci
+      - if: needs.changes.outputs.next == 'true'
+        run: npm run test
+      - if: needs.changes.outputs.next != 'true'
+        run: echo "::notice::Next.js surface unchanged; test trivially passes."
 
   e2e:
     runs-on: ubuntu-latest
-    needs: [test]
+    needs: [changes, test]
     services:
       postgres:
         image: postgres:16
@@ -63,99 +129,127 @@ jobs:
       CLAUDE_TEST_USER: claude-test
       CLAUDE_TEST_PASSWORD: claude-test-password
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - if: needs.changes.outputs.next == 'true'
+        uses: actions/checkout@v4
+      - if: needs.changes.outputs.next == 'true'
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
-      - run: npm ci
-      - name: Prisma generate + push
+      - if: needs.changes.outputs.next == 'true'
+        run: npm ci
+      - if: needs.changes.outputs.next == 'true'
+        name: Prisma generate + push
         run: |
           npm run db:generate
           npm run db:push
-      - name: Seed with E2E fixtures
+      - if: needs.changes.outputs.next == 'true'
+        name: Seed with E2E fixtures
         run: SEED_E2E=1 npm run db:seed
-      - name: Cache Playwright browsers
+      - if: needs.changes.outputs.next == 'true'
+        name: Cache Playwright browsers
         id: playwright-cache
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
-      - name: Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
+      - if: needs.changes.outputs.next == 'true' && steps.playwright-cache.outputs.cache-hit != 'true'
+        name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
-      - name: Install Playwright system deps (cache hit)
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
+      - if: needs.changes.outputs.next == 'true' && steps.playwright-cache.outputs.cache-hit == 'true'
+        name: Install Playwright system deps (cache hit)
         run: npx playwright install-deps chromium
-      - name: Run Playwright smoke suite
+      - if: needs.changes.outputs.next == 'true'
+        name: Run Playwright smoke suite
         run: npm run test:e2e
-      - name: Upload Playwright report
-        if: failure()
+      - if: failure() && needs.changes.outputs.next == 'true'
+        name: Upload Playwright report
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report
           path: playwright-report/
           retention-days: 7
+      - if: needs.changes.outputs.next != 'true'
+        run: echo "::notice::Next.js surface unchanged; e2e trivially passes."
 
   build:
     runs-on: ubuntu-latest
-    needs: [test]
+    needs: [changes, test]
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up Docker Buildx
+      - if: needs.changes.outputs.next == 'true'
+        uses: actions/checkout@v4
+      - if: needs.changes.outputs.next == 'true'
+        name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Docker build (production image)
+      - if: needs.changes.outputs.next == 'true'
+        name: Docker build (production image)
         run: |
           docker build \
            --pull \
            --no-cache \
            --file Dockerfile \
            --tag family-recipe:ci .
-      - name: Save image artifact
+      - if: needs.changes.outputs.next == 'true'
+        name: Save image artifact
         run: docker save family-recipe:ci -o family-recipe.tar
-      - name: Upload image artifact
+      - if: needs.changes.outputs.next == 'true'
+        name: Upload image artifact
         uses: actions/upload-artifact@v4
         with:
           name: family-recipe-image
           path: family-recipe.tar
+      - if: needs.changes.outputs.next != 'true'
+        run: echo "::notice::Next.js surface unchanged; build trivially passes."
 
   container-scan:
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [changes, build]
     steps:
-      - uses: actions/checkout@v4
-      - name: Download image artifact
+      - if: needs.changes.outputs.next == 'true'
+        uses: actions/checkout@v4
+      - if: needs.changes.outputs.next == 'true'
+        name: Download image artifact
         uses: actions/download-artifact@v4
         with:
           name: family-recipe-image
           path: .
-      - name: Load image
+      - if: needs.changes.outputs.next == 'true'
+        name: Load image
         run: docker load -i family-recipe.tar
-      - name: Container scan (Trivy)
+      - if: needs.changes.outputs.next == 'true'
+        name: Container scan (Trivy)
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: family-recipe:ci
           format: table
           exit-code: 1
           severity: HIGH,CRITICAL
+      - if: needs.changes.outputs.next != 'true'
+        run: echo "::notice::Next.js surface unchanged; container-scan trivially passes."
 
   prisma-validate:
     runs-on: ubuntu-latest
-    needs: [typecheck]
+    needs: [changes, typecheck]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - if: needs.changes.outputs.prisma == 'true'
+        uses: actions/checkout@v4
+      - if: needs.changes.outputs.prisma == 'true'
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
-      - run: npm ci
-      - run: npx prisma validate --schema prisma/schema.postgres.prisma
+      - if: needs.changes.outputs.prisma == 'true'
+        run: npm ci
+      - if: needs.changes.outputs.prisma == 'true'
+        run: npx prisma validate --schema prisma/schema.postgres.prisma
         env:
           DATABASE_URL: postgresql://user:pass@localhost:5432/db
+      - if: needs.changes.outputs.prisma != 'true'
+        run: echo "::notice::Prisma schema unchanged; prisma-validate trivially passes."
 
   prisma-drift-check:
     runs-on: ubuntu-latest
-    needs: [typecheck]
+    needs: [changes, typecheck]
     services:
       postgres:
         image: postgres:16
@@ -173,26 +267,38 @@ jobs:
     env:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/drift_check
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - if: needs.changes.outputs.prisma == 'true'
+        uses: actions/checkout@v4
+      - if: needs.changes.outputs.prisma == 'true'
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
-      - run: npm ci
-      - name: Replay prisma/migrations and diff against both schemas
+      - if: needs.changes.outputs.prisma == 'true'
+        run: npm ci
+      - if: needs.changes.outputs.prisma == 'true'
+        name: Replay prisma/migrations and diff against both schemas
         run: scripts/check-prisma-drift.sh
+      - if: needs.changes.outputs.prisma != 'true'
+        run: echo "::notice::Prisma schema unchanged; prisma-drift-check trivially passes."
 
   dependency-scan:
     runs-on: ubuntu-latest
-    needs: [typecheck]
+    needs: [changes, typecheck]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - if: needs.changes.outputs.next == 'true'
+        uses: actions/checkout@v4
+      - if: needs.changes.outputs.next == 'true'
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
-      - run: npm ci
-      - run: npm audit --production --audit-level=high
+      - if: needs.changes.outputs.next == 'true'
+        run: npm ci
+      - if: needs.changes.outputs.next == 'true'
+        run: npm audit --production --audit-level=high
+      - if: needs.changes.outputs.next != 'true'
+        run: echo "::notice::Next.js surface unchanged; dependency-scan trivially passes."
 
   dependency-review:
     runs-on: ubuntu-latest
@@ -202,27 +308,33 @@ jobs:
 
   sast-semgrep:
     runs-on: ubuntu-latest
-    needs: [lint, typecheck]
+    needs: [changes, lint, typecheck]
     steps:
-      - uses: actions/checkout@v4
+      - if: needs.changes.outputs.next == 'true'
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Run Semgrep (SAST)
+      - if: needs.changes.outputs.next == 'true'
+        name: Run Semgrep (SAST)
         uses: returntocorp/semgrep-action@v1
         with:
           config: p/ci
         env:
           SEMGREP_RULES: p/ci
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - if: needs.changes.outputs.next != 'true'
+        run: echo "::notice::Next.js surface unchanged; sast-semgrep trivially passes."
 
   iac-scan:
     runs-on: ubuntu-latest
-    needs: [typecheck]
+    needs: [changes, typecheck]
     steps:
-      - uses: actions/checkout@v4
+      - if: needs.changes.outputs.infra == 'true'
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: IaC scan (Trivy)
+      - if: needs.changes.outputs.infra == 'true'
+        name: IaC scan (Trivy)
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'config'
@@ -230,10 +342,11 @@ jobs:
           format: 'table'
           exit-code: '1'
           severity: 'HIGH,CRITICAL'
+      - if: needs.changes.outputs.infra != 'true'
+        run: echo "::notice::Infra unchanged; iac-scan trivially passes."
 
   secrets-scan:
     runs-on: ubuntu-latest
-    needs: [typecheck]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ Always finish with `npm test` (the pre-commit hook doesn't run it). If the sessi
 
 ## CI gates
 
-[.github/workflows/ci.yml](.github/workflows/ci.yml) runs typecheck → lint → test → docker build → trivy scan, plus prisma validate (postgres schema), `npm audit`, dependency-review, semgrep, IaC scan, and gitleaks. Separate workflows cover [api-ci.yml](.github/workflows/api-ci.yml) and [recipe-url-importer-ci.yml](.github/workflows/recipe-url-importer-ci.yml). Deploy workflows target GCP Cloud Run.
+[.github/workflows/ci.yml](.github/workflows/ci.yml) runs typecheck → lint → test → docker build → trivy scan, plus prisma validate (postgres schema), `npm audit`, dependency-review, semgrep, IaC scan, and gitleaks. Jobs are gated per-surface by a top `changes` job (dorny/paths-filter) — each job always runs so required-check contexts report, but expensive steps short-circuit when their surface (`next` / `prisma` / `infra`) didn't change. Separate workflows cover [api-ci.yml](.github/workflows/api-ci.yml) and [recipe-url-importer-ci.yml](.github/workflows/recipe-url-importer-ci.yml). Deploy workflows target GCP Cloud Run.
 
 ## What's out of scope (don't add unless asked)
 


### PR DESCRIPTION
## Summary

- Add a top-level `changes` job (`dorny/paths-filter@v3`) that computes per-surface booleans `next` / `prisma` / `infra`.
- Each downstream ci.yml job always runs (so its required-status-check context always reports), but its expensive steps are wrapped in `if: needs.changes.outputs.<flag> == 'true'`. When the surface is unchanged, steps short-circuit to a no-op `echo ::notice::` and the job completes green.
- `secrets-scan` and `dependency-review` stay unconditional per the ticket (repo-wide security scans shouldn't be path-filtered).
- Update [.github/GITHUB_GUIDE.md](.github/GITHUB_GUIDE.md) `#branch-protection` + CI-gates bullet, and [CLAUDE.md](CLAUDE.md) CI-gates section, to describe the new gating mechanism.

**Surface classification:**

| Flag | Paths | Jobs gated |
|---|---|---|
| `next` | `src/**`, `__tests__/**`, `e2e/**`, `prisma/**`, `public/**`, `scripts/**`, `package*.json`, `tsconfig*.json`, `next.config.*`, `tailwind.config.*`, `postcss.config.*`, `jest.config.js`, `jest.setup.js`, `playwright.config.*`, `eslint.config.mjs`, `middleware.*`, `Dockerfile`, `.dockerignore`, `.github/workflows/ci.yml` | `typecheck`, `lint`, `test`, `e2e`, `build`, `container-scan`, `dependency-scan`, `sast-semgrep` |
| `prisma` | `prisma/**`, `scripts/check-prisma-drift.sh`, `package*.json`, `.github/workflows/ci.yml` | `prisma-validate`, `prisma-drift-check` |
| `infra` | `infra/**`, `.github/workflows/ci.yml` | `iac-scan` |
| (always) | — | `secrets-scan`, `dependency-review` |

## Closes

Closes #129

## Test notes

The real test matrix is this PR itself plus a handful of scratch PRs — the gating only exercises on `pull_request` events, so local verification is limited to YAML validity.

Local:
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — parses clean.
- `actionlint .github/workflows/ci.yml` — clean (tested with v1.7.4).
- Pre-commit: `type-check` + `lint-staged` pass.

This PR (src-unchanged + ci.yml changed) should:
- Trigger all `next` filter jobs (ci.yml touches `next` filter paths).
- Trigger all `prisma` / `infra` filter jobs (ci.yml touches those filter paths too).
- So effectively this PR runs the full pipeline — which is the right smoke for "did I break anything mechanically".

Follow-up verification (from ticket, best done on subsequent PRs):

- [ ] Open a PR touching only `apps/api/**` — ci.yml Next-jobs short-circuit to green, api-ci.yml runs, required checks resolve.
- [ ] Open a PR touching only `apps/recipe-url-importer/**` — ci.yml short-circuits, recipe-url-importer-ci.yml runs.
- [ ] Open a docs-only PR (`docs/**` or `*.md`) — all required checks report green via no-op steps, merge not blocked.
- [ ] Confirm wall-clock CI time on a FastAPI-only PR drops noticeably vs. pre-change baseline.

**Branch-protection note:** required check names (`typecheck`, `lint`, `test`, `e2e`, `build`, `container-scan`, `prisma-validate`, `prisma-drift-check`, `dependency-scan`, `sast-semgrep`, `iac-scan`, `secrets-scan`) are preserved — no `gh api` branch-protection changes are needed. The "never-run required check" footgun is avoided by keeping every required-check-named job queued on every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)