### PR TITLE
chore(ci): canary deploy + auto-unpin to fix silent traffic pinning (closes #158)

### DIFF
--- a/.claude/skills/release-testing/SKILL.md
+++ b/.claude/skills/release-testing/SKILL.md
@@ -81,19 +81,35 @@ Map the file list to areas:
 
 ### 3. Confirm the dev deployment is actually for the release SHA
 
+This is the most important guard in the skill — running smoke against a stale revision was the exact bug behind #158, and produced false-confidence green reports for ~30 deploys before discovery. Treat any mismatch here as an automatic **HOLD**, not a "probably fine" warning.
+
 ```bash
-# The latest revision should have been built from the head of `develop`.
+# Both columns: the revision currently serving traffic, and the latest-ready
+# revision (i.e. the one the most recent deploy built).
+gcloud run services describe family-recipe-dev \
+  --project family-recipe-dev --region us-east1 \
+  --format='value(status.traffic[0].revisionName,status.latestReadyRevisionName,status.traffic[0].latestRevision)'
+# Want: same revision in cols 1 and 2, AND col 3 == True (LATEST routing).
+```
+
+Two failure modes are HOLDs:
+
+1. **`status.traffic[0].revisionName != status.latestReadyRevisionName`** — the service is pinned to an older revision while a newer one sits at 0% traffic. This is the #158 traffic-pin bug. Surface the mismatch in the report, recommend running `gcloud run services update-traffic family-recipe-dev --to-latest --remove-tags=candidate` (or re-running deploy-dev), and stop. Do **not** run the smoke against the stale revision and call it green.
+2. **`status.traffic[0].latestRevision != True`** — even if the revision names happen to match right now, traffic is pinned by name rather than tracking LATEST, so the next deploy will silently sit at 0%. Surface the same recommendation.
+
+If both columns match and `latestRevision=True`, confirm the deployed image SHA matches `git rev-parse origin/develop`:
+
+```bash
 REV=$(gcloud run services describe family-recipe-dev \
   --project family-recipe-dev --region us-east1 \
   --format='value(status.traffic[0].revisionName)')
-# Cloud Run revisions are named like family-recipe-dev-00051-cv6 — the SHA
-# is visible in the Cloud Console or via:
 gcloud run revisions describe "$REV" \
   --project family-recipe-dev --region us-east1 \
   --format='value(spec.containers[0].image)'
+# The image tag is the commit SHA; compare to `git rev-parse origin/develop`.
 ```
 
-The image tag is the commit SHA. Compare to `git rev-parse origin/develop`. If they don't match, the deploy workflow is still running or failed — check `gh run list --workflow=deploy-dev.yml` before continuing; running the smoke against a stale revision tests the wrong artifact.
+If the SHAs don't match, the deploy workflow is still running or failed — check `gh run list --workflow=deploy-dev.yml -L 5` before continuing.
 
 ### 4. Confirm infrastructure state
 

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -137,8 +137,16 @@ jobs:
       - name: Push image
         run: docker push "$IMAGE"
 
-      - name: Deploy to Cloud Run (dev)
+      - name: Deploy to Cloud Run (dev) at 0% traffic with candidate tag
         run: |
+          # --no-traffic builds the new revision without flipping traffic to it,
+          # and --tag=candidate gives us a tagged URL we can probe directly.
+          # Traffic is promoted in the "Promote candidate to LATEST" step below
+          # only after smoke + Playwright pass. This canary pattern also fixes
+          # the latent traffic-pin bug from #158: a prior failed deploy could
+          # leave the service pinned to a specific revision, and an unconditional
+          # `--to-latest` promotion below restores LATEST routing on every green
+          # deploy.
           gcloud run deploy "$CLOUD_RUN_SERVICE" \
             --project "$PROJECT_ID" \
             --region "$REGION" \
@@ -147,24 +155,40 @@ jobs:
             --platform managed \
             --port 3000 \
             --quiet \
+            --no-traffic \
+            --tag candidate \
             --add-cloudsql-instances "$INSTANCE_CONNECTION_NAME" \
             --set-secrets DATABASE_URL=${DATABASE_URL_SECRET}:latest,JWT_SECRET=${JWT_SECRET_NAME}:latest,FAMILY_MASTER_KEY=${FAMILY_MASTER_KEY_SECRET_NAME}:latest \
             --set-env-vars PRISMA_SCHEMA=${PRISMA_SCHEMA},UPLOADS_BUCKET=${UPLOADS_BUCKET},UPLOADS_BASE_URL=${UPLOADS_BASE_URL},RECIPE_IMPORTER_URL=${RECIPE_IMPORTER_URL},RECIPE_IMPORTER_AUDIENCE=${RECIPE_IMPORTER_AUDIENCE},RECIPE_IMPORTER_SERVICE_ACCOUNT_EMAIL=${RECIPE_IMPORTER_SERVICE_ACCOUNT_EMAIL} \
             --ingress all \
             --no-allow-unauthenticated
 
-      - name: Print service URL
+      - name: Resolve candidate + service URLs
+        id: urls
         run: |
-          URI="$(gcloud run services describe "$CLOUD_RUN_SERVICE" --project "$PROJECT_ID" --region "$REGION" --format='value(status.url)')"
-          echo "Cloud Run URL: $URI"
-          echo "Healthcheck:  $URI/api/health"
+          SERVICE_URL="$(gcloud run services describe "$CLOUD_RUN_SERVICE" --project "$PROJECT_ID" --region "$REGION" --format='value(status.url)')"
+          CANDIDATE_URL="$(gcloud run services describe "$CLOUD_RUN_SERVICE" \
+            --project "$PROJECT_ID" --region "$REGION" \
+            --format='value(status.traffic.filter("tag:candidate").extract(url).flatten())')"
+          if [ -z "$CANDIDATE_URL" ]; then
+            echo "Could not resolve candidate tag URL — failing fast." >&2
+            exit 1
+          fi
+          echo "Service URL:    $SERVICE_URL"
+          echo "Candidate URL:  $CANDIDATE_URL"
+          echo "Healthcheck:    $CANDIDATE_URL/api/health"
+          echo "SERVICE_URL=$SERVICE_URL" >> "$GITHUB_ENV"
+          echo "CANDIDATE_URL=$CANDIDATE_URL" >> "$GITHUB_ENV"
 
-      - name: Smoke check /api/health
+      - name: Smoke check /api/health (against candidate revision)
         id: smoke_check
         env:
           DEPLOYER_SA_EMAIL: ${{ secrets.DEV_GCP_DEPLOYER_SA }}
         run: |
-          URI="$(gcloud run services describe "$CLOUD_RUN_SERVICE" --project "$PROJECT_ID" --region "$REGION" --format='value(status.url)')"
+          URI="$CANDIDATE_URL"
+          # DEV_NEXT_URL is published for downstream steps; the auth-injecting
+          # proxy and Playwright run target the candidate URL so we exercise
+          # the just-built revision, not whatever the service URL routes to.
           echo "DEV_NEXT_URL=$URI" >> "$GITHUB_ENV"
           # Dev service requires auth (--no-allow-unauthenticated). Under WIF the active
           # gcloud credential is an access token, which `print-identity-token --audiences`
@@ -275,18 +299,43 @@ jobs:
           path: playwright-report/
           retention-days: 7
 
-      - name: Rollback traffic on smoke-check failure
-        if: failure() && (steps.smoke_check.conclusion == 'failure' || steps.post_deploy_smoke.conclusion == 'failure')
+      - name: Promote candidate to LATEST
+        if: steps.smoke_check.conclusion == 'success' && steps.post_deploy_smoke.conclusion == 'success'
         run: |
-          if [ -z "${PREV_REVISION:-}" ]; then
-            echo "No previous revision was captured (first deploy?); cannot roll back."
-            exit 1
-          fi
-          echo "Smoke check failed. Rolling traffic back to previous revision: $PREV_REVISION"
+          # Flip 100% of traffic to the just-built revision and remove the
+          # candidate tag so the next deploy starts clean. --to-latest also
+          # clears any prior pin (see #158): once promoted, status.traffic[0]
+          # tracks LATEST again instead of being stuck on a frozen revision.
           gcloud run services update-traffic "$CLOUD_RUN_SERVICE" \
             --project "$PROJECT_ID" \
             --region "$REGION" \
-            --to-revisions="$PREV_REVISION=100" \
+            --to-latest \
+            --remove-tags=candidate \
             --quiet
+
+      - name: Rollback traffic on smoke-check failure
+        if: failure() && (steps.smoke_check.conclusion == 'failure' || steps.post_deploy_smoke.conclusion == 'failure')
+        run: |
+          # Because the deploy uses --no-traffic, the failed revision never
+          # served users — the previous revision is still receiving 100%.
+          # We still pin to PREV_REVISION explicitly to defend against any
+          # mid-flight traffic state and remove the candidate tag so the next
+          # deploy can re-create it cleanly.
+          if [ -n "${PREV_REVISION:-}" ]; then
+            echo "Smoke check failed. Pinning traffic to previous revision: $PREV_REVISION"
+            gcloud run services update-traffic "$CLOUD_RUN_SERVICE" \
+              --project "$PROJECT_ID" \
+              --region "$REGION" \
+              --to-revisions="$PREV_REVISION=100" \
+              --remove-tags=candidate \
+              --quiet
+          else
+            echo "No previous revision captured (first deploy?); removing candidate tag only."
+            gcloud run services update-traffic "$CLOUD_RUN_SERVICE" \
+              --project "$PROJECT_ID" \
+              --region "$REGION" \
+              --remove-tags=candidate \
+              --quiet || true
+          fi
           echo "Rollback complete. Job will fail so the broken deploy is surfaced."
           exit 1

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -138,6 +138,7 @@ jobs:
         run: docker push "$IMAGE"
 
       - name: Deploy to Cloud Run (dev) at 0% traffic with candidate tag
+        id: deploy
         run: |
           # --no-traffic builds the new revision without flipping traffic to it,
           # and --tag=candidate gives us a tagged URL we can probe directly.
@@ -318,24 +319,38 @@ jobs:
         run: |
           # Because the deploy uses --no-traffic, the failed revision never
           # served users — the previous revision is still receiving 100%.
-          # We still pin to PREV_REVISION explicitly to defend against any
-          # mid-flight traffic state and remove the candidate tag so the next
-          # deploy can re-create it cleanly.
+          # Pin to PREV_REVISION explicitly to defend against any mid-flight
+          # traffic state. Tag cleanup is handled by the always()-gated step
+          # below, so this step's only job is to make traffic safe.
           if [ -n "${PREV_REVISION:-}" ]; then
             echo "Smoke check failed. Pinning traffic to previous revision: $PREV_REVISION"
             gcloud run services update-traffic "$CLOUD_RUN_SERVICE" \
               --project "$PROJECT_ID" \
               --region "$REGION" \
               --to-revisions="$PREV_REVISION=100" \
-              --remove-tags=candidate \
               --quiet
           else
-            echo "No previous revision captured (first deploy?); removing candidate tag only."
-            gcloud run services update-traffic "$CLOUD_RUN_SERVICE" \
-              --project "$PROJECT_ID" \
-              --region "$REGION" \
-              --remove-tags=candidate \
-              --quiet || true
+            echo "No previous revision captured (first deploy?); skipping traffic pin."
           fi
           echo "Rollback complete. Job will fail so the broken deploy is surfaced."
           exit 1
+
+      - name: Always remove candidate tag
+        # Runs on every conclusion — including step failures between deploy
+        # and the rollback gate (Playwright install/cache failures, runner
+        # OOMs, the 5-minute Playwright timeout). Without this, a mid-pipeline
+        # failure would leave the `candidate` tag attached to the failed
+        # revision and the next deploy's "Resolve candidate + service URLs"
+        # step would either resolve a stale URL or fail the existence check.
+        # `--remove-tags=candidate` with no `--to-*` flag preserves whatever
+        # traffic spec is currently in place (the Promote/Rollback steps
+        # already settled traffic). The command is idempotent — it's a no-op
+        # when the tag is already gone, which is the common path after a
+        # successful Promote.
+        if: always() && steps.deploy.conclusion == 'success'
+        run: |
+          gcloud run services update-traffic "$CLOUD_RUN_SERVICE" \
+            --project "$PROJECT_ID" \
+            --region "$REGION" \
+            --remove-tags=candidate \
+            --quiet || true

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -143,8 +143,15 @@ jobs:
       - name: Push image
         run: docker push "$IMAGE"
 
-      - name: Deploy to Cloud Run (prod)
+      - name: Deploy to Cloud Run (prod) at 0% traffic with candidate tag
         run: |
+          # --no-traffic + --tag=candidate match the dev workflow's canary
+          # pattern (#158): smoke against the new revision via the tag URL,
+          # then explicitly --to-latest to promote. The same step also unpins
+          # any previous traffic pin on every successful deploy, which fixes
+          # the latent bug where a one-off rollback (--to-revisions=X=100)
+          # would freeze the service on a stale revision and silently route
+          # every subsequent green deploy to 0%.
           gcloud run deploy "$CLOUD_RUN_SERVICE" \
             --project "$PROJECT_ID" \
             --region "$REGION" \
@@ -153,22 +160,34 @@ jobs:
             --platform managed \
             --port 3000 \
             --quiet \
+            --no-traffic \
+            --tag candidate \
             --add-cloudsql-instances "$INSTANCE_CONNECTION_NAME" \
             --set-secrets DATABASE_URL=${DATABASE_URL_SECRET}:latest,JWT_SECRET=${JWT_SECRET_NAME}:latest,FAMILY_MASTER_KEY=${FAMILY_MASTER_KEY_SECRET_NAME}:latest \
             --set-env-vars PRISMA_SCHEMA=${PRISMA_SCHEMA},UPLOADS_BUCKET=${UPLOADS_BUCKET},UPLOADS_BASE_URL=${UPLOADS_BASE_URL},RECIPE_IMPORTER_URL=${RECIPE_IMPORTER_URL},RECIPE_IMPORTER_AUDIENCE=${RECIPE_IMPORTER_AUDIENCE},RECIPE_IMPORTER_SERVICE_ACCOUNT_EMAIL=${RECIPE_IMPORTER_SERVICE_ACCOUNT_EMAIL} \
             --ingress all \
             --allow-unauthenticated
 
-      - name: Print service URL
+      - name: Resolve candidate + service URLs
         run: |
-          URI="$(gcloud run services describe "$CLOUD_RUN_SERVICE" --project "$PROJECT_ID" --region "$REGION" --format='value(status.url)')"
-          echo "Cloud Run URL: $URI"
-          echo "Healthcheck:  $URI/api/health"
+          SERVICE_URL="$(gcloud run services describe "$CLOUD_RUN_SERVICE" --project "$PROJECT_ID" --region "$REGION" --format='value(status.url)')"
+          CANDIDATE_URL="$(gcloud run services describe "$CLOUD_RUN_SERVICE" \
+            --project "$PROJECT_ID" --region "$REGION" \
+            --format='value(status.traffic.filter("tag:candidate").extract(url).flatten())')"
+          if [ -z "$CANDIDATE_URL" ]; then
+            echo "Could not resolve candidate tag URL — failing fast." >&2
+            exit 1
+          fi
+          echo "Service URL:    $SERVICE_URL"
+          echo "Candidate URL:  $CANDIDATE_URL"
+          echo "Healthcheck:    $CANDIDATE_URL/api/health"
+          echo "SERVICE_URL=$SERVICE_URL" >> "$GITHUB_ENV"
+          echo "CANDIDATE_URL=$CANDIDATE_URL" >> "$GITHUB_ENV"
 
-      - name: Smoke check /api/health
+      - name: Smoke check /api/health (against candidate revision)
         id: smoke_check
         run: |
-          URI="$(gcloud run services describe "$CLOUD_RUN_SERVICE" --project "$PROJECT_ID" --region "$REGION" --format='value(status.url)')"
+          URI="$CANDIDATE_URL"
           for i in {1..20}; do
             STATUS="$(curl -sS -o /dev/null -w '%{http_code}' "$URI/api/health" || true)"
             if [ "$STATUS" = "200" ]; then
@@ -181,18 +200,37 @@ jobs:
           echo "Healthcheck did not return 200 within timeout."
           exit 1
 
-      - name: Rollback traffic on smoke-check failure
-        if: failure() && steps.smoke_check.conclusion == 'failure'
+      - name: Promote candidate to LATEST
+        if: steps.smoke_check.conclusion == 'success'
         run: |
-          if [ -z "${PREV_REVISION:-}" ]; then
-            echo "No previous revision was captured (first deploy?); cannot roll back."
-            exit 1
-          fi
-          echo "Smoke check failed. Rolling traffic back to previous revision: $PREV_REVISION"
           gcloud run services update-traffic "$CLOUD_RUN_SERVICE" \
             --project "$PROJECT_ID" \
             --region "$REGION" \
-            --to-revisions="$PREV_REVISION=100" \
+            --to-latest \
+            --remove-tags=candidate \
             --quiet
+
+      - name: Rollback traffic on smoke-check failure
+        if: failure() && steps.smoke_check.conclusion == 'failure'
+        run: |
+          # Deploy used --no-traffic, so the failed revision never served
+          # users; PREV_REVISION is still receiving 100%. Re-pin defensively
+          # and remove the candidate tag so the next deploy can re-create it.
+          if [ -n "${PREV_REVISION:-}" ]; then
+            echo "Smoke check failed. Pinning traffic to previous revision: $PREV_REVISION"
+            gcloud run services update-traffic "$CLOUD_RUN_SERVICE" \
+              --project "$PROJECT_ID" \
+              --region "$REGION" \
+              --to-revisions="$PREV_REVISION=100" \
+              --remove-tags=candidate \
+              --quiet
+          else
+            echo "No previous revision captured (first deploy?); removing candidate tag only."
+            gcloud run services update-traffic "$CLOUD_RUN_SERVICE" \
+              --project "$PROJECT_ID" \
+              --region "$REGION" \
+              --remove-tags=candidate \
+              --quiet || true
+          fi
           echo "Rollback complete. Job will fail so the broken deploy is surfaced."
           exit 1

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -144,6 +144,7 @@ jobs:
         run: docker push "$IMAGE"
 
       - name: Deploy to Cloud Run (prod) at 0% traffic with candidate tag
+        id: deploy
         run: |
           # --no-traffic + --tag=candidate match the dev workflow's canary
           # pattern (#158): smoke against the new revision via the tag URL,
@@ -214,23 +215,30 @@ jobs:
         if: failure() && steps.smoke_check.conclusion == 'failure'
         run: |
           # Deploy used --no-traffic, so the failed revision never served
-          # users; PREV_REVISION is still receiving 100%. Re-pin defensively
-          # and remove the candidate tag so the next deploy can re-create it.
+          # users; PREV_REVISION is still receiving 100%. Re-pin defensively;
+          # tag cleanup is handled by the always()-gated step below.
           if [ -n "${PREV_REVISION:-}" ]; then
             echo "Smoke check failed. Pinning traffic to previous revision: $PREV_REVISION"
             gcloud run services update-traffic "$CLOUD_RUN_SERVICE" \
               --project "$PROJECT_ID" \
               --region "$REGION" \
               --to-revisions="$PREV_REVISION=100" \
-              --remove-tags=candidate \
               --quiet
           else
-            echo "No previous revision captured (first deploy?); removing candidate tag only."
-            gcloud run services update-traffic "$CLOUD_RUN_SERVICE" \
-              --project "$PROJECT_ID" \
-              --region "$REGION" \
-              --remove-tags=candidate \
-              --quiet || true
+            echo "No previous revision captured (first deploy?); skipping traffic pin."
           fi
           echo "Rollback complete. Job will fail so the broken deploy is surfaced."
           exit 1
+
+      - name: Always remove candidate tag
+        # Runs on every conclusion so a step failure between deploy and the
+        # rollback gate doesn't leak the tag into the next deploy. Idempotent
+        # — `--remove-tags=candidate` with no `--to-*` preserves traffic and
+        # is a no-op when the tag is already gone (the success path).
+        if: always() && steps.deploy.conclusion == 'success'
+        run: |
+          gcloud run services update-traffic "$CLOUD_RUN_SERVICE" \
+            --project "$PROJECT_ID" \
+            --region "$REGION" \
+            --remove-tags=candidate \
+            --quiet || true

--- a/docs/verification/dev-deployments.md
+++ b/docs/verification/dev-deployments.md
@@ -177,6 +177,30 @@ npm run test:e2e:dev -- e2e/auth.spec.ts
 
 Prerequisites: the one-time setup above (`roles/iam.serviceAccountTokenCreator`, `.env.dev.local` populated). The wrapper forwards `CLAUDE_TEST_PASSWORD` to Playwright as `E2E_PASSWORD` automatically.
 
+## Confirming the deploy actually flipped traffic
+
+A successful `deploy-dev.yml` run does not, on its own, mean the dev URL is serving the new revision. Always confirm with:
+
+```bash
+gcloud run services describe family-recipe-dev \
+  --project family-recipe-dev --region us-east1 \
+  --format='value(status.traffic[0].revisionName,status.latestReadyRevisionName)'
+# Want: same revision name in both columns. Mismatch = traffic is pinned and
+# the new revision is sitting at 0%.
+```
+
+The deploy workflow uses a canary pattern (`gcloud run deploy --no-traffic --tag=candidate`, smoke against the candidate URL, then `gcloud run services update-traffic --to-latest --remove-tags=candidate` on success). The `--to-latest` step is what unpins the service after a previous rollback — without it, a single `--to-revisions=X=100` rollback would freeze the service on a stale revision forever, and every subsequent green deploy would build a new revision at 0% traffic while still reporting `success` (#158). If the columns above don't match, check `gh run list --workflow=deploy-dev.yml -L 1` for the most recent deploy and inspect the "Promote candidate to LATEST" step.
+
+To unpin manually (if the pin survives somehow):
+
+```bash
+gcloud run services update-traffic family-recipe-dev \
+  --project family-recipe-dev --region us-east1 \
+  --to-latest --remove-tags=candidate --quiet
+```
+
+The same canary pattern lives in `deploy-prod.yml` — confirm prod the same way before assuming a prod release shipped.
+
 ## Gotchas
 
 - **`curl -F` interprets `;` in values** as a content-type delimiter and silently truncates the payload. Use `curl --form-string` for `multipart/form-data` JSON payloads (the smoke script does; so must your manual probes).

--- a/docs/verification/dev-deployments.md
+++ b/docs/verification/dev-deployments.md
@@ -184,9 +184,12 @@ A successful `deploy-dev.yml` run does not, on its own, mean the dev URL is serv
 ```bash
 gcloud run services describe family-recipe-dev \
   --project family-recipe-dev --region us-east1 \
-  --format='value(status.traffic[0].revisionName,status.latestReadyRevisionName)'
-# Want: same revision name in both columns. Mismatch = traffic is pinned and
-# the new revision is sitting at 0%.
+  --format='value(status.traffic[0].revisionName,status.latestReadyRevisionName,status.traffic[0].latestRevision)'
+# Want: same revision name in cols 1+2 AND `True` in col 3.
+# - Cols 1≠2 → traffic is pinned to a stale revision; the new one is at 0%.
+# - Col 3 != True → traffic is pinned by name, so even if cols 1+2 match
+#   today, the *next* deploy will silently sit at 0%.
+# Either failure mode is the #158 bug. /release-testing treats both as HOLD.
 ```
 
 The deploy workflow uses a canary pattern (`gcloud run deploy --no-traffic --tag=candidate`, smoke against the candidate URL, then `gcloud run services update-traffic --to-latest --remove-tags=candidate` on success). The `--to-latest` step is what unpins the service after a previous rollback — without it, a single `--to-revisions=X=100` rollback would freeze the service on a stale revision forever, and every subsequent green deploy would build a new revision at 0% traffic while still reporting `success` (#158). If the columns above don't match, check `gh run list --workflow=deploy-dev.yml -L 1` for the most recent deploy and inspect the "Promote candidate to LATEST" step.


### PR DESCRIPTION
## Summary

- Switches `deploy-dev.yml` and `deploy-prod.yml` to a Cloud Run canary pattern: `gcloud run deploy --no-traffic --tag=candidate`, smoke against the candidate's tag URL, then `update-traffic --to-latest --remove-tags=candidate` only on success. The explicit `--to-latest` promotion fixes the #158 bug where a one-off rollback (`--to-revisions=X=100`) froze the service on a stale revision and routed every subsequent green deploy to 0% traffic — silently and with `success` reported.
- Same fix applied to **prod** so the latent bug there can never fire (currently dormant — prod is still on `latestRevision=True`, confirmed via `gcloud run services describe family-recipe-prod` before the fix).
- Dev's post-deploy Playwright `@smoke` step now exercises the **just-built** revision via the candidate URL (`echo "DEV_NEXT_URL=$CANDIDATE_URL" >> $GITHUB_ENV`) instead of whatever the service URL routed to. Closes the third checkbox in the issue.
- Documents the failure mode + manual unpin command in `docs/verification/dev-deployments.md`, and strengthens `/release-testing` step 3 so a `status.traffic[0].revisionName != status.latestReadyRevisionName` mismatch (or `latestRevision != True`) is an automatic HOLD instead of a "probably fine" warning.

## Test plan

- [ ] **Merge to `develop`** and confirm in the deploy-dev run logs that the new "Resolve candidate + service URLs" step prints a `candidate---family-recipe-dev-...run.app` URL and the smoke + Playwright steps target it.
- [ ] After the deploy-dev run goes green, locally confirm:
  ```bash
  gcloud run services describe family-recipe-dev \
    --project family-recipe-dev --region us-east1 \
    --format='value(status.traffic[0].revisionName,status.latestReadyRevisionName,status.traffic[0].latestRevision)'
  # Want: same revision name in cols 1+2, `True` in col 3.
  ```
  This will *implicitly* unpin the dev service that's currently stuck on `00087-s8h` (latestReady is `00088-4pk`) — the first run after this PR lands will auto-promote and clear the pin.
- [ ] Force a smoke-check failure on a throwaway feature branch (temporarily make `/api/health` return 500) and confirm:
  - The "Rollback traffic on smoke-check failure" step fires.
  - `status.traffic[0].revisionName` stays on the previous revision (it never moved, because `--no-traffic`).
  - The `candidate` tag is removed so the next deploy can re-create it.
- [ ] **Prod dry-run** — after the next legitimate prod deploy, run the same `gcloud run services describe family-recipe-prod ...` check and verify it's still on LATEST (it already is; we just want to confirm the new workflow didn't regress it).
- [ ] Run `/release-testing` against the next `develop → main` PR and confirm the strengthened step 3 wording catches a synthetic mismatch (can be tested by manually pinning dev to a non-latest revision before the skill runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)