### PR TITLE
chore(ui): extract PillButton primitive and migrate add-form pills (#146)

### DIFF
--- a/src/components/add/AddPostForm.tsx
+++ b/src/components/add/AddPostForm.tsx
@@ -29,7 +29,7 @@ import {
   X,
 } from 'lucide-react';
 
-import { Button, Card, Input, Textarea } from '@/components/ui';
+import { Button, Card, Input, PillButton, Textarea } from '@/components/ui';
 import { ingredientUnitOptions } from '@/lib/ingredients';
 import { MAX_PHOTO_COUNT } from '@/lib/postPayload';
 import { type RecipeIngredientUnit } from '@/lib/validation';
@@ -64,18 +64,6 @@ const sectionHeadingClass = 'text-lg font-medium text-[var(--fg-strong)]';
 const sectionSubtitleClass = 'text-sm text-[var(--fg-meta)]';
 const selectClass =
   'w-full rounded-input border border-[var(--border-input)] bg-[var(--bg-surface)] px-4 py-3 text-base text-[var(--fg-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-active)] focus-visible:ring-offset-1';
-
-function pillClass(active: boolean, disabled = false): string {
-  return [
-    'rounded-full px-3 py-1 text-sm font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--border-active)]',
-    active
-      ? 'bg-[var(--bg-primary)] text-[var(--fg-on-primary)] border border-transparent'
-      : 'bg-[var(--bg-surface)] text-[var(--fg-body)] border border-[var(--border-input)] hover:border-[var(--border-active)]',
-    disabled ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer',
-  ]
-    .filter(Boolean)
-    .join(' ');
-}
 
 interface ExistingPhotoAttachment {
   id: string;
@@ -1412,15 +1400,14 @@ export default function AddPostForm({
                     const disabled =
                       !selected && selectedCourses.length >= MAX_COURSES;
                     return (
-                      <button
+                      <PillButton
                         key={option.value}
-                        type="button"
-                        onClick={() => toggleCourseSelection(option.value)}
+                        pressed={selected}
                         disabled={disabled}
-                        className={pillClass(selected, disabled)}
+                        onClick={() => toggleCourseSelection(option.value)}
                       >
                         {option.label}
-                      </button>
+                      </PillButton>
                     );
                   })}
                 </div>
@@ -1431,19 +1418,18 @@ export default function AddPostForm({
                   {difficultyOptions.map((option) => {
                     const selected = recipe.difficulty === option.value;
                     return (
-                      <button
+                      <PillButton
                         key={option.value}
-                        type="button"
+                        pressed={selected}
                         onClick={() =>
                           handleRecipeChange(
                             'difficulty',
                             selected ? '' : option.value
                           )
                         }
-                        className={pillClass(selected)}
                       >
                         {option.label}
-                      </button>
+                      </PillButton>
                     );
                   })}
                 </div>
@@ -1551,15 +1537,14 @@ export default function AddPostForm({
                             const disabled =
                               !selected && tags.length >= MAX_TAGS;
                             return (
-                              <button
+                              <PillButton
                                 key={tag.id}
-                                type="button"
-                                onClick={() => toggleTagSelection(tag.name)}
+                                pressed={selected}
                                 disabled={disabled}
-                                className={pillClass(selected, disabled)}
+                                onClick={() => toggleTagSelection(tag.name)}
                               >
                                 #{tag.name}
-                              </button>
+                              </PillButton>
                             );
                           })}
                         </div>

--- a/src/components/ui/PillButton.tsx
+++ b/src/components/ui/PillButton.tsx
@@ -1,0 +1,51 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+
+export type PillButtonSize = 'sm' | 'md';
+
+interface PillButtonProps extends Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  'children'
+> {
+  pressed: boolean;
+  size?: PillButtonSize;
+  children: ReactNode;
+}
+
+const sizeClasses: Record<PillButtonSize, string> = {
+  sm: 'px-2 py-0.5 text-[11px]',
+  md: 'px-3 py-1 text-sm',
+};
+
+export default function PillButton({
+  pressed,
+  size = 'md',
+  disabled = false,
+  className = '',
+  type = 'button',
+  children,
+  ...rest
+}: PillButtonProps) {
+  const composed = [
+    'inline-flex items-center gap-1 rounded-full font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--border-active)]',
+    sizeClasses[size],
+    pressed
+      ? 'bg-[var(--bg-primary)] text-[var(--fg-on-primary)] border border-transparent'
+      : 'bg-[var(--bg-surface)] text-[var(--fg-body)] border border-[var(--border-input)] hover:border-[var(--border-active)]',
+    disabled ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <button
+      type={type}
+      aria-pressed={pressed}
+      disabled={disabled}
+      className={composed}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/ui/PillButton.tsx
+++ b/src/components/ui/PillButton.tsx
@@ -39,11 +39,11 @@ export default function PillButton({
 
   return (
     <button
+      {...rest}
       type={type}
       aria-pressed={pressed}
       disabled={disabled}
       className={composed}
-      {...rest}
     >
       {children}
     </button>

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -5,4 +5,6 @@ export { default as Card } from './Card';
 export { default as Chip } from './Chip';
 export type { ChipVariant, ChipSize } from './Chip';
 export { default as Input } from './Input';
+export { default as PillButton } from './PillButton';
+export type { PillButtonSize } from './PillButton';
 export { default as Textarea } from './Textarea';


### PR DESCRIPTION
## Summary

- Adds `PillButton` design-system primitive in `src/components/ui/` — renders a real `<button>` with `aria-pressed` for assistive-tech state announcement.
- Migrates the three pill consumers in `AddPostForm` (course / difficulty / tag) off the local `pillClass()` helper, then deletes the helper.
- Path (b) from #146: a sibling primitive rather than a polymorphic `Chip`. Keeps `Chip`'s `<span>` semantics correct for the future label use case (e.g. the photo-grid "Cover" badge, which is currently a plain span and out of scope for this ticket).

Closes #146.

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [x] `npm test` — 46 suites / 963 tests passing
- [x] Browser via Playwright at `/add` → expand Recipe Details:
  - Course pills: clicking 3 enables them and disables the remaining 3 (cap=3 enforced); `aria-pressed` flips correctly
  - Difficulty pills: single-select, click toggles `aria-pressed`
  - Tag pills: multi-select, click toggles `aria-pressed`
  - Keyboard: focus a pill + `Space` → `aria-pressed` flips; cap-disabled pills re-enable on deselect
  - Visual parity with previous shipped state — same active (filled dark) / inactive (outline) styling, no regressions

## Notes

- `PillButton` deliberately mirrors the existing `pillClass()` size scale (`text-sm` at `md`) rather than `Chip`'s `text-xs`. This is a no-op chore on visuals — it preserves what just shipped in #139/#145 — not a redesign.
- The "Cover" badge at `AddPostForm.tsx:1238` is a plain `<span>`, not a `Chip` consumer, so the ticket's polymorphic-Chip regression-guard scenario doesn't apply here. Migrating Cover to `Chip` is a separate label-cleanup task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)