### PR TITLE
chore: sync main into develop (recipe validation from f7b7393)

### DIFF
--- a/__tests__/unit/lib/validation.test.ts
+++ b/__tests__/unit/lib/validation.test.ts
@@ -8,6 +8,8 @@
  */
 
 import {
+  MAX_RECIPE_INGREDIENT_NAME_LENGTH,
+  MAX_RECIPE_ORIGIN_LENGTH,
   paginationSchema,
   recipeFiltersSchema,
   postIdParamSchema,
@@ -506,6 +508,37 @@ describe('Validation Schemas', () => {
     });
 
     describe('recipeDetailsSchema', () => {
+      it('should accept ingredient names up to the max length', () => {
+        const result = recipeDetailsSchema.safeParse({
+          ingredients: [
+            {
+              name: 'a'.repeat(MAX_RECIPE_INGREDIENT_NAME_LENGTH),
+              unit: 'cup',
+            },
+          ],
+          steps: [{ text: 'Mix' }],
+        });
+        expect(result.success).toBe(true);
+      });
+
+      it('should reject ingredient names longer than the max length', () => {
+        const result = recipeDetailsSchema.safeParse({
+          ingredients: [
+            {
+              name: 'a'.repeat(MAX_RECIPE_INGREDIENT_NAME_LENGTH + 1),
+              unit: 'cup',
+            },
+          ],
+          steps: [{ text: 'Mix' }],
+        });
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.error.issues[0].message).toBe(
+            `Ingredient name must be ${MAX_RECIPE_INGREDIENT_NAME_LENGTH} characters or fewer`
+          );
+        }
+      });
+
       it('should validate course enum', () => {
         const result = recipeDetailsSchema.safeParse({
           ingredients: [{ name: 'flour', unit: 'cup' }],
@@ -621,6 +654,29 @@ describe('Validation Schemas', () => {
           servings: 4,
         });
         expect(result.success).toBe(true);
+      });
+
+      it('should accept origin up to the max length', () => {
+        const result = recipeDetailsSchema.safeParse({
+          ingredients: [{ name: 'flour', unit: 'cup' }],
+          steps: [{ text: 'Mix' }],
+          origin: 'a'.repeat(MAX_RECIPE_ORIGIN_LENGTH),
+        });
+        expect(result.success).toBe(true);
+      });
+
+      it('should reject origin longer than the max length', () => {
+        const result = recipeDetailsSchema.safeParse({
+          ingredients: [{ name: 'flour', unit: 'cup' }],
+          steps: [{ text: 'Mix' }],
+          origin: 'a'.repeat(MAX_RECIPE_ORIGIN_LENGTH + 1),
+        });
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.error.issues[0].message).toBe(
+            `Origin must be ${MAX_RECIPE_ORIGIN_LENGTH} characters or fewer`
+          );
+        }
       });
 
       it('should validate positive totalTime', () => {

--- a/src/components/add/AddPostForm.tsx
+++ b/src/components/add/AddPostForm.tsx
@@ -14,7 +14,11 @@ import { CSS } from '@dnd-kit/utilities';
 
 import { ingredientUnitOptions } from '@/lib/ingredients';
 import { MAX_PHOTO_COUNT } from '@/lib/postPayload';
-import { type RecipeIngredientUnit } from '@/lib/validation';
+import {
+  MAX_RECIPE_INGREDIENT_NAME_LENGTH,
+  MAX_RECIPE_ORIGIN_LENGTH,
+  type RecipeIngredientUnit,
+} from '@/lib/validation';
 import { mapImporterResponseToPrefill } from './importerMapping';
 
 const courseOptions = [
@@ -137,6 +141,7 @@ function SortableIngredientRow({
               type="text"
               className="w-full rounded-xl border border-gray-300 px-4 py-3 text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900"
               placeholder="Ingredient name"
+              maxLength={MAX_RECIPE_INGREDIENT_NAME_LENGTH}
               value={ingredient.name}
               data-ingredient-focus={ingredient.id}
               onChange={(event) =>
@@ -901,6 +906,13 @@ export default function AddPostForm({
         continue;
       }
 
+      if (name.length > MAX_RECIPE_INGREDIENT_NAME_LENGTH) {
+        setFormError(
+          `Ingredient ${index + 1} name must be ${MAX_RECIPE_INGREDIENT_NAME_LENGTH} characters or fewer`
+        );
+        return;
+      }
+
       let parsedQuantity: number | undefined;
       if (quantityValue) {
         parsedQuantity = Number(quantityValue);
@@ -922,6 +934,14 @@ export default function AddPostForm({
     const sanitizedSteps = steps
       .map((step) => step.text.trim())
       .filter((text) => text.length > 0);
+
+    const trimmedOrigin = recipe.origin.trim();
+    if (trimmedOrigin.length > MAX_RECIPE_ORIGIN_LENGTH) {
+      setFormError(
+        `Origin must be ${MAX_RECIPE_ORIGIN_LENGTH} characters or fewer`
+      );
+      return;
+    }
 
     if (
       recipeHasCoreDetails &&
@@ -1009,7 +1029,7 @@ export default function AddPostForm({
 
       if (recipeHasAnyData) {
         payload.recipe = {
-          origin: recipe.origin.trim() || undefined,
+          origin: trimmedOrigin || undefined,
           ingredients: sanitizedIngredients.map((ingredient) => ({
             name: ingredient.name,
             unit: ingredient.unit,
@@ -1296,6 +1316,7 @@ export default function AddPostForm({
                   type="text"
                   className="w-full rounded-xl border border-gray-300 px-4 py-3 text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900"
                   placeholder="Story / Source / Origin"
+                  maxLength={MAX_RECIPE_ORIGIN_LENGTH}
                   value={recipe.origin}
                   onChange={(event) =>
                     handleRecipeChange('origin', event.target.value)

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod';
 
+export const MAX_RECIPE_INGREDIENT_NAME_LENGTH = 240;
+export const MAX_RECIPE_ORIGIN_LENGTH = 240;
+
 export const signupSchema = z.object({
   name: z.string().min(1, 'Name is required').max(100),
   email: z
@@ -74,7 +77,13 @@ export const ingredientUnitEnum = z.enum([
 ]);
 
 const recipeIngredientSchema = z.object({
-  name: z.string().min(1, 'Ingredient name is required').max(120),
+  name: z
+    .string()
+    .min(1, 'Ingredient name is required')
+    .max(
+      MAX_RECIPE_INGREDIENT_NAME_LENGTH,
+      `Ingredient name must be ${MAX_RECIPE_INGREDIENT_NAME_LENGTH} characters or fewer`
+    ),
   quantity: z
     .number({ invalid_type_error: 'Quantity must be a number' })
     .positive('Quantity must be positive')
@@ -87,7 +96,14 @@ const recipeStepSchema = z.object({
   text: z.string().min(1, 'Step description is required').max(2000),
 });
 export const recipeDetailsSchema = z.object({
-  origin: z.string().min(1).max(120).optional(),
+  origin: z
+    .string()
+    .min(1)
+    .max(
+      MAX_RECIPE_ORIGIN_LENGTH,
+      `Origin must be ${MAX_RECIPE_ORIGIN_LENGTH} characters or fewer`
+    )
+    .optional(),
   ingredients: z
     .array(recipeIngredientSchema)
     .min(1, 'At least one ingredient is required')
@@ -334,9 +350,21 @@ export const recipeFiltersSchema = paginationSchema
       .optional(),
     ingredients: z
       .union([
-        z.string().max(120, 'Ingredient name too long'),
         z
-          .array(z.string().max(120, 'Ingredient name too long'))
+          .string()
+          .max(
+            MAX_RECIPE_INGREDIENT_NAME_LENGTH,
+            `Ingredient name must be ${MAX_RECIPE_INGREDIENT_NAME_LENGTH} characters or fewer`
+          ),
+        z
+          .array(
+            z
+              .string()
+              .max(
+                MAX_RECIPE_INGREDIENT_NAME_LENGTH,
+                `Ingredient name must be ${MAX_RECIPE_INGREDIENT_NAME_LENGTH} characters or fewer`
+              )
+          )
           .max(INGREDIENT_LIMIT, `Maximum ${INGREDIENT_LIMIT} ingredients`),
       ])
       .optional()


### PR DESCRIPTION
## Summary

- Merges `main` into `develop` to incorporate [`f7b7393`](https://github.com/wnorowskie/family-recipe/commit/f7b7393) ("feat: add validation for recipe ingredient name and origin length"), which was committed directly to `main` on 2026-04-05 and never made it back into `develop`.
- Resolves the resulting conflict in [`src/components/add/AddPostForm.tsx`](../blob/develop/src/components/add/AddPostForm.tsx) by keeping develop's redesigned `Input` primitive + new placeholder ("e.g. Grandma's recipe, NYT Cooking…") and re-applying `main`'s `maxLength={MAX_RECIPE_ORIGIN_LENGTH}` attribute. `validation.ts` and the unit test file auto-merged.
- Unblocks release PR [#157](https://github.com/wnorowskie/family-recipe/pull/157), which is currently `CONFLICTING`.

Closes #159.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npx jest __tests__/unit/lib/validation.test.ts` — 123/123 passing
- [x] `npm test` — 967/967 passing across 46 suites
- [ ] CI green on this PR (lint + typecheck + jest + docker build + security scans)
- [ ] After merge, `gh pr view 157 --json mergeStateStatus` no longer reports `DIRTY` / `CONFLICTING`
- [ ] Manual: in the add-recipe form, paste an origin > 240 chars or an ingredient name > 240 chars and confirm the `<Input maxLength>` clamps + the submit guard surfaces the validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)