### PR TITLE
docs: note ci.yml path-filter short-circuit in verification README

### DIFF
--- a/docs/verification/README.md
+++ b/docs/verification/README.md
@@ -10,6 +10,8 @@ Decision rationale and tool alternatives: [docs/research/claude-local-verificati
 
 **What CI covers for you.** The `e2e` job in [ci.yml](../../.github/workflows/ci.yml) runs the Playwright smoke suite in [e2e/](../../e2e/) against an ephemeral Postgres + `next start` on every PR (fails uploads the `playwright-report/` artifact). That catches login + protected-route regressions automatically; the local playbooks below still cover everything the smoke suite doesn't yet.
 
+ci.yml jobs are per-surface path-filtered (`next` / `prisma` / `infra`). Each job still queues on every PR so required-status-check contexts always report, but expensive steps short-circuit to a no-op when the owning surface is unchanged — so a docs-only or FastAPI-only PR won't rebuild the Next.js Docker image or run Playwright. See [.github/GITHUB_GUIDE.md#branch-protection](../../.github/GITHUB_GUIDE.md#branch-protection) for the mechanism.
+
 ## Local vs dev deployment
 
 | Stage                           | Target                                          | Playbook                                 |


### PR DESCRIPTION
## Summary

- Adds a short paragraph to [docs/verification/README.md](docs/verification/README.md) noting that ci.yml jobs are per-surface path-filtered as of #129 / #133, and linking to [.github/GITHUB_GUIDE.md#branch-protection](.github/GITHUB_GUIDE.md#branch-protection) for the mechanism.
- Doubles as the **docs-only verification PR** for #129's post-merge checklist — this PR's only changed path is `docs/**`, which matches none of the `next` / `prisma` / `infra` filters, so every filterable ci.yml job should short-circuit to a no-op `echo ::notice::` while still reporting green.

## Closes

Trivial docs follow-up; no issue. References #129.

## Test notes

**Expected CI behavior for this PR:**

- `changes` job: runs, emits `next=false`, `prisma=false`, `infra=false`.
- `typecheck`, `lint`, `test`, `e2e`, `build`, `container-scan`, `prisma-validate`, `prisma-drift-check`, `dependency-scan`, `sast-semgrep`, `iac-scan`: all queue, all steps skip except the final `echo ::notice::`, all report green.
- `secrets-scan`, `dependency-review`: run normally (unconditional).
- Total wall-clock expected: well under a minute for the short-circuited jobs (just runner provisioning + the echo).

If this PR merges with all 13 required checks green, the "docs-only PR cannot permanently block on a missing required check" bullet in #129's testing plan is proven in the wild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)