### PR TITLE
feat(ui): desktop polish — content column at lg+ (#141)

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -37,7 +37,7 @@ export default async function AppLayout({
   return (
     <div className="min-h-screen bg-gray-50 pb-24">
       <header className="sticky top-0 z-30 border-b border-gray-200 bg-white/95 backdrop-blur">
-        <div className="mx-auto flex max-w-3xl items-center justify-between px-4 py-4 gap-4">
+        <div className="mx-auto flex max-w-3xl lg:max-w-2xl items-center justify-between px-4 py-4 gap-4">
           <div>
             <h1 className="text-xl font-bold text-gray-900">
               Wnorowski Family Recipe
@@ -52,7 +52,9 @@ export default async function AppLayout({
           </div>
         </div>
       </header>
-      <main className="mx-auto mt-4 max-w-3xl px-4 pb-10">{children}</main>
+      <main className="mx-auto mt-4 max-w-3xl lg:max-w-2xl px-4 pb-10">
+        {children}
+      </main>
       <BottomNav />
     </div>
   );

--- a/src/components/navigation/BottomNav.tsx
+++ b/src/components/navigation/BottomNav.tsx
@@ -24,7 +24,7 @@ export default function BottomNav() {
 
   return (
     <nav className="fixed bottom-0 left-0 right-0 z-40 border-t border-[var(--border-input)] bg-[var(--bg-surface)]">
-      <div className="mx-auto flex max-w-3xl items-center justify-around px-4 py-2">
+      <div className="mx-auto flex max-w-3xl lg:max-w-2xl items-center justify-around px-4 py-2">
         {NAV_ITEMS.map(({ href, label, Icon, fab }) => {
           const active = pathname ? pathname.startsWith(href) : false;
 


### PR DESCRIPTION
## Summary
- Constrain the `(app)` shell's three width-bearing containers (header inner, `<main>`, bottom-nav inner) to `lg:max-w-2xl` (672px) so that on desktop widths the content sits in a single comfortably readable column with balanced gray-50 bands instead of stretching the mobile-first 768px container.
- No structural / chrome changes — bottom nav stays at the bottom centered with the content column, header stays sticky, mobile and tablet layouts unchanged.

Closes #141.

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 963 / 963 pass
- [x] Visual at 390×844 — main column fills viewport, no regression vs. mobile baseline
- [x] Visual at 1023×800 — main = 768px (`max-w-3xl` still applies under `lg`)
- [x] Visual at 1024×800 — main = 672px (single-step 96px transition exactly at `lg`, no in-between janky width)
- [x] Visual at 1280×900 — main = 672px, balanced 304px bands; verified on `/timeline`, `/recipes`, `/profile`, `/add`, `/posts/[postId]`
- [x] Visual at 1920×1080 — main = 672px, balanced 624px bands; gray-50 background, no midline
- [x] Header sticks to top, content scrolls between header and bottom nav across all checked viewports

Screenshots saved locally at `.playwright-mcp/141-*.png` (timeline / recipes / profile / add / postdetail @ 1280, timeline @ 390 and @ 1920).

🤖 Generated with [Claude Code](https://claude.com/claude-code)