### PR TITLE
chore(ci): fetch deploy-dev claude-test password from GSM (closes #164)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -215,6 +215,23 @@ jobs:
           echo "Healthcheck did not return 200 within timeout."
           exit 1
 
+      - name: Fetch claude-test password from GSM
+        # GSM is the single source of truth for the dev `claude-test`
+        # password (the seed in prisma/seed.ts pulls from CLAUDE_TEST_PASSWORD
+        # which is sourced from this same secret per docs/verification/
+        # dev-deployments.md). Surfacing it here as $GITHUB_ENV avoids a
+        # GHA-secret duplicate that drifts on rotation (closes #164 — the
+        # workflow previously fell back to the literal default
+        # `claude-test-password`, which mismatched the rotated DB password
+        # and produced 401s in Playwright's global-setup login).
+        if: steps.smoke_check.conclusion == 'success'
+        run: |
+          E2E_PASSWORD="$(gcloud secrets versions access latest \
+            --secret family-recipe-dev-claude-test-password \
+            --project "$PROJECT_ID")"
+          echo "::add-mask::${E2E_PASSWORD}"
+          echo "E2E_PASSWORD=${E2E_PASSWORD}" >> "$GITHUB_ENV"
+
       - name: Cache Playwright browsers
         if: steps.smoke_check.conclusion == 'success'
         id: playwright-cache
@@ -240,10 +257,12 @@ jobs:
         timeout-minutes: 5
         env:
           DEV_DEPLOYER_SA: ${{ secrets.DEV_GCP_DEPLOYER_SA }}
-          # Optional override secrets — fall back to the seeded `claude-test`
-          # creds from prisma/seed.ts when unset, matching e2e/global-setup.ts.
+          # E2E_USER stays a literal because the seeded username has never
+          # been rotated and is set on user-create only (see prisma/seed.ts
+          # comment about CLAUDE_TEST_USER). E2E_PASSWORD is set in the
+          # "Fetch claude-test password from GSM" step above, sourcing from
+          # the same secret prisma/seed.ts uses.
           E2E_USER: ${{ secrets.DEV_E2E_USER || 'claude-test' }}
-          E2E_PASSWORD: ${{ secrets.DEV_E2E_PASSWORD || 'claude-test-password' }}
           PROXY_PORT: '3100'
           PROXY_PID_FILE: ${{ runner.temp }}/dev-auth-proxy.pid
         run: |


### PR DESCRIPTION
## Summary

- Run [25007408671](https://github.com/wnorowskie/family-recipe/actions/runs/25007408671)'s Playwright `@smoke` step failed `globalSetup` with HTTP 401 from `/api/auth/login`. Smoke step itself was green (transport-level auth via the proxy works) — the rejection was at the application layer because the workflow sent the literal default password `claude-test-password` while the dev DB's `claude-test` user has a rotated GSM-sourced password.
- Fix: add a "Fetch claude-test password from GSM" step that pulls `family-recipe-dev-claude-test-password` at deploy time, masks it, and exports `E2E_PASSWORD` to `$GITHUB_ENV`. Drops the now-misleading `secrets.DEV_E2E_PASSWORD || 'claude-test-password'` fallback. GSM becomes the single source of truth — matches what `smoke-dev.sh`, `.env.dev.local`, and the seed-rotation block in [`docs/verification/dev-deployments.md`](docs/verification/dev-deployments.md) already do.
- The deployer SA (`family-recipe-deployer@`) already reads other GSM secrets (`DATABASE_URL_SECRET`, `JWT_SECRET_NAME`, `FAMILY_MASTER_KEY_SECRET_NAME`) in this same workflow, so `secretmanager.secretAccessor` on this secret should already be in place.
- Closes #164. Builds on #163 (token audience fix) — that one was the transport layer, this is the application layer.

## Test plan

- [ ] After merge, push to `develop` triggers a deploy-dev — Playwright `globalSetup` should authenticate cleanly and the three `@smoke` flows should pass.
- [ ] Confirm in the run logs that the password value is masked (appears as `***` in any echoed gcloud output).
- [ ] Rotation rehearsal (low priority, future): rotate `family-recipe-dev-claude-test-password` (add a new GSM version), re-seed the dev DB per the verification doc, and confirm the next deploy-dev still passes Playwright `@smoke` without any GHA-secret update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)