### PR TITLE
chore(ci): mint deploy-dev smoke token against service URL, not candidate tag URL (closes #162)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -186,11 +186,15 @@ jobs:
         env:
           DEPLOYER_SA_EMAIL: ${{ secrets.DEV_GCP_DEPLOYER_SA }}
         run: |
-          URI="$CANDIDATE_URL"
-          # DEV_NEXT_URL is published for downstream steps; the auth-injecting
-          # proxy and Playwright run target the candidate URL so we exercise
-          # the just-built revision, not whatever the service URL routes to.
-          echo "DEV_NEXT_URL=$URI" >> "$GITHUB_ENV"
+          # Publish env for downstream steps. The auth-injecting proxy and
+          # Playwright will route requests through the candidate URL so the
+          # just-built revision is exercised; DEV_AUDIENCE stays on the
+          # service URL because Cloud Run's IAM bearer-token check validates
+          # the `aud` claim against the service URL, not per-tag hostnames.
+          # (Run 25002226021 hit 60s of 401s because the smoke step minted a
+          # token with --audiences=$CANDIDATE_URL.)
+          echo "DEV_NEXT_URL=$CANDIDATE_URL" >> "$GITHUB_ENV"
+          echo "DEV_AUDIENCE=$SERVICE_URL" >> "$GITHUB_ENV"
           # Dev service requires auth (--no-allow-unauthenticated). Under WIF the active
           # gcloud credential is an access token, which `print-identity-token --audiences`
           # rejects; --impersonate-service-account routes the mint through the
@@ -198,9 +202,9 @@ jobs:
           # self-binding of roles/iam.serviceAccountTokenCreator).
           TOKEN="$(gcloud auth print-identity-token \
             --impersonate-service-account="$DEPLOYER_SA_EMAIL" \
-            --audiences="$URI")"
+            --audiences="$SERVICE_URL")"
           for i in {1..20}; do
-            STATUS="$(curl -sS -H "Authorization: Bearer $TOKEN" -o /dev/null -w '%{http_code}' "$URI/api/health" || true)"
+            STATUS="$(curl -sS -H "Authorization: Bearer $TOKEN" -o /dev/null -w '%{http_code}' "$CANDIDATE_URL/api/health" || true)"
             if [ "$STATUS" = "200" ]; then
               echo "Healthcheck OK (200)"
               exit 0

--- a/scripts/dev-auth-proxy.ts
+++ b/scripts/dev-auth-proxy.ts
@@ -18,6 +18,14 @@
  * Required env (from .env.dev.local or the shell):
  *   DEV_NEXT_URL                  upstream Cloud Run URL
  *   DEV_DEPLOYER_SA               SA to impersonate for ID tokens
+ *
+ * Optional env:
+ *   DEV_AUDIENCE                  audience for the minted ID token. Defaults
+ *                                 to DEV_NEXT_URL. Set this when the upstream
+ *                                 host differs from the IAM-validated audience
+ *                                 — e.g. when forwarding to a Cloud Run tag URL
+ *                                 (`https://candidate---svc-...run.app`) but
+ *                                 IAM expects the service URL.
  */
 import { spawn } from 'node:child_process';
 import * as fs from 'node:fs';
@@ -44,6 +52,7 @@ loadEnvFile(ENV_FILE);
 
 const UPSTREAM_URL = requiredEnv('DEV_NEXT_URL');
 const DEPLOYER_SA = requiredEnv('DEV_DEPLOYER_SA');
+const TOKEN_AUDIENCE = process.env.DEV_AUDIENCE ?? UPSTREAM_URL;
 const PORT = Number(process.env.PROXY_PORT ?? 3100);
 
 const upstream = new URL(UPSTREAM_URL);
@@ -77,7 +86,7 @@ function mintToken(): Promise<TokenState> {
         'auth',
         'print-identity-token',
         `--impersonate-service-account=${DEPLOYER_SA}`,
-        `--audiences=${UPSTREAM_URL}`,
+        `--audiences=${TOKEN_AUDIENCE}`,
       ],
       { stdio: ['ignore', 'pipe', 'pipe'] }
     );


### PR DESCRIPTION
## Summary

- The deploy-dev smoke step + Playwright @smoke step on `develop` are currently broken (run [25002226021](https://github.com/wnorowskie/family-recipe/actions/runs/25002226021) — 60s of HTTP 401 on `/api/health`). Token was minted with `--audiences="$CANDIDATE_URL"`; Cloud Run's IAM bearer-token check validates the `aud` claim against the **service URL**, not per-tag hostnames.
- Fix: mint with `--audiences="$SERVICE_URL"` while still sending the request to `$CANDIDATE_URL` (Cloud Run's edge authorizes by service-URL audience, then routes by hostname).
- Adds an optional `DEV_AUDIENCE` env var to `scripts/dev-auth-proxy.ts` (defaulting to `DEV_NEXT_URL` for back-compat) so the workflow can decouple "where requests go" from "what audience to mint" when starting the proxy for the Playwright step.
- Prod is unaffected — `deploy-prod.yml` uses `--allow-unauthenticated`, no bearer token, no audience.
- Closes #162. Cherry-picked from f3ac452 on the now-merged #161 branch (the audience fix landed after #161 was already merged).

## Test plan

- [ ] After merge to `develop`, push triggers a deploy-dev run — smoke step should report `Healthcheck OK (200)` against `$CANDIDATE_URL/api/health`, then Playwright `@smoke` should pass against the candidate revision via the proxy.
- [ ] After the green run, confirm:
  ```bash
  gcloud run services describe family-recipe-dev \
    --project family-recipe-dev --region us-east1 \
    --format='value(status.traffic[0].revisionName,status.latestReadyRevisionName,status.traffic[0].latestRevision)'
  # Want: same revision in cols 1+2, `True` in col 3 (Promote --to-latest unpinned).
  ```
- [ ] Verify local `npm run proxy:dev` still works without setting `DEV_AUDIENCE` (the default keeps the existing single-host behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)