### PR TITLE
chore(ui): migrate Cover photo-grid badge to Chip primitive (#149)

### DIFF
--- a/src/components/add/AddPostForm.tsx
+++ b/src/components/add/AddPostForm.tsx
@@ -29,7 +29,14 @@ import {
   X,
 } from 'lucide-react';
 
-import { Button, Card, Input, PillButton, Textarea } from '@/components/ui';
+import {
+  Button,
+  Card,
+  Chip,
+  Input,
+  PillButton,
+  Textarea,
+} from '@/components/ui';
 import { ingredientUnitOptions } from '@/lib/ingredients';
 import { MAX_PHOTO_COUNT } from '@/lib/postPayload';
 import { type RecipeIngredientUnit } from '@/lib/validation';
@@ -1223,9 +1230,9 @@ export default function AddPostForm({
                     </div>
                     <div className="absolute top-2 left-2">
                       {index === 0 && (
-                        <span className="bg-[var(--bg-surface)] text-xs font-medium px-2 py-0.5 rounded-full text-[var(--fg-strong)]">
+                        <Chip variant="surface" size="sm">
                           Cover
-                        </span>
+                        </Chip>
                       )}
                     </div>
                     <div className="absolute top-2 right-2 flex gap-1">

--- a/src/components/ui/Chip.tsx
+++ b/src/components/ui/Chip.tsx
@@ -1,6 +1,6 @@
 import type { HTMLAttributes, ReactNode } from 'react';
 
-export type ChipVariant = 'active' | 'soft' | 'outline' | 'muted';
+export type ChipVariant = 'active' | 'soft' | 'outline' | 'muted' | 'surface';
 export type ChipSize = 'sm' | 'md';
 
 interface ChipProps extends HTMLAttributes<HTMLSpanElement> {
@@ -16,10 +16,11 @@ const variantClasses: Record<ChipVariant, string> = {
   outline:
     'bg-transparent text-[var(--fg-body)] border border-[var(--border-input)]',
   muted: 'bg-[var(--bg-chip-soft)] text-[var(--fg-meta)] border-0',
+  surface: 'bg-[var(--bg-surface)] text-[var(--fg-strong)] border-0',
 };
 
 const sizeClasses: Record<ChipSize, string> = {
-  sm: 'px-2 py-0.5 text-[11px]',
+  sm: 'px-2 py-0.5 text-xs',
   md: 'px-3 py-1 text-xs',
 };
 


### PR DESCRIPTION
## Summary

- Add `surface` variant to `Chip` (`bg-surface` / `fg-strong`) — first non-zero consumer for the primitive.
- Bump `Chip` `sm` from `text-[11px]` to `text-xs` so Cover migrates pixel-for-pixel; `Chip` had zero existing consumers, so this is not a regression. The deeper Chip↔PillButton size-scale alignment is still tracked in #148.
- Replace the inline `<span>` at `AddPostForm.tsx` photo-grid Cover badge with `<Chip variant="surface" size="sm">Cover</Chip>`.

Closes #149.

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm test` — 46 suites / 963 tests pass
- [x] Local browser at `/add`, upload 2 photos: Cover badge appears on slot 0 only with computed style `12px / px-2 py-0.5 / rounded-full / bg #fff / fg near-black` (matches pre-migration span exactly)
- [x] Reorder via "Move photo left" on slot 1 → Cover follows to the new slot 0; no other tile gains the badge
- [ ] (Owner sanity-check) `/add` Cover badge still looks right on a real upload session

🤖 Generated with [Claude Code](https://claude.com/claude-code)