### PR TITLE
feat(api): FastAPI Phase 1 — token auth with rotating refresh + reuse detection

### DIFF
--- a/apps/api/openapi.snapshot.json
+++ b/apps/api/openapi.snapshot.json
@@ -1,6 +1,20 @@
 {
   "components": {
     "schemas": {
+      "AccessTokenResponse": {
+        "description": "Returned by /v1/auth/refresh \u2014 only the access token rotates here.\nThe user does not change between rotations.",
+        "properties": {
+          "accessToken": {
+            "title": "Accesstoken",
+            "type": "string"
+          }
+        },
+        "required": [
+          "accessToken"
+        ],
+        "title": "AccessTokenResponse",
+        "type": "object"
+      },
       "AuthResponse": {
         "properties": {
           "user": {
@@ -11,6 +25,24 @@
           "user"
         ],
         "title": "AuthResponse",
+        "type": "object"
+      },
+      "AuthTokenResponse": {
+        "description": "Returned by /v1/auth/{login,signup} \u2014 full bootstrap payload.",
+        "properties": {
+          "accessToken": {
+            "title": "Accesstoken",
+            "type": "string"
+          },
+          "user": {
+            "$ref": "#/components/schemas/UserResponse"
+          }
+        },
+        "required": [
+          "accessToken",
+          "user"
+        ],
+        "title": "AuthTokenResponse",
         "type": "object"
       },
       "Body_create_comment_posts__post_id__comments_post": {
@@ -161,6 +193,18 @@
           "password"
         ],
         "title": "LoginRequest",
+        "type": "object"
+      },
+      "MeResponse": {
+        "properties": {
+          "user": {
+            "$ref": "#/components/schemas/UserResponse"
+          }
+        },
+        "required": [
+          "user"
+        ],
+        "title": "MeResponse",
         "type": "object"
       },
       "ReactionRequest": {
@@ -336,6 +380,12 @@
         ],
         "title": "ValidationError",
         "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "HTTPBearer": {
+        "scheme": "bearer",
+        "type": "http"
       }
     }
   },
@@ -1760,6 +1810,177 @@
         "summary": "Get Timeline",
         "tags": [
           "timeline"
+        ]
+      }
+    },
+    "/v1/auth/login": {
+      "post": {
+        "operationId": "login_v1_auth_login_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthTokenResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Login",
+        "tags": [
+          "auth-v1"
+        ]
+      }
+    },
+    "/v1/auth/logout": {
+      "post": {
+        "operationId": "logout_v1_auth_logout_post",
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Logout",
+        "tags": [
+          "auth-v1"
+        ]
+      }
+    },
+    "/v1/auth/me": {
+      "get": {
+        "operationId": "me_v1_auth_me_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Me",
+        "tags": [
+          "auth-v1"
+        ]
+      }
+    },
+    "/v1/auth/refresh": {
+      "post": {
+        "operationId": "refresh_v1_auth_refresh_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-CSRF-Token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Csrf-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccessTokenResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Refresh",
+        "tags": [
+          "auth-v1"
+        ]
+      }
+    },
+    "/v1/auth/signup": {
+      "post": {
+        "operationId": "signup_v1_auth_signup_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SignupRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthTokenResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Signup",
+        "tags": [
+          "auth-v1"
         ]
       }
     }

--- a/apps/api/src/cookies.py
+++ b/apps/api/src/cookies.py
@@ -1,0 +1,71 @@
+"""Cookie helpers for the v1 token-auth endpoints.
+
+Why a dedicated module: cookie attributes (Secure, SameSite, Domain) vary by
+environment and need to stay consistent across set/clear paths. Also lets
+us flip refresh+csrf cookies in lockstep without per-handler boilerplate.
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+from fastapi import Response
+
+from .settings import settings
+
+SameSite = Literal["lax", "strict", "none"]
+
+
+def _samesite() -> SameSite:
+    raw = settings.refresh_cookie_samesite.lower()
+    if raw not in ("lax", "strict", "none"):
+        return "lax"
+    return raw  # type: ignore[return-value]
+
+
+def set_refresh_cookie(response: Response, value: str, max_age_seconds: int) -> None:
+    response.set_cookie(
+        settings.refresh_cookie_name,
+        value,
+        max_age=max_age_seconds,
+        httponly=True,
+        secure=settings.is_production or _samesite() == "none",
+        samesite=_samesite(),
+        domain=settings.refresh_cookie_domain,
+        path="/",
+    )
+
+
+def clear_refresh_cookie(response: Response) -> None:
+    response.delete_cookie(
+        settings.refresh_cookie_name,
+        httponly=True,
+        secure=settings.is_production or _samesite() == "none",
+        samesite=_samesite(),
+        domain=settings.refresh_cookie_domain,
+        path="/",
+    )
+
+
+def set_csrf_cookie(response: Response, value: str, max_age_seconds: int) -> None:
+    # Non-HttpOnly so the SPA can read it and echo as `X-CSRF-Token`.
+    response.set_cookie(
+        settings.csrf_cookie_name,
+        value,
+        max_age=max_age_seconds,
+        httponly=False,
+        secure=settings.is_production or _samesite() == "none",
+        samesite=_samesite(),
+        domain=settings.refresh_cookie_domain,
+        path="/",
+    )
+
+
+def clear_csrf_cookie(response: Response) -> None:
+    response.delete_cookie(
+        settings.csrf_cookie_name,
+        httponly=False,
+        secure=settings.is_production or _samesite() == "none",
+        samesite=_samesite(),
+        domain=settings.refresh_cookie_domain,
+        path="/",
+    )

--- a/apps/api/src/dependencies_v1.py
+++ b/apps/api/src/dependencies_v1.py
@@ -6,10 +6,11 @@ site doesn't accidentally accept both auth modes.
 """
 from __future__ import annotations
 
-from fastapi import Depends, HTTPException, Request, status
+from fastapi import Depends, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from .db import prisma
+from .errors import ApiError
 from .schemas.auth import UserResponse
 from .tokens import verify_access_token
 from .uploads import get_signed_upload_url
@@ -17,16 +18,19 @@ from .uploads import get_signed_upload_url
 bearer_scheme = HTTPBearer(auto_error=False)
 
 
+def _unauthorized() -> ApiError:
+    return ApiError("UNAUTHORIZED", "Unauthorized", status.HTTP_401_UNAUTHORIZED)
+
+
 async def get_current_user_v1(
-    request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
 ) -> UserResponse:
     if credentials is None or credentials.scheme.lower() != "bearer":
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+        raise _unauthorized()
 
     claims = verify_access_token(credentials.credentials)
     if claims is None:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+        raise _unauthorized()
 
     user = await prisma.user.find_unique(
         where={"id": claims.sub},
@@ -38,7 +42,7 @@ async def get_current_user_v1(
         },
     )
     if not user or not user.memberships:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+        raise _unauthorized()
 
     membership = user.memberships[0]
     avatar_url = await get_signed_upload_url(getattr(user, "avatarStorageKey", None))

--- a/apps/api/src/dependencies_v1.py
+++ b/apps/api/src/dependencies_v1.py
@@ -1,0 +1,55 @@
+"""Bearer-token auth dependencies for /v1/* endpoints.
+
+Mirrors src/dependencies.py but reads `Authorization: Bearer <jwt>` instead
+of the legacy session cookie. Kept in a separate module so a single import
+site doesn't accidentally accept both auth modes.
+"""
+from __future__ import annotations
+
+from fastapi import Depends, HTTPException, Request, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from .db import prisma
+from .schemas.auth import UserResponse
+from .tokens import verify_access_token
+from .uploads import get_signed_upload_url
+
+bearer_scheme = HTTPBearer(auto_error=False)
+
+
+async def get_current_user_v1(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
+) -> UserResponse:
+    if credentials is None or credentials.scheme.lower() != "bearer":
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+
+    claims = verify_access_token(credentials.credentials)
+    if claims is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+
+    user = await prisma.user.find_unique(
+        where={"id": claims.sub},
+        include={
+            "memberships": {
+                "where": {"familySpaceId": claims.family_space_id},
+                "include": {"familySpace": True},
+            }
+        },
+    )
+    if not user or not user.memberships:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+
+    membership = user.memberships[0]
+    avatar_url = await get_signed_upload_url(getattr(user, "avatarStorageKey", None))
+    return UserResponse(
+        id=user.id,
+        name=user.name,
+        email=user.email,
+        username=user.username,
+        emailOrUsername=user.email,
+        avatarUrl=avatar_url,
+        role=membership.role,
+        familySpaceId=membership.familySpaceId,
+        familySpaceName=membership.familySpace.name if membership.familySpace else None,
+    )

--- a/apps/api/src/errors.py
+++ b/apps/api/src/errors.py
@@ -1,6 +1,25 @@
 from fastapi.responses import JSONResponse
 
 
+class ApiError(Exception):
+    """Raised from a dependency or handler when we want the canonical
+    `{error: {code, message}}` envelope returned. Mapped to a JSONResponse
+    by the global exception handler in main.py.
+
+    Why not just `raise HTTPException(detail=...)`: FastAPI's default
+    serialization for HTTPException is `{"detail": ...}`, which doesn't
+    match the documented contract. The /v1 SPA in #36 keys off
+    `error.code`, so dependencies need a way to signal the same envelope
+    that handler-returned `unauthorized()`/`bad_request()` etc. produce.
+    """
+
+    def __init__(self, code: str, message: str, status_code: int) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+
+
 def error_response(code: str, message: str, status_code: int) -> JSONResponse:
     return JSONResponse(
         status_code=status_code,

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -1,9 +1,12 @@
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from .db import connect_db, disconnect_db
 from .routers import auth, comments, family, health, me, posts, profile, reactions, recipes, tags, timeline
+from .routers.v1 import auth as auth_v1
+from .settings import settings
 
 
 @asynccontextmanager
@@ -18,8 +21,19 @@ async def lifespan(app: FastAPI):
 app = FastAPI(title="Family Recipe API", lifespan=lifespan)
 
 
+if settings.cors_origins_list:
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=settings.cors_origins_list,
+        allow_credentials=True,
+        allow_methods=["GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS"],
+        allow_headers=["Authorization", "Content-Type", "X-CSRF-Token", "X-Request-Id"],
+    )
+
+
 app.include_router(health.router)
 app.include_router(auth.router)
+app.include_router(auth_v1.router)
 app.include_router(posts.router)
 app.include_router(comments.comments_router)
 app.include_router(comments.delete_router)

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -1,9 +1,10 @@
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 
 from .db import connect_db, disconnect_db
+from .errors import ApiError, error_response
 from .routers import auth, comments, family, health, me, posts, profile, reactions, recipes, tags, timeline
 from .routers.v1 import auth as auth_v1
 from .settings import settings
@@ -19,6 +20,11 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(title="Family Recipe API", lifespan=lifespan)
+
+
+@app.exception_handler(ApiError)
+async def _api_error_handler(_request: Request, exc: ApiError):
+    return error_response(exc.code, exc.message, exc.status_code)
 
 
 if settings.cors_origins_list:

--- a/apps/api/src/routers/v1/auth.py
+++ b/apps/api/src/routers/v1/auth.py
@@ -1,0 +1,397 @@
+"""/v1/auth/* — token-based auth (issue #35).
+
+Replaces the legacy single-cookie JWT flow with:
+  - short-lived `accessToken` returned in the JSON response body
+  - rotating refresh token in an httpOnly `refresh_token` cookie
+  - CSRF double-submit `csrf_token` cookie + `X-CSRF-Token` header on /refresh
+
+Design: docs/research/refresh-token-store.md
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Header, Request, Response, status
+from prisma.errors import PrismaError
+
+from ...cookies import (
+    clear_csrf_cookie,
+    clear_refresh_cookie,
+    set_csrf_cookie,
+    set_refresh_cookie,
+)
+from ...db import prisma
+from ...dependencies_v1 import get_current_user_v1
+from ...errors import bad_request, forbidden, internal_error, invalid_credentials, unauthorized
+from ...schemas.auth import LoginRequest, SignupRequest, UserResponse
+from ...schemas.auth_v1 import AccessTokenResponse, AuthTokenResponse, MeResponse
+from ...security import hash_password, verify_password
+from ...settings import settings
+from ...tokens import (
+    REVOKED_LOGOUT,
+    REVOKED_REUSE_DETECTED,
+    REVOKED_ROTATED,
+    constant_time_hash_eq,
+    csrf_token_matches,
+    issue_refresh_token,
+    mint_access_token,
+    mint_csrf_token,
+    parse_refresh_cookie,
+)
+from ...uploads import get_signed_upload_url
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/v1/auth", tags=["auth-v1"])
+
+
+def _client_ip(request: Request) -> Optional[str]:
+    fwd = request.headers.get("x-forwarded-for")
+    if fwd:
+        return fwd.split(",")[0].strip()
+    if request.client:
+        return request.client.host
+    return None
+
+
+def _user_agent(request: Request) -> Optional[str]:
+    ua = request.headers.get("user-agent")
+    return ua[:500] if ua else None
+
+
+async def _persist_refresh_and_set_cookies(
+    *,
+    response: Response,
+    request: Request,
+    user_id: str,
+    family_space_id: str,
+    chain_id: Optional[str],
+    rotated_from_jti: Optional[str],
+    remember_me: bool,
+) -> int:
+    """Insert a fresh RefreshToken row and set both cookies. Returns max-age seconds."""
+    issued = issue_refresh_token(chain_id=chain_id, remember_me=remember_me)
+    await prisma.refreshtoken.create(
+        data={
+            "userId": user_id,
+            "familySpaceId": family_space_id,
+            "jti": issued.jti,
+            "tokenHash": issued.token_hash,
+            "chainId": issued.chain_id,
+            "rotatedFromJti": rotated_from_jti,
+            "rememberMe": remember_me,
+            "expiresAt": issued.expires_at,
+            "userAgent": _user_agent(request),
+            "ipAddress": _client_ip(request),
+        }
+    )
+    max_age = (
+        settings.refresh_token_ttl_remember_seconds
+        if remember_me
+        else settings.refresh_token_ttl_default_seconds
+    )
+    set_refresh_cookie(response, issued.cookie_value, max_age)
+    set_csrf_cookie(response, mint_csrf_token(), max_age)
+    return max_age
+
+
+async def _build_user_response(user, membership) -> UserResponse:
+    avatar_url = await get_signed_upload_url(getattr(user, "avatarStorageKey", None))
+    return UserResponse(
+        id=user.id,
+        name=user.name,
+        email=user.email,
+        username=user.username,
+        emailOrUsername=user.email,
+        avatarUrl=avatar_url,
+        role=membership.role,
+        familySpaceId=membership.familySpaceId,
+        familySpaceName=membership.familySpace.name if membership.familySpace else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/auth/signup
+# ---------------------------------------------------------------------------
+@router.post("/signup", response_model=AuthTokenResponse, status_code=status.HTTP_201_CREATED)
+async def signup(payload: SignupRequest, request: Request, response: Response):
+    try:
+        email = payload.email.strip()
+        username = payload.username.strip()
+
+        existing_user = await prisma.user.find_first(
+            where={"OR": [{"email": email}, {"username": username}]}
+        )
+        if existing_user:
+            return bad_request("A user with this email or username already exists")
+
+        family_space = await prisma.familyspace.find_first()
+        if not family_space:
+            return internal_error("No family space found. Please contact the administrator.")
+
+        if not verify_password(payload.familyMasterKey, family_space.masterKeyHash):
+            return bad_request("Invalid Family Master Key")
+
+        members_count = await prisma.familymembership.count(
+            where={"familySpaceId": family_space.id}
+        )
+        role = "owner" if members_count == 0 else "member"
+
+        async with prisma.tx() as tx:
+            user = await tx.user.create(
+                data={
+                    "name": payload.name,
+                    "email": email,
+                    "username": username,
+                    "passwordHash": hash_password(payload.password),
+                }
+            )
+            membership = await tx.familymembership.create(
+                data={
+                    "familySpaceId": family_space.id,
+                    "userId": user.id,
+                    "role": role,
+                }
+            )
+
+        access_token = mint_access_token(
+            user_id=user.id,
+            family_space_id=membership.familySpaceId,
+            role=membership.role,
+        )
+
+        await _persist_refresh_and_set_cookies(
+            response=response,
+            request=request,
+            user_id=user.id,
+            family_space_id=membership.familySpaceId,
+            chain_id=None,
+            rotated_from_jti=None,
+            remember_me=payload.rememberMe,
+        )
+
+        membership_with_space = type("M", (), {
+            "role": membership.role,
+            "familySpaceId": membership.familySpaceId,
+            "familySpace": family_space,
+        })
+        user_response = await _build_user_response(user, membership_with_space)
+        return AuthTokenResponse(accessToken=access_token, user=user_response)
+    except PrismaError as error:
+        logger.exception("auth_v1.signup.prisma_error: %s", error)
+        return internal_error("Database error during signup")
+    except Exception as error:  # noqa: BLE001
+        logger.exception("auth_v1.signup.error: %s", error)
+        return internal_error("Failed to signup")
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/auth/login
+# ---------------------------------------------------------------------------
+@router.post("/login", response_model=AuthTokenResponse)
+async def login(payload: LoginRequest, request: Request, response: Response):
+    try:
+        identifier = payload.emailOrUsername.strip()
+        user = await prisma.user.find_first(
+            where={"OR": [{"email": identifier}, {"username": identifier}]},
+            include={"memberships": {"include": {"familySpace": True}}},
+        )
+
+        if not user:
+            logger.info("auth_v1.login.invalid_credentials: user not found")
+            return invalid_credentials()
+
+        if not verify_password(payload.password, user.passwordHash):
+            logger.info("auth_v1.login.invalid_credentials: bad password")
+            return invalid_credentials()
+
+        if not user.memberships:
+            logger.info("auth_v1.login.no_membership: userId=%s", user.id)
+            return forbidden("User is not a member of any family space")
+
+        membership = user.memberships[0]
+
+        access_token = mint_access_token(
+            user_id=user.id,
+            family_space_id=membership.familySpaceId,
+            role=membership.role,
+        )
+
+        await _persist_refresh_and_set_cookies(
+            response=response,
+            request=request,
+            user_id=user.id,
+            family_space_id=membership.familySpaceId,
+            chain_id=None,
+            rotated_from_jti=None,
+            remember_me=payload.rememberMe,
+        )
+
+        user_response = await _build_user_response(user, membership)
+        return AuthTokenResponse(accessToken=access_token, user=user_response)
+    except PrismaError as error:
+        logger.exception("auth_v1.login.prisma_error: %s", error)
+        return internal_error("Database error during login")
+    except Exception as error:  # noqa: BLE001
+        logger.exception("auth_v1.login.error: %s", error)
+        return internal_error("Failed to login")
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/auth/refresh
+# ---------------------------------------------------------------------------
+@router.post("/refresh", response_model=AccessTokenResponse)
+async def refresh(
+    request: Request,
+    response: Response,
+    x_csrf_token: Optional[str] = Header(default=None, alias="X-CSRF-Token"),
+):
+    refresh_cookie = request.cookies.get(settings.refresh_cookie_name)
+    csrf_cookie = request.cookies.get(settings.csrf_cookie_name)
+
+    # CSRF double-submit gate — must precede DB work so a malformed request
+    # cannot probe the token store.
+    if not csrf_token_matches(csrf_cookie, x_csrf_token):
+        return unauthorized("Invalid CSRF token")
+
+    parsed = parse_refresh_cookie(refresh_cookie or "")
+    if not parsed:
+        return unauthorized("Missing or malformed refresh token")
+    jti, secret = parsed
+
+    try:
+        row = await prisma.refreshtoken.find_unique(where={"jti": jti})
+        now = datetime.now(timezone.utc)
+
+        # If the cookie hashes back to a row we've already marked 'rotated',
+        # this is the textbook reuse signal — burn the chain.
+        if row is None:
+            return unauthorized("Refresh token not recognized")
+
+        is_expired = row.expiresAt <= now
+        is_revoked = row.revokedAt is not None
+        hash_ok = constant_time_hash_eq(row.tokenHash, secret)
+
+        if (is_expired or is_revoked or not hash_ok) and row.revokedReason == REVOKED_ROTATED:
+            await prisma.refreshtoken.update_many(
+                where={"chainId": row.chainId, "revokedAt": None},
+                data={"revokedAt": now, "revokedReason": REVOKED_REUSE_DETECTED},
+            )
+            logger.warning(
+                "auth_v1.refresh.reuse_detected userId=%s chainId=%s issuanceIp=%s replayIp=%s",
+                row.userId, row.chainId, row.ipAddress, _client_ip(request),
+            )
+            clear_refresh_cookie(response)
+            clear_csrf_cookie(response)
+            return unauthorized("Refresh token reuse detected")
+
+        if is_expired or is_revoked or not hash_ok:
+            return unauthorized("Refresh token invalid")
+
+        # Rotate inside a single transaction so two concurrent /refresh callers
+        # cannot both insert a successor row.
+        async with prisma.tx() as tx:
+            # SELECT … FOR UPDATE: lock the row before we mutate.
+            await tx.execute_raw(
+                'SELECT id FROM "refresh_tokens" WHERE jti = $1 FOR UPDATE',
+                jti,
+            )
+            # Re-read inside the lock; another caller may have rotated us.
+            locked = await tx.refreshtoken.find_unique(where={"jti": jti})
+            if locked is None or locked.revokedAt is not None:
+                return unauthorized("Refresh token invalid")
+
+            await tx.refreshtoken.update(
+                where={"jti": jti},
+                data={"revokedAt": now, "revokedReason": REVOKED_ROTATED},
+            )
+
+            # The new row inherits the chain + remember_me — caller's flag is
+            # set once at login and carried forward so /refresh doesn't silently
+            # downgrade a remember-me session.
+            issued = issue_refresh_token(chain_id=locked.chainId, remember_me=locked.rememberMe)
+            await tx.refreshtoken.create(
+                data={
+                    "userId": locked.userId,
+                    "familySpaceId": locked.familySpaceId,
+                    "jti": issued.jti,
+                    "tokenHash": issued.token_hash,
+                    "chainId": issued.chain_id,
+                    "rotatedFromJti": jti,
+                    "rememberMe": locked.rememberMe,
+                    "expiresAt": issued.expires_at,
+                    "userAgent": _user_agent(request),
+                    "ipAddress": _client_ip(request),
+                }
+            )
+
+        # Membership lookup happens outside the transaction; tx scope is
+        # narrow on purpose to keep the row lock short-lived.
+        user = await prisma.user.find_unique(
+            where={"id": locked.userId},
+            include={
+                "memberships": {
+                    "where": {"familySpaceId": locked.familySpaceId},
+                }
+            },
+        )
+        if not user or not user.memberships:
+            return unauthorized("Membership no longer valid")
+
+        membership = user.memberships[0]
+        access_token = mint_access_token(
+            user_id=locked.userId,
+            family_space_id=locked.familySpaceId,
+            role=membership.role,
+        )
+
+        max_age = (
+            settings.refresh_token_ttl_remember_seconds
+            if locked.rememberMe
+            else settings.refresh_token_ttl_default_seconds
+        )
+        set_refresh_cookie(response, issued.cookie_value, max_age)
+        set_csrf_cookie(response, mint_csrf_token(), max_age)
+
+        return AccessTokenResponse(accessToken=access_token)
+    except PrismaError as error:
+        logger.exception("auth_v1.refresh.prisma_error: %s", error)
+        return internal_error("Database error during refresh")
+    except Exception as error:  # noqa: BLE001
+        logger.exception("auth_v1.refresh.error: %s", error)
+        return internal_error("Failed to refresh")
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/auth/logout
+# ---------------------------------------------------------------------------
+@router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
+async def logout(request: Request, response: Response):
+    refresh_cookie = request.cookies.get(settings.refresh_cookie_name)
+    parsed = parse_refresh_cookie(refresh_cookie or "")
+    if parsed:
+        jti, _ = parsed
+        try:
+            await prisma.refreshtoken.update_many(
+                where={"jti": jti, "revokedAt": None},
+                data={"revokedAt": datetime.now(timezone.utc), "revokedReason": REVOKED_LOGOUT},
+            )
+        except PrismaError as error:
+            # Logout should be best-effort; we still want to clear the client
+            # cookie even if the DB write fails. Log loudly so we notice.
+            logger.exception("auth_v1.logout.prisma_error: %s", error)
+
+    clear_refresh_cookie(response)
+    clear_csrf_cookie(response)
+    response.status_code = status.HTTP_204_NO_CONTENT
+    return response
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/auth/me
+# ---------------------------------------------------------------------------
+@router.get("/me", response_model=MeResponse)
+async def me(user: UserResponse = Depends(get_current_user_v1)):
+    return MeResponse(user=user)

--- a/apps/api/src/schemas/auth_v1.py
+++ b/apps/api/src/schemas/auth_v1.py
@@ -1,0 +1,33 @@
+"""Request/response shapes for /v1/auth/* — distinct from the legacy
+session-cookie schemas in auth.py because the v1 contract returns an
+access token alongside the user payload."""
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from .auth import LoginRequest, SignupRequest, UserResponse
+
+__all__ = [
+    "LoginRequest",
+    "SignupRequest",
+    "UserResponse",
+    "AccessTokenResponse",
+    "AuthTokenResponse",
+    "MeResponse",
+]
+
+
+class AccessTokenResponse(BaseModel):
+    """Returned by /v1/auth/refresh — only the access token rotates here.
+    The user does not change between rotations."""
+    accessToken: str
+
+
+class AuthTokenResponse(BaseModel):
+    """Returned by /v1/auth/{login,signup} — full bootstrap payload."""
+    accessToken: str
+    user: UserResponse
+
+
+class MeResponse(BaseModel):
+    user: UserResponse

--- a/apps/api/src/settings.py
+++ b/apps/api/src/settings.py
@@ -1,3 +1,4 @@
+import json
 import os
 from typing import Optional
 
@@ -16,6 +17,35 @@ class Settings(BaseSettings):
     cookie_name: str = "session"
     environment: str = "development"
 
+    # ----- v1 token-auth (issue #35) -----
+    # JSON map of kid -> secret. Allows overlap-window key rotation.
+    # If unset, falls back to {"v1": jwt_secret} so dev works out of the box.
+    access_token_signing_keys: Optional[str] = None
+    access_token_active_kid: str = "v1"
+    access_token_ttl_seconds: int = 15 * 60  # 15 minutes
+    refresh_token_ttl_default_seconds: int = 7 * 24 * 60 * 60   # 7 days
+    refresh_token_ttl_remember_seconds: int = 30 * 24 * 60 * 60  # 30 days
+
+    # HMAC pepper for refresh-token hashes; required in production.
+    refresh_pepper: Optional[str] = None
+
+    # Monotonic epoch used to invalidate every live access token at once
+    # (e.g. on signing-key compromise). Bumping it forces a refresh-rotation.
+    auth_epoch: int = 1
+
+    # CORS origins for the v1 token flow (comma-separated). The legacy
+    # session-cookie endpoints stay same-origin.
+    cors_allow_origins: str = ""
+
+    # Refresh cookie attributes; production overrides via env.
+    refresh_cookie_name: str = "refresh_token"
+    csrf_cookie_name: str = "csrf_token"
+    refresh_cookie_domain: Optional[str] = None
+    refresh_cookie_samesite: str = "lax"  # 'lax' | 'strict' | 'none'
+
+    # Token audience claim — clients should verify match.
+    jwt_audience: str = "family-recipe-app"
+
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
     @field_validator("database_url", "jwt_secret")
@@ -28,6 +58,37 @@ class Settings(BaseSettings):
     @property
     def is_production(self) -> bool:
         return self.environment.lower() == "production"
+
+    @property
+    def signing_keys(self) -> dict[str, str]:
+        """Map of kid -> signing secret. Used for access-token rotation overlap."""
+        if self.access_token_signing_keys:
+            try:
+                parsed = json.loads(self.access_token_signing_keys)
+                if not isinstance(parsed, dict) or not parsed:
+                    raise ValueError("ACCESS_TOKEN_SIGNING_KEYS must be a non-empty JSON object")
+                if self.access_token_active_kid not in parsed:
+                    raise ValueError(
+                        f"ACCESS_TOKEN_ACTIVE_KID '{self.access_token_active_kid}' "
+                        "is not present in ACCESS_TOKEN_SIGNING_KEYS"
+                    )
+                return {str(k): str(v) for k, v in parsed.items()}
+            except json.JSONDecodeError as exc:
+                raise ValueError("ACCESS_TOKEN_SIGNING_KEYS must be valid JSON") from exc
+        return {self.access_token_active_kid: self.jwt_secret}
+
+    @property
+    def effective_refresh_pepper(self) -> str:
+        """Required pepper; falls back to jwt_secret in non-production."""
+        if self.refresh_pepper:
+            return self.refresh_pepper
+        if self.is_production:
+            raise RuntimeError("REFRESH_PEPPER must be set in production")
+        return self.jwt_secret
+
+    @property
+    def cors_origins_list(self) -> list[str]:
+        return [o.strip() for o in self.cors_allow_origins.split(",") if o.strip()]
 
 
 settings = Settings()

--- a/apps/api/src/tokens.py
+++ b/apps/api/src/tokens.py
@@ -1,0 +1,225 @@
+"""Token-auth primitives for the FastAPI v1 endpoints.
+
+Implements the design in docs/research/refresh-token-store.md:
+
+- Short-lived access JWTs with `kid` header (signing-key rotation overlap)
+  and an `epoch` claim (`AUTH_EPOCH` env) for global revocation.
+- Refresh tokens delivered as `{jti}.{secret}` opaque cookie strings; the
+  secret half is stored as HMAC-SHA256(REFRESH_PEPPER, secret).
+- CSRF double-submit cookie helpers for /refresh.
+
+Pure functions where possible — DB I/O lives in the routers.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import logging
+import secrets
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import jwt
+
+from .settings import settings
+
+logger = logging.getLogger(__name__)
+
+JWT_ISSUER = "family-recipe-app"
+JWT_ALGORITHM = "HS256"
+
+# Revocation reasons — keep aligned with TS counterpart when one is added.
+REVOKED_ROTATED = "rotated"
+REVOKED_LOGOUT = "logout"
+REVOKED_LOGOUT_ALL = "logout_all"
+REVOKED_REUSE_DETECTED = "reuse_detected"
+REVOKED_ADMIN = "admin"
+
+VALID_REVOKED_REASONS = {
+    REVOKED_ROTATED,
+    REVOKED_LOGOUT,
+    REVOKED_LOGOUT_ALL,
+    REVOKED_REUSE_DETECTED,
+    REVOKED_ADMIN,
+}
+
+
+# ---------------------------------------------------------------------------
+# Access tokens
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AccessTokenClaims:
+    sub: str
+    family_space_id: str
+    role: str
+    jti: str
+    epoch: int
+    iss: str
+    aud: str
+    iat: int
+    exp: int
+    kid: str
+
+
+def mint_access_token(
+    *,
+    user_id: str,
+    family_space_id: str,
+    role: str,
+    now: Optional[datetime] = None,
+) -> str:
+    """Sign a short-lived access JWT using the active kid."""
+    keys = settings.signing_keys
+    kid = settings.access_token_active_kid
+    secret = keys[kid]
+    issued_at = now or datetime.now(timezone.utc)
+    expires_at = issued_at + timedelta(seconds=settings.access_token_ttl_seconds)
+    payload = {
+        "sub": user_id,
+        "familySpaceId": family_space_id,
+        "role": role,
+        "epoch": settings.auth_epoch,
+        "iss": JWT_ISSUER,
+        "aud": settings.jwt_audience,
+        "iat": int(issued_at.timestamp()),
+        "exp": int(expires_at.timestamp()),
+        "jti": uuid.uuid4().hex,
+    }
+    return jwt.encode(payload, secret, algorithm=JWT_ALGORITHM, headers={"kid": kid})
+
+
+def verify_access_token(token: str) -> Optional[AccessTokenClaims]:
+    """Verify an access token against any known kid; reject if epoch is stale.
+
+    During key rotation, both the old and new kid live in `signing_keys`;
+    once the rotation overlap window passes (>= 2x access TTL), the old kid
+    is removed from the map and tokens signed by it stop verifying.
+    """
+    keys = settings.signing_keys
+    try:
+        unverified_header = jwt.get_unverified_header(token)
+    except jwt.InvalidTokenError:
+        return None
+
+    kid = unverified_header.get("kid")
+    if not isinstance(kid, str) or kid not in keys:
+        return None
+
+    try:
+        decoded = jwt.decode(
+            token,
+            keys[kid],
+            algorithms=[JWT_ALGORITHM],
+            issuer=JWT_ISSUER,
+            audience=settings.jwt_audience,
+        )
+    except jwt.InvalidTokenError:
+        return None
+
+    # Epoch gate: any token minted before the current AUTH_EPOCH is dead.
+    epoch = decoded.get("epoch")
+    if not isinstance(epoch, int) or epoch < settings.auth_epoch:
+        return None
+
+    sub = decoded.get("sub")
+    family_space_id = decoded.get("familySpaceId")
+    role = decoded.get("role")
+    jti = decoded.get("jti")
+    if not (isinstance(sub, str) and isinstance(family_space_id, str)
+            and isinstance(role, str) and isinstance(jti, str)):
+        return None
+
+    return AccessTokenClaims(
+        sub=sub,
+        family_space_id=family_space_id,
+        role=role,
+        jti=jti,
+        epoch=epoch,
+        iss=JWT_ISSUER,
+        aud=settings.jwt_audience,
+        iat=int(decoded.get("iat", 0)),
+        exp=int(decoded.get("exp", 0)),
+        kid=kid,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Refresh tokens
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class IssuedRefreshToken:
+    jti: str
+    secret: str
+    cookie_value: str          # what to set on the wire: "{jti}.{secret}"
+    token_hash: str            # HMAC(pepper, secret) — store this
+    expires_at: datetime
+    chain_id: str
+    remember_me: bool
+
+
+def _hash_refresh_secret(secret: str) -> str:
+    pepper = settings.effective_refresh_pepper.encode("utf-8")
+    digest = hmac.new(pepper, secret.encode("utf-8"), hashlib.sha256).digest()
+    return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+
+
+def constant_time_hash_eq(stored_hash: str, candidate_secret: str) -> bool:
+    return hmac.compare_digest(stored_hash, _hash_refresh_secret(candidate_secret))
+
+
+def issue_refresh_token(
+    *,
+    chain_id: Optional[str] = None,
+    remember_me: bool = False,
+    now: Optional[datetime] = None,
+) -> IssuedRefreshToken:
+    """Mint a new refresh token. Caller is responsible for the DB insert."""
+    issued_at = now or datetime.now(timezone.utc)
+    ttl_seconds = (
+        settings.refresh_token_ttl_remember_seconds
+        if remember_me
+        else settings.refresh_token_ttl_default_seconds
+    )
+    jti = uuid.uuid4().hex
+    secret = secrets.token_urlsafe(32)
+    return IssuedRefreshToken(
+        jti=jti,
+        secret=secret,
+        cookie_value=f"{jti}.{secret}",
+        token_hash=_hash_refresh_secret(secret),
+        expires_at=issued_at + timedelta(seconds=ttl_seconds),
+        chain_id=chain_id or uuid.uuid4().hex,
+        remember_me=remember_me,
+    )
+
+
+def parse_refresh_cookie(cookie_value: str) -> Optional[tuple[str, str]]:
+    """Split a `{jti}.{secret}` cookie. Returns None on malformed input."""
+    if not cookie_value or "." not in cookie_value:
+        return None
+    jti, _, secret = cookie_value.partition(".")
+    if not jti or not secret:
+        return None
+    return jti, secret
+
+
+# ---------------------------------------------------------------------------
+# CSRF double-submit
+# ---------------------------------------------------------------------------
+
+
+def mint_csrf_token() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def csrf_token_matches(cookie_value: Optional[str], header_value: Optional[str]) -> bool:
+    if not cookie_value or not header_value:
+        return False
+    return hmac.compare_digest(cookie_value, header_value)

--- a/apps/api/tests/helpers/mock_prisma.py
+++ b/apps/api/tests/helpers/mock_prisma.py
@@ -14,6 +14,7 @@ MODEL_NAMES = [
     "familyspace",
     "familymembership",
     "tag",
+    "refreshtoken",
 ]
 
 
@@ -24,6 +25,7 @@ def _make_model_mock() -> MagicMock:
     model_mock.find_many = AsyncMock(return_value=[])
     model_mock.create = AsyncMock(return_value=None)
     model_mock.update = AsyncMock(return_value=None)
+    model_mock.update_many = AsyncMock(return_value=None)
     model_mock.delete = AsyncMock(return_value=None)
     model_mock.delete_many = AsyncMock(return_value=None)
     model_mock.count = AsyncMock(return_value=0)
@@ -42,6 +44,10 @@ def create_mock_prisma_client() -> MagicMock:
         def __init__(self, prisma_mock: MagicMock):
             self.post = prisma_mock.post
             self.postphoto = prisma_mock.postphoto
+            self.user = prisma_mock.user
+            self.familymembership = prisma_mock.familymembership
+            self.refreshtoken = prisma_mock.refreshtoken
+            self.execute_raw = AsyncMock(return_value=0)
 
         async def __aenter__(self):
             return self
@@ -65,6 +71,7 @@ def reset_mock_prisma(mock_prisma: MagicMock) -> None:
             "find_many",
             "create",
             "update",
+            "update_many",
             "delete",
             "delete_many",
             "count",

--- a/apps/api/tests/helpers/test_data.py
+++ b/apps/api/tests/helpers/test_data.py
@@ -47,3 +47,25 @@ def make_mock_membership(**overrides: Any) -> SimpleNamespace:
     }
     data.update(overrides)
     return SimpleNamespace(**data)
+
+
+def make_mock_refresh_token(**overrides: Any) -> SimpleNamespace:
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    data = {
+        "id": overrides.get("id", "rt_test_123"),
+        "userId": overrides.get("userId", "user_test_123"),
+        "familySpaceId": overrides.get("familySpaceId", "family_test_123"),
+        "jti": overrides.get("jti", "jti_test_123"),
+        "tokenHash": overrides.get("tokenHash", "stored-hash-placeholder"),
+        "chainId": overrides.get("chainId", "chain_test_123"),
+        "rotatedFromJti": overrides.get("rotatedFromJti", None),
+        "rememberMe": overrides.get("rememberMe", False),
+        "issuedAt": overrides.get("issuedAt", now),
+        "expiresAt": overrides.get("expiresAt", datetime(2099, 1, 1, tzinfo=timezone.utc)),
+        "revokedAt": overrides.get("revokedAt", None),
+        "revokedReason": overrides.get("revokedReason", None),
+        "userAgent": overrides.get("userAgent", None),
+        "ipAddress": overrides.get("ipAddress", None),
+    }
+    data.update(overrides)
+    return SimpleNamespace(**data)

--- a/apps/api/tests/integration/conftest.py
+++ b/apps/api/tests/integration/conftest.py
@@ -36,7 +36,9 @@ def mock_prisma(monkeypatch):
     monkeypatch.setattr("src.routers.me.prisma", mock)
     monkeypatch.setattr("src.routers.family.prisma", mock)
     monkeypatch.setattr("src.routers.recipes.prisma", mock)
+    monkeypatch.setattr("src.routers.v1.auth.prisma", mock)
     monkeypatch.setattr("src.dependencies.prisma", mock)
+    monkeypatch.setattr("src.dependencies_v1.prisma", mock)
     yield mock
     reset_mock_prisma(mock)
 

--- a/apps/api/tests/integration/test_auth_v1.py
+++ b/apps/api/tests/integration/test_auth_v1.py
@@ -1,0 +1,571 @@
+"""Integration tests for /v1/auth/* — token-based auth (issue #35).
+
+These tests use the mock-Prisma fixture and a real test client so they
+exercise the full FastAPI middleware/dependency chain, but skip a real DB
+round-trip. Concurrency behavior is validated via a fake-DB harness in
+TestRefreshConcurrency at the bottom of the file.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src import tokens
+from src.settings import settings
+from tests.helpers.test_data import (
+    make_mock_family_space,
+    make_mock_membership,
+    make_mock_refresh_token,
+    make_mock_user,
+)
+
+
+def _setup_signup_tx(mock_prisma, user, membership):
+    """Mirror the legacy test_auth helper for the v1 signup transaction."""
+    tx_client = MagicMock()
+    tx_client.user.create = AsyncMock(return_value=user)
+    tx_client.familymembership.create = AsyncMock(return_value=membership)
+    tx_manager = MagicMock()
+    tx_manager.__aenter__ = AsyncMock(return_value=tx_client)
+    tx_manager.__aexit__ = AsyncMock(return_value=False)
+    mock_prisma.tx = MagicMock(return_value=tx_manager)
+    return tx_client
+
+
+def _refresh_tx_fixture(mock_prisma, locked_row):
+    """Stand up a tx context whose `find_unique` returns the locked row,
+    plus stub `update`+`create` so the rotation path completes.
+
+    Returns the tx_client mock so tests can assert on what was written.
+    """
+    tx_client = MagicMock()
+    tx_client.execute_raw = AsyncMock(return_value=0)
+    tx_client.refreshtoken = MagicMock()
+    tx_client.refreshtoken.find_unique = AsyncMock(return_value=locked_row)
+    tx_client.refreshtoken.update = AsyncMock(return_value=None)
+    tx_client.refreshtoken.create = AsyncMock(return_value=None)
+    tx_manager = MagicMock()
+    tx_manager.__aenter__ = AsyncMock(return_value=tx_client)
+    tx_manager.__aexit__ = AsyncMock(return_value=False)
+    mock_prisma.tx = MagicMock(return_value=tx_manager)
+    return tx_client
+
+
+# ---------------------------------------------------------------------------
+# /v1/auth/login + /v1/auth/signup happy path
+# ---------------------------------------------------------------------------
+
+
+class TestV1Login:
+    def test_login_returns_access_token_and_sets_cookies(
+        self, client, mock_prisma, monkeypatch
+    ):
+        family = make_mock_family_space()
+        membership = make_mock_membership(familySpaceId=family.id, familySpace=family)
+        user = make_mock_user(memberships=[membership])
+        mock_prisma.user.find_first.return_value = user
+        mock_prisma.refreshtoken.create = AsyncMock(return_value=None)
+        monkeypatch.setattr("src.routers.v1.auth.verify_password", lambda *_: True)
+
+        response = client.post(
+            "/v1/auth/login",
+            json={"emailOrUsername": user.email, "password": "password123"},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert "accessToken" in body
+        assert body["user"]["id"] == user.id
+
+        # Both cookies must land on the response.
+        cookie_header = response.headers.get("set-cookie", "")
+        assert settings.refresh_cookie_name in cookie_header
+        assert settings.csrf_cookie_name in cookie_header
+
+        # The access token must verify with our own helper.
+        claims = tokens.verify_access_token(body["accessToken"])
+        assert claims is not None
+        assert claims.sub == user.id
+        assert claims.family_space_id == family.id
+
+    def test_login_invalid_credentials(self, client, mock_prisma, monkeypatch):
+        mock_prisma.user.find_first.return_value = None
+        response = client.post(
+            "/v1/auth/login",
+            json={"emailOrUsername": "missing@example.com", "password": "password123"},
+        )
+        assert response.status_code == 401
+        assert response.json()["error"]["code"] == "INVALID_CREDENTIALS"
+
+    def test_login_remember_me_extends_cookie_max_age(
+        self, client, mock_prisma, monkeypatch
+    ):
+        family = make_mock_family_space()
+        membership = make_mock_membership(familySpaceId=family.id, familySpace=family)
+        user = make_mock_user(memberships=[membership])
+        mock_prisma.user.find_first.return_value = user
+        mock_prisma.refreshtoken.create = AsyncMock(return_value=None)
+        monkeypatch.setattr("src.routers.v1.auth.verify_password", lambda *_: True)
+
+        response = client.post(
+            "/v1/auth/login",
+            json={"emailOrUsername": user.email, "password": "password123", "rememberMe": True},
+        )
+
+        assert response.status_code == 200
+        cookies_raw = response.headers.get("set-cookie", "")
+        assert str(settings.refresh_token_ttl_remember_seconds) in cookies_raw
+
+
+class TestV1Signup:
+    def test_signup_first_user_owner_returns_token(
+        self, client, mock_prisma, monkeypatch
+    ):
+        family = make_mock_family_space()
+        mock_prisma.user.find_first.return_value = None
+        mock_prisma.familyspace.find_first.return_value = family
+        mock_prisma.familymembership.count.return_value = 0
+        user = make_mock_user(id="user_signup_1", email="new@example.com")
+        membership = make_mock_membership(
+            userId=user.id, familySpaceId=family.id, role="owner", familySpace=family
+        )
+        _setup_signup_tx(mock_prisma, user, membership)
+        mock_prisma.refreshtoken.create = AsyncMock(return_value=None)
+        monkeypatch.setattr("src.routers.v1.auth.verify_password", lambda *_: True)
+
+        response = client.post(
+            "/v1/auth/signup",
+            json={
+                "name": "New User",
+                "email": "new@example.com",
+                "username": "newuser",
+                "password": "password123",
+                "familyMasterKey": "secret-key",
+                "rememberMe": False,
+            },
+        )
+
+        assert response.status_code == 201
+        body = response.json()
+        assert "accessToken" in body
+        assert body["user"]["role"] == "owner"
+
+        cookie_header = response.headers.get("set-cookie", "")
+        assert settings.refresh_cookie_name in cookie_header
+        assert settings.csrf_cookie_name in cookie_header
+
+
+# ---------------------------------------------------------------------------
+# /v1/auth/me — access-token bearer auth
+# ---------------------------------------------------------------------------
+
+
+class TestV1Me:
+    def test_me_without_authorization_header_returns_401(self, client):
+        response = client.get("/v1/auth/me")
+        assert response.status_code == 401
+
+    def test_me_with_valid_access_token_returns_user(
+        self, client, mock_prisma, mock_user, mock_family_space
+    ):
+        membership = make_mock_membership(
+            userId=mock_user.id,
+            familySpaceId=mock_family_space.id,
+            familySpace=mock_family_space,
+        )
+        user_with_membership = make_mock_user(memberships=[membership], id=mock_user.id)
+        mock_prisma.user.find_unique = AsyncMock(return_value=user_with_membership)
+
+        access_token = tokens.mint_access_token(
+            user_id=mock_user.id, family_space_id=mock_family_space.id, role="member"
+        )
+
+        response = client.get(
+            "/v1/auth/me",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["user"]["id"] == mock_user.id
+
+    def test_me_rejects_expired_access_token(self, client):
+        past = datetime.now(timezone.utc) - timedelta(hours=2)
+        token = tokens.mint_access_token(
+            user_id="u1", family_space_id="fs1", role="member", now=past
+        )
+        response = client.get(
+            "/v1/auth/me", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# /v1/auth/refresh — happy path + every negative case the AC lists
+# ---------------------------------------------------------------------------
+
+
+class TestV1Refresh:
+    def _seed_active_row(
+        self, mock_prisma, *, secret: str, jti: str = "jti_active",
+        chain_id: str = "chain_a", remember_me: bool = False, user_id: str = "u1",
+        family_space_id: str = "fs1",
+    ):
+        token_hash = tokens._hash_refresh_secret(secret)
+        row = make_mock_refresh_token(
+            jti=jti,
+            tokenHash=token_hash,
+            chainId=chain_id,
+            rememberMe=remember_me,
+            userId=user_id,
+            familySpaceId=family_space_id,
+            expiresAt=datetime.now(timezone.utc) + timedelta(days=7),
+        )
+        mock_prisma.refreshtoken.find_unique = AsyncMock(return_value=row)
+        return row
+
+    def test_refresh_happy_path_rotates_and_returns_new_access_token(
+        self, client, mock_prisma, mock_user, mock_family_space
+    ):
+        secret = "secret-original"
+        row = self._seed_active_row(
+            mock_prisma, secret=secret, user_id=mock_user.id,
+            family_space_id=mock_family_space.id,
+        )
+        # Membership lookup post-rotation
+        membership = make_mock_membership(
+            userId=mock_user.id,
+            familySpaceId=mock_family_space.id,
+            familySpace=mock_family_space,
+        )
+        user_with_membership = make_mock_user(memberships=[membership], id=mock_user.id)
+        mock_prisma.user.find_unique = AsyncMock(return_value=user_with_membership)
+
+        tx_client = _refresh_tx_fixture(mock_prisma, row)
+
+        client.cookies.set(settings.refresh_cookie_name, f"{row.jti}.{secret}")
+        client.cookies.set(settings.csrf_cookie_name, "csrf-abc")
+
+        response = client.post(
+            "/v1/auth/refresh",
+            headers={"X-CSRF-Token": "csrf-abc"},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert "accessToken" in body
+        # New refresh + CSRF cookies set
+        cookie_header = response.headers.get("set-cookie", "")
+        assert settings.refresh_cookie_name in cookie_header
+        assert settings.csrf_cookie_name in cookie_header
+        # Rotation must have called update (mark old rotated) and create (new row)
+        tx_client.refreshtoken.update.assert_awaited_once()
+        tx_client.refreshtoken.create.assert_awaited_once()
+
+    def test_refresh_missing_csrf_returns_401(
+        self, client, mock_prisma, mock_user, mock_family_space
+    ):
+        row = self._seed_active_row(mock_prisma, secret="s", user_id=mock_user.id)
+        client.cookies.set(settings.refresh_cookie_name, f"{row.jti}.s")
+        client.cookies.set(settings.csrf_cookie_name, "csrf-abc")
+
+        # No X-CSRF-Token header
+        response = client.post("/v1/auth/refresh")
+        assert response.status_code == 401
+        assert response.json()["error"]["code"] == "UNAUTHORIZED"
+
+    def test_refresh_csrf_mismatch_returns_401(
+        self, client, mock_prisma, mock_user, mock_family_space
+    ):
+        row = self._seed_active_row(mock_prisma, secret="s", user_id=mock_user.id)
+        client.cookies.set(settings.refresh_cookie_name, f"{row.jti}.s")
+        client.cookies.set(settings.csrf_cookie_name, "csrf-cookie-value")
+
+        response = client.post(
+            "/v1/auth/refresh",
+            headers={"X-CSRF-Token": "different-value"},
+        )
+        assert response.status_code == 401
+
+    def test_refresh_missing_cookie_returns_401(self, client, mock_prisma):
+        client.cookies.set(settings.csrf_cookie_name, "x")
+        response = client.post("/v1/auth/refresh", headers={"X-CSRF-Token": "x"})
+        assert response.status_code == 401
+
+    def test_refresh_unknown_jti_returns_401(self, client, mock_prisma):
+        mock_prisma.refreshtoken.find_unique = AsyncMock(return_value=None)
+        client.cookies.set(settings.refresh_cookie_name, "ghost-jti.some-secret")
+        client.cookies.set(settings.csrf_cookie_name, "x")
+        response = client.post("/v1/auth/refresh", headers={"X-CSRF-Token": "x"})
+        assert response.status_code == 401
+
+    def test_refresh_wrong_secret_returns_401_without_chain_revoke(
+        self, client, mock_prisma
+    ):
+        # Active (non-rotated) row but caller has a wrong secret. This MUST NOT
+        # escalate to chain revocation — only reuse of an already-rotated jti
+        # triggers the chain-burn per the design doc.
+        self._seed_active_row(mock_prisma, secret="real-secret", jti="jti_x")
+        mock_prisma.refreshtoken.update_many = AsyncMock(return_value=None)
+
+        client.cookies.set(settings.refresh_cookie_name, "jti_x.WRONG-secret")
+        client.cookies.set(settings.csrf_cookie_name, "x")
+        response = client.post("/v1/auth/refresh", headers={"X-CSRF-Token": "x"})
+
+        assert response.status_code == 401
+        # No chain revocation triggered.
+        mock_prisma.refreshtoken.update_many.assert_not_called()
+
+    def test_refresh_reused_rotated_jti_revokes_whole_chain(
+        self, client, mock_prisma
+    ):
+        # Row was already rotated (revokedAt set, reason='rotated'). Replaying
+        # this cookie is the textbook reuse signal — chain gets revoked.
+        secret = "stolen-secret"
+        token_hash = tokens._hash_refresh_secret(secret)
+        revoked_row = make_mock_refresh_token(
+            jti="jti_old",
+            tokenHash=token_hash,
+            chainId="chain_compromised",
+            revokedAt=datetime.now(timezone.utc) - timedelta(minutes=1),
+            revokedReason=tokens.REVOKED_ROTATED,
+        )
+        mock_prisma.refreshtoken.find_unique = AsyncMock(return_value=revoked_row)
+        mock_prisma.refreshtoken.update_many = AsyncMock(return_value=None)
+
+        client.cookies.set(settings.refresh_cookie_name, f"jti_old.{secret}")
+        client.cookies.set(settings.csrf_cookie_name, "x")
+
+        response = client.post("/v1/auth/refresh", headers={"X-CSRF-Token": "x"})
+
+        assert response.status_code == 401
+        mock_prisma.refreshtoken.update_many.assert_awaited_once()
+        call_kwargs = mock_prisma.refreshtoken.update_many.await_args.kwargs
+        assert call_kwargs["where"]["chainId"] == "chain_compromised"
+        assert call_kwargs["data"]["revokedReason"] == tokens.REVOKED_REUSE_DETECTED
+
+    def test_refresh_reused_logout_jti_does_not_escalate(
+        self, client, mock_prisma
+    ):
+        # A row whose reason is 'logout' (or 'logout_all'/'reuse_detected') —
+        # replay returns 401 but does NOT trigger chain revoke.
+        secret = "s"
+        token_hash = tokens._hash_refresh_secret(secret)
+        row = make_mock_refresh_token(
+            jti="jti_loggedout",
+            tokenHash=token_hash,
+            chainId="chain_z",
+            revokedAt=datetime.now(timezone.utc) - timedelta(minutes=1),
+            revokedReason=tokens.REVOKED_LOGOUT,
+        )
+        mock_prisma.refreshtoken.find_unique = AsyncMock(return_value=row)
+        mock_prisma.refreshtoken.update_many = AsyncMock(return_value=None)
+
+        client.cookies.set(settings.refresh_cookie_name, f"jti_loggedout.{secret}")
+        client.cookies.set(settings.csrf_cookie_name, "x")
+
+        response = client.post("/v1/auth/refresh", headers={"X-CSRF-Token": "x"})
+
+        assert response.status_code == 401
+        mock_prisma.refreshtoken.update_many.assert_not_called()
+
+    def test_refresh_carries_remember_me_through_rotation(
+        self, client, mock_prisma, mock_user, mock_family_space
+    ):
+        secret = "rm-secret"
+        row = self._seed_active_row(
+            mock_prisma, secret=secret, jti="rm_jti",
+            chain_id="rm_chain", remember_me=True,
+            user_id=mock_user.id, family_space_id=mock_family_space.id,
+        )
+        membership = make_mock_membership(
+            userId=mock_user.id, familySpaceId=mock_family_space.id,
+            familySpace=mock_family_space,
+        )
+        user_with_membership = make_mock_user(memberships=[membership], id=mock_user.id)
+        mock_prisma.user.find_unique = AsyncMock(return_value=user_with_membership)
+
+        tx_client = _refresh_tx_fixture(mock_prisma, row)
+
+        client.cookies.set(settings.refresh_cookie_name, f"{row.jti}.{secret}")
+        client.cookies.set(settings.csrf_cookie_name, "csrf")
+        response = client.post("/v1/auth/refresh", headers={"X-CSRF-Token": "csrf"})
+
+        assert response.status_code == 200
+        # The new refresh row inherits rememberMe=True
+        create_kwargs = tx_client.refreshtoken.create.await_args.kwargs
+        assert create_kwargs["data"]["rememberMe"] is True
+        # And the cookie's Max-Age uses the extended TTL.
+        cookies_raw = response.headers.get("set-cookie", "")
+        assert str(settings.refresh_token_ttl_remember_seconds) in cookies_raw
+
+
+# ---------------------------------------------------------------------------
+# /v1/auth/logout — revokes the row, clears cookies
+# ---------------------------------------------------------------------------
+
+
+class TestV1Logout:
+    def test_logout_revokes_token_and_clears_cookies(self, client, mock_prisma):
+        mock_prisma.refreshtoken.update_many = AsyncMock(return_value=None)
+        client.cookies.set(settings.refresh_cookie_name, "jti_to_kill.some-secret")
+        response = client.post("/v1/auth/logout")
+
+        assert response.status_code == 204
+        mock_prisma.refreshtoken.update_many.assert_awaited_once()
+        call_kwargs = mock_prisma.refreshtoken.update_many.await_args.kwargs
+        assert call_kwargs["where"]["jti"] == "jti_to_kill"
+        assert call_kwargs["data"]["revokedReason"] == tokens.REVOKED_LOGOUT
+        # Both cookies cleared (Max-Age=0 in deletion)
+        cookie_header = response.headers.get("set-cookie", "")
+        assert settings.refresh_cookie_name in cookie_header
+        assert settings.csrf_cookie_name in cookie_header
+
+    def test_logout_without_refresh_cookie_still_returns_204(self, client, mock_prisma):
+        mock_prisma.refreshtoken.update_many = AsyncMock(return_value=None)
+        response = client.post("/v1/auth/logout")
+        assert response.status_code == 204
+        mock_prisma.refreshtoken.update_many.assert_not_called()
+
+    def test_logout_then_refresh_returns_401_without_chain_revoke(
+        self, client, mock_prisma
+    ):
+        # Sanity check on top of the unit-level logout test: a refresh
+        # attempt against a logged-out jti should fail with 401, not burn
+        # the chain (already covered by test_refresh_reused_logout_jti_does_not_escalate
+        # but exercising the end-to-end flow shape gives confidence the
+        # router wires reasons correctly).
+        secret = "s"
+        token_hash = tokens._hash_refresh_secret(secret)
+        row = make_mock_refresh_token(
+            jti="jti_after_logout",
+            tokenHash=token_hash,
+            revokedAt=datetime.now(timezone.utc),
+            revokedReason=tokens.REVOKED_LOGOUT,
+        )
+        mock_prisma.refreshtoken.find_unique = AsyncMock(return_value=row)
+        mock_prisma.refreshtoken.update_many = AsyncMock(return_value=None)
+        client.cookies.set(settings.refresh_cookie_name, f"{row.jti}.{secret}")
+        client.cookies.set(settings.csrf_cookie_name, "x")
+        response = client.post("/v1/auth/refresh", headers={"X-CSRF-Token": "x"})
+        assert response.status_code == 401
+        mock_prisma.refreshtoken.update_many.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Concurrency: parallel /refresh calls don't double-issue
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshConcurrency:
+    """The AC requires concurrent /refresh calls to not double-issue or lose
+    reuse detection. We can't meaningfully test that with the FastAPI test
+    client (single thread, single connection). Instead we exercise the router
+    function directly with a hand-rolled async-locking 'DB' that simulates
+    `SELECT … FOR UPDATE` so two coroutines race on the same jti."""
+
+    @pytest.mark.asyncio
+    async def test_two_concurrent_refreshes_only_one_succeeds(
+        self, mock_prisma, mock_user, mock_family_space, monkeypatch
+    ):
+        """Two concurrent /refresh callers race. The first to acquire the
+        SELECT…FOR UPDATE lock rotates and returns 200. The second blocks
+        on the lock, sees the row's revokedAt populated when it unblocks,
+        and bails out with 401 — without double-issuing a successor."""
+        from src.routers.v1.auth import refresh as refresh_handler
+        from fastapi.responses import JSONResponse
+        from fastapi import Response
+
+        secret = "race-secret"
+        jti = "race_jti"
+        token_hash = tokens._hash_refresh_secret(secret)
+        chain_id = "race_chain"
+
+        # Stateful row mutated as the first caller's transaction commits.
+        row_state = SimpleNamespace(
+            jti=jti, tokenHash=token_hash, chainId=chain_id,
+            rememberMe=False, userId=mock_user.id,
+            familySpaceId=mock_family_space.id,
+            expiresAt=datetime.now(timezone.utc) + timedelta(days=7),
+            revokedAt=None, revokedReason=None, ipAddress=None,
+            id="r1", rotatedFromJti=None,
+            issuedAt=datetime.now(timezone.utc), userAgent=None,
+        )
+
+        lock = asyncio.Lock()
+        mock_prisma.refreshtoken.find_unique = AsyncMock(return_value=row_state)
+        mock_prisma.refreshtoken.update_many = AsyncMock(return_value=None)
+
+        membership = make_mock_membership(
+            userId=mock_user.id, familySpaceId=mock_family_space.id,
+            familySpace=mock_family_space,
+        )
+        user_with_membership = make_mock_user(memberships=[membership], id=mock_user.id)
+        mock_prisma.user.find_unique = AsyncMock(return_value=user_with_membership)
+
+        rotation_count = {"value": 0}
+
+        class TxCtx:
+            def __init__(self):
+                self.refreshtoken = MagicMock()
+                self.refreshtoken.update = AsyncMock(side_effect=self._update)
+                self.refreshtoken.create = AsyncMock(return_value=None)
+                self.refreshtoken.find_unique = AsyncMock(side_effect=self._find_unique)
+                self.execute_raw = AsyncMock(side_effect=self._execute_raw)
+                self._holds_lock = False
+
+            async def _execute_raw(self, *_args, **_kwargs):
+                # Block until lock is free — mirrors SELECT … FOR UPDATE.
+                await lock.acquire()
+                self._holds_lock = True
+                # Yield once so the other coroutine has a chance to wake up
+                # and find itself blocked (deterministic interleaving).
+                await asyncio.sleep(0)
+                return 0
+
+            async def _find_unique(self, *args, **kwargs):
+                return row_state
+
+            async def _update(self, *args, **kwargs):
+                rotation_count["value"] += 1
+                row_state.revokedAt = datetime.now(timezone.utc)
+                row_state.revokedReason = tokens.REVOKED_ROTATED
+                return None
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                if self._holds_lock and lock.locked():
+                    lock.release()
+                return False
+
+        mock_prisma.tx = MagicMock(side_effect=lambda: TxCtx())
+
+        async def _make_call():
+            req = MagicMock()
+            req.cookies = {
+                settings.refresh_cookie_name: f"{jti}.{secret}",
+                settings.csrf_cookie_name: "csrf",
+            }
+            req.headers = {}
+            req.client = None
+            resp = Response()
+            return await refresh_handler(request=req, response=resp, x_csrf_token="csrf")
+
+        results = await asyncio.gather(_make_call(), _make_call())
+
+        # Exactly one rotation happened — the loser's tx-scope find_unique
+        # saw revokedAt != None and bailed out before calling update().
+        assert rotation_count["value"] == 1
+
+        # Loser returns a JSONResponse (401) directly; winner returns the
+        # AccessTokenResponse pydantic model (FastAPI wraps it for the wire).
+        success = [r for r in results if not isinstance(r, JSONResponse)]
+        failure = [r for r in results if isinstance(r, JSONResponse)]
+        assert len(success) == 1, f"expected 1 success, got {success}"
+        assert len(failure) == 1, f"expected 1 failure, got {failure}"
+        assert failure[0].status_code == 401

--- a/apps/api/tests/integration/test_auth_v1.py
+++ b/apps/api/tests/integration/test_auth_v1.py
@@ -165,9 +165,27 @@ class TestV1Signup:
 
 
 class TestV1Me:
-    def test_me_without_authorization_header_returns_401(self, client):
+    def test_me_without_authorization_header_returns_401_envelope(self, client):
         response = client.get("/v1/auth/me")
         assert response.status_code == 401
+        # Must use the canonical envelope, not FastAPI's default {"detail": ...}.
+        # The Phase 2 SPA keys off `error.code`.
+        body = response.json()
+        assert body == {"error": {"code": "UNAUTHORIZED", "message": "Unauthorized"}}
+
+    def test_me_with_invalid_bearer_token_returns_401_envelope(self, client):
+        response = client.get(
+            "/v1/auth/me", headers={"Authorization": "Bearer not-a-jwt"}
+        )
+        assert response.status_code == 401
+        assert response.json()["error"]["code"] == "UNAUTHORIZED"
+
+    def test_me_with_non_bearer_scheme_returns_401_envelope(self, client):
+        response = client.get(
+            "/v1/auth/me", headers={"Authorization": "Basic abc123"}
+        )
+        assert response.status_code == 401
+        assert response.json()["error"]["code"] == "UNAUTHORIZED"
 
     def test_me_with_valid_access_token_returns_user(
         self, client, mock_prisma, mock_user, mock_family_space

--- a/apps/api/tests/unit/test_tokens.py
+++ b/apps/api/tests/unit/test_tokens.py
@@ -1,0 +1,246 @@
+"""Unit tests for src/tokens.py — issuance, verification, rotation primitives,
+key-rotation overlap, and CSRF helpers."""
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import pytest
+
+from src import tokens
+from src.settings import settings
+
+
+# ---------------------------------------------------------------------------
+# Access tokens
+# ---------------------------------------------------------------------------
+
+
+class TestAccessTokenMintAndVerify:
+    def test_mint_returns_three_part_jwt_with_kid_header(self):
+        token = tokens.mint_access_token(
+            user_id="u1", family_space_id="fs1", role="member"
+        )
+        parts = token.split(".")
+        assert len(parts) == 3
+
+        header = jwt.get_unverified_header(token)
+        assert header["kid"] == settings.access_token_active_kid
+        assert header["alg"] == "HS256"
+
+    def test_verify_round_trip_returns_claims(self):
+        token = tokens.mint_access_token(
+            user_id="u1", family_space_id="fs1", role="owner"
+        )
+        claims = tokens.verify_access_token(token)
+        assert claims is not None
+        assert claims.sub == "u1"
+        assert claims.family_space_id == "fs1"
+        assert claims.role == "owner"
+        assert claims.epoch == settings.auth_epoch
+        assert claims.kid == settings.access_token_active_kid
+        # jti should be a hex uuid (32 chars)
+        assert len(claims.jti) == 32
+
+    def test_verify_returns_none_for_garbage(self):
+        assert tokens.verify_access_token("not.a.jwt") is None
+        assert tokens.verify_access_token("") is None
+
+    def test_verify_returns_none_for_expired_token(self):
+        past = datetime.now(timezone.utc) - timedelta(hours=2)
+        token = tokens.mint_access_token(
+            user_id="u1", family_space_id="fs1", role="member", now=past
+        )
+        # mint with `now` in the past makes exp also in the past
+        time.sleep(0)  # no-op; emphasizes that the mint set exp from `past`
+        assert tokens.verify_access_token(token) is None
+
+    def test_verify_rejects_token_with_lower_epoch(self, monkeypatch):
+        token = tokens.mint_access_token(
+            user_id="u1", family_space_id="fs1", role="member"
+        )
+        # Bump server's epoch — the issued token's epoch is now stale.
+        monkeypatch.setattr(settings, "auth_epoch", settings.auth_epoch + 1)
+        assert tokens.verify_access_token(token) is None
+
+    def test_verify_rejects_token_with_unknown_kid(self):
+        # Sign a token with a kid that isn't in the keys map.
+        payload = {
+            "sub": "u1",
+            "familySpaceId": "fs1",
+            "role": "member",
+            "epoch": settings.auth_epoch,
+            "iss": tokens.JWT_ISSUER,
+            "aud": settings.jwt_audience,
+            "iat": int(datetime.now(timezone.utc).timestamp()),
+            "exp": int((datetime.now(timezone.utc) + timedelta(minutes=5)).timestamp()),
+            "jti": "x",
+        }
+        bad = jwt.encode(payload, "irrelevant", algorithm="HS256", headers={"kid": "ghost"})
+        assert tokens.verify_access_token(bad) is None
+
+    def test_verify_rejects_wrong_audience(self):
+        # Sign with the right key but the wrong aud claim.
+        secret = settings.signing_keys[settings.access_token_active_kid]
+        payload = {
+            "sub": "u1",
+            "familySpaceId": "fs1",
+            "role": "member",
+            "epoch": settings.auth_epoch,
+            "iss": tokens.JWT_ISSUER,
+            "aud": "some-other-app",
+            "iat": int(datetime.now(timezone.utc).timestamp()),
+            "exp": int((datetime.now(timezone.utc) + timedelta(minutes=5)).timestamp()),
+            "jti": "x",
+        }
+        bad = jwt.encode(
+            payload, secret, algorithm="HS256",
+            headers={"kid": settings.access_token_active_kid},
+        )
+        assert tokens.verify_access_token(bad) is None
+
+
+class TestKeyRotationOverlap:
+    """During rotation, both the old and new kid live in `signing_keys`.
+    Tokens signed by either kid must verify until the old kid is removed."""
+
+    def test_token_signed_with_previous_kid_still_verifies(self, monkeypatch):
+        active_kid = settings.access_token_active_kid
+        active_secret = settings.signing_keys[active_kid]
+        previous_secret = "previous-rotation-secret-value"
+        rotation_keys = json.dumps({"v0": previous_secret, active_kid: active_secret})
+
+        monkeypatch.setattr(settings, "access_token_signing_keys", rotation_keys)
+
+        # Sign a token by hand with the previous kid.
+        payload = {
+            "sub": "u1",
+            "familySpaceId": "fs1",
+            "role": "member",
+            "epoch": settings.auth_epoch,
+            "iss": tokens.JWT_ISSUER,
+            "aud": settings.jwt_audience,
+            "iat": int(datetime.now(timezone.utc).timestamp()),
+            "exp": int((datetime.now(timezone.utc) + timedelta(minutes=5)).timestamp()),
+            "jti": "x",
+        }
+        legacy_token = jwt.encode(
+            payload, previous_secret, algorithm="HS256", headers={"kid": "v0"}
+        )
+        claims = tokens.verify_access_token(legacy_token)
+        assert claims is not None
+        assert claims.kid == "v0"
+        assert claims.sub == "u1"
+
+    def test_token_stops_verifying_after_old_kid_removed(self, monkeypatch):
+        # No "v0" in keys map => previous-kid tokens stop verifying.
+        previous_secret = "previous-rotation-secret-value"
+        monkeypatch.setattr(
+            settings, "access_token_signing_keys",
+            json.dumps({settings.access_token_active_kid: settings.jwt_secret}),
+        )
+        payload = {
+            "sub": "u1", "familySpaceId": "fs1", "role": "member",
+            "epoch": settings.auth_epoch,
+            "iss": tokens.JWT_ISSUER, "aud": settings.jwt_audience,
+            "iat": int(datetime.now(timezone.utc).timestamp()),
+            "exp": int((datetime.now(timezone.utc) + timedelta(minutes=5)).timestamp()),
+            "jti": "x",
+        }
+        stale = jwt.encode(payload, previous_secret, algorithm="HS256", headers={"kid": "v0"})
+        assert tokens.verify_access_token(stale) is None
+
+
+# ---------------------------------------------------------------------------
+# Refresh tokens
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshTokenIssuance:
+    def test_issue_returns_split_cookie_format(self):
+        issued = tokens.issue_refresh_token()
+        # `{jti}.{secret}` shape
+        assert "." in issued.cookie_value
+        parts = issued.cookie_value.split(".", 1)
+        assert parts[0] == issued.jti
+        assert parts[1] == issued.secret
+
+    def test_issue_uses_fresh_chain_when_none_provided(self):
+        a = tokens.issue_refresh_token()
+        b = tokens.issue_refresh_token()
+        assert a.chain_id != b.chain_id
+
+    def test_issue_carries_chain_when_provided(self):
+        chain = "fixed-chain-id"
+        issued = tokens.issue_refresh_token(chain_id=chain)
+        assert issued.chain_id == chain
+
+    def test_remember_me_extends_expiry(self):
+        short = tokens.issue_refresh_token(remember_me=False)
+        long_ = tokens.issue_refresh_token(remember_me=True)
+        # Difference roughly equals the configured TTL gap (30d - 7d).
+        delta = long_.expires_at - short.expires_at
+        expected = (
+            settings.refresh_token_ttl_remember_seconds
+            - settings.refresh_token_ttl_default_seconds
+        )
+        # Allow 5s for the two issue calls happening at slightly different times.
+        assert abs(delta.total_seconds() - expected) < 5
+
+    def test_token_hash_matches_via_constant_time_eq(self):
+        issued = tokens.issue_refresh_token()
+        assert tokens.constant_time_hash_eq(issued.token_hash, issued.secret) is True
+        assert tokens.constant_time_hash_eq(issued.token_hash, "wrong-secret") is False
+
+    def test_two_issues_with_same_secret_input_produce_same_hash(self):
+        # Determinism check — HMAC with a fixed pepper is deterministic.
+        h1 = tokens._hash_refresh_secret("the-same-secret")
+        h2 = tokens._hash_refresh_secret("the-same-secret")
+        assert h1 == h2
+
+    def test_changing_pepper_changes_hash(self, monkeypatch):
+        secret = "abc123"
+        h1 = tokens._hash_refresh_secret(secret)
+        monkeypatch.setattr(settings, "refresh_pepper", "different-pepper-value")
+        h2 = tokens._hash_refresh_secret(secret)
+        assert h1 != h2
+
+
+class TestParseRefreshCookie:
+    def test_parse_well_formed(self):
+        out = tokens.parse_refresh_cookie("abc.xyz")
+        assert out == ("abc", "xyz")
+
+    def test_parse_handles_secret_containing_dot(self):
+        # token_urlsafe never produces dots, but the parser should be safe
+        # regardless: only the FIRST dot splits jti from secret.
+        out = tokens.parse_refresh_cookie("jti.part1.part2")
+        assert out == ("jti", "part1.part2")
+
+    @pytest.mark.parametrize("value", ["", ".", "no-dot", ".onlysecret", "onlyjti."])
+    def test_parse_rejects_malformed(self, value):
+        assert tokens.parse_refresh_cookie(value) is None
+
+
+# ---------------------------------------------------------------------------
+# CSRF helpers
+# ---------------------------------------------------------------------------
+
+
+class TestCsrfHelpers:
+    def test_mint_returns_url_safe_string(self):
+        a = tokens.mint_csrf_token()
+        b = tokens.mint_csrf_token()
+        assert a != b
+        assert len(a) >= 32
+
+    def test_match_requires_both_present(self):
+        assert tokens.csrf_token_matches(None, "x") is False
+        assert tokens.csrf_token_matches("x", None) is False
+        assert tokens.csrf_token_matches("", "") is False
+
+    def test_match_only_when_equal(self):
+        assert tokens.csrf_token_matches("same", "same") is True
+        assert tokens.csrf_token_matches("same", "Same") is False

--- a/prisma/migrations/20260427000000_add_refresh_tokens/migration.sql
+++ b/prisma/migrations/20260427000000_add_refresh_tokens/migration.sql
@@ -1,0 +1,33 @@
+-- Refresh-token store for FastAPI Phase 1 token auth
+-- Design: docs/research/refresh-token-store.md
+-- Issue: https://github.com/wnorowskie/family-recipe/issues/35
+
+CREATE TABLE "refresh_tokens" (
+  "id" TEXT PRIMARY KEY,
+  "user_id" TEXT NOT NULL,
+  "family_space_id" TEXT NOT NULL,
+  "jti" TEXT NOT NULL,
+  "token_hash" TEXT NOT NULL,
+  "chain_id" TEXT NOT NULL,
+  "rotated_from_jti" TEXT,
+  "remember_me" BOOLEAN NOT NULL DEFAULT FALSE,
+  "issued_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "expires_at" TIMESTAMP(3) NOT NULL,
+  "revoked_at" TIMESTAMP(3),
+  "revoked_reason" TEXT,
+  "user_agent" TEXT,
+  "ip_address" TEXT
+);
+
+ALTER TABLE "refresh_tokens"
+  ADD CONSTRAINT "refresh_tokens_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT "refresh_tokens_family_space_id_fkey"
+    FOREIGN KEY ("family_space_id") REFERENCES "family_spaces"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+CREATE UNIQUE INDEX "refresh_tokens_jti_key" ON "refresh_tokens" ("jti");
+CREATE INDEX "refresh_tokens_user_id_revoked_at_idx" ON "refresh_tokens" ("user_id", "revoked_at");
+CREATE INDEX "refresh_tokens_chain_id_idx" ON "refresh_tokens" ("chain_id");
+CREATE INDEX "refresh_tokens_family_space_id_idx" ON "refresh_tokens" ("family_space_id");
+CREATE INDEX "refresh_tokens_expires_at_idx" ON "refresh_tokens" ("expires_at");
+CREATE INDEX "refresh_tokens_revoked_at_idx" ON "refresh_tokens" ("revoked_at");

--- a/prisma/schema.postgres.node.prisma
+++ b/prisma/schema.postgres.node.prisma
@@ -31,6 +31,7 @@ model User {
   feedbackSubmissions FeedbackSubmission[]
   receivedNotifications Notification[] @relation("NotificationRecipient")
   sentNotifications     Notification[] @relation("NotificationActor")
+  refreshTokens         RefreshToken[]
 
   @@map("users")
 }
@@ -48,6 +49,7 @@ model FamilySpace {
   posts           Post[]
   feedbackSubmissions FeedbackSubmission[]
   notifications   Notification[]
+  refreshTokens   RefreshToken[]
 
   @@map("family_spaces")
 }
@@ -293,4 +295,33 @@ model Notification {
   @@map("notifications")
   @@index([recipientId, readAt, createdAt], map: "notifications_recipient_read_idx")
   @@index([familySpaceId, postId], map: "notifications_family_post_idx")
+}
+
+// RefreshToken stores rotating refresh tokens for the FastAPI token-auth flow
+// Design: docs/research/refresh-token-store.md
+model RefreshToken {
+  id             String    @id @default(cuid())
+  userId         String    @map("user_id")
+  familySpaceId  String    @map("family_space_id")
+  jti            String    @unique
+  tokenHash      String    @map("token_hash")
+  chainId        String    @map("chain_id")
+  rotatedFromJti String?   @map("rotated_from_jti")
+  rememberMe     Boolean   @default(false) @map("remember_me")
+  issuedAt       DateTime  @default(now()) @map("issued_at")
+  expiresAt      DateTime  @map("expires_at")
+  revokedAt      DateTime? @map("revoked_at")
+  revokedReason  String?   @map("revoked_reason")
+  userAgent      String?   @map("user_agent")
+  ipAddress      String?   @map("ip_address")
+
+  user        User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  familySpace FamilySpace @relation(fields: [familySpaceId], references: [id], onDelete: Cascade)
+
+  @@map("refresh_tokens")
+  @@index([userId, revokedAt])
+  @@index([chainId])
+  @@index([familySpaceId])
+  @@index([expiresAt])
+  @@index([revokedAt])
 }

--- a/prisma/schema.postgres.prisma
+++ b/prisma/schema.postgres.prisma
@@ -35,6 +35,7 @@ model User {
   feedbackSubmissions   FeedbackSubmission[]
   receivedNotifications Notification[]       @relation("NotificationRecipient")
   sentNotifications     Notification[]       @relation("NotificationActor")
+  refreshTokens         RefreshToken[]
 
   @@map("users")
 }
@@ -52,6 +53,7 @@ model FamilySpace {
   posts               Post[]
   feedbackSubmissions FeedbackSubmission[]
   notifications       Notification[]
+  refreshTokens       RefreshToken[]
 
   @@map("family_spaces")
 }
@@ -297,4 +299,33 @@ model Notification {
   @@index([recipientId, readAt, createdAt], map: "notifications_recipient_read_idx")
   @@index([familySpaceId, postId], map: "notifications_family_post_idx")
   @@map("notifications")
+}
+
+// RefreshToken stores rotating refresh tokens for the FastAPI token-auth flow
+// Design: docs/research/refresh-token-store.md
+model RefreshToken {
+  id             String    @id @default(cuid())
+  userId         String    @map("user_id")
+  familySpaceId  String    @map("family_space_id")
+  jti            String    @unique
+  tokenHash      String    @map("token_hash")
+  chainId        String    @map("chain_id")
+  rotatedFromJti String?   @map("rotated_from_jti")
+  rememberMe     Boolean   @default(false) @map("remember_me")
+  issuedAt       DateTime  @default(now()) @map("issued_at")
+  expiresAt      DateTime  @map("expires_at")
+  revokedAt      DateTime? @map("revoked_at")
+  revokedReason  String?   @map("revoked_reason")
+  userAgent      String?   @map("user_agent")
+  ipAddress      String?   @map("ip_address")
+
+  user        User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  familySpace FamilySpace @relation(fields: [familySpaceId], references: [id], onDelete: Cascade)
+
+  @@index([userId, revokedAt])
+  @@index([chainId])
+  @@index([familySpaceId])
+  @@index([expiresAt])
+  @@index([revokedAt])
+  @@map("refresh_tokens")
 }


### PR DESCRIPTION
Closes #35.

## Summary
- New `/v1/auth/{login,signup,refresh,logout,me}` endpoints serve short-lived access JWTs alongside an httpOnly rotating `refresh_token` cookie + non-httpOnly `csrf_token` cookie. Legacy `/auth/*` (session-cookie) endpoints stay in place — both paths run in parallel until Phase 2 cuts the frontend over.
- Refresh tokens are `{jti}.{secret}` opaque strings; secrets are hashed with HMAC-SHA-256 + a server-side pepper (`REFRESH_PEPPER`). Every `/refresh` rotates the row inside a `SELECT … FOR UPDATE` transaction so concurrent callers can't double-issue.
- Replay of an already-rotated `jti` revokes the **whole chain** (`chain_id`) — keeps the user's other devices alive. Replay of a `'logout'`/`'reuse_detected'` row returns 401 without escalating, per the design doc's narrower-case rule.
- Access tokens carry a `kid` header (signing-key rotation overlap) and `epoch` claim (`AUTH_EPOCH` env — bumping it invalidates every live access token without any DB writes).
- Schema/rotation design follows [docs/research/refresh-token-store.md](docs/research/refresh-token-store.md) (research ticket #40).

## Files of note
- [apps/api/src/tokens.py](apps/api/src/tokens.py) — pure issuance/verify primitives + CSRF helpers
- [apps/api/src/routers/v1/auth.py](apps/api/src/routers/v1/auth.py) — handlers
- [apps/api/src/dependencies_v1.py](apps/api/src/dependencies_v1.py) — Bearer-token `get_current_user_v1` (separate module so a single import site doesn't accidentally accept both auth modes)
- [apps/api/src/cookies.py](apps/api/src/cookies.py) — refresh + CSRF cookie helpers (env-aware Secure/SameSite/Domain)
- [prisma/migrations/20260427000000_add_refresh_tokens/migration.sql](prisma/migrations/20260427000000_add_refresh_tokens/migration.sql) + matching schema edits in both `prisma/schema.postgres*.prisma`
- [apps/api/openapi.snapshot.json](apps/api/openapi.snapshot.json) — regenerated; reviewers should treat the diff as the contract changelog

## Test plan
- [x] `pytest` — 352/352 pass (316 baseline FastAPI + 26 new unit + 19 new integration + 1 concurrency)
  - Unit tests cover: access-token mint/verify with `kid`/`epoch`, key-rotation overlap window, expired/wrong-aud/unknown-kid rejection, refresh issuance + HMAC determinism, parse_refresh_cookie edge cases, CSRF helpers
  - Integration tests cover: login/signup/me happy path, missing/mismatched CSRF, malformed/unknown jti, wrong secret without chain revoke, rotated-jti reuse → chain burn, logout-reason-replay does not escalate, rememberMe carried through rotation, logout revokes + clears cookies
  - Concurrency test: two parallel refreshes serialize on a fake `SELECT … FOR UPDATE` lock; exactly one rotates, the other gets 401 — no double-issue
- [x] `npm test` — 994/994 pass (no regression in Next.js suite)
- [x] `npm run lint` + `npm run type-check` — clean
- [x] `ruff check` — clean
- [x] `npm run db:drift-check` — both Postgres schemas match the migration history
- [x] **Live FastAPI smoke** (uvicorn against the sandbox DB):
  - login → `/v1/auth/me` with Bearer → 200
  - `/v1/auth/me` without token → 401
  - `/v1/auth/refresh` rotates access token (new value differs from original)
  - `/v1/auth/refresh` without `X-CSRF-Token` → 401
  - `/v1/auth/logout` → 204
  - **post-logout cookie replay** → 401, no chain escalation
  - **rotated-cookie replay** → 401 "Refresh token reuse detected", chain revoked (next refresh of the active cookie also 401)
- [ ] mypy — deferred to CI's `api-ci.yml` job; local mypy stalls on this venv (saved to memory for future sessions)

## What's NOT in this PR
- Frontend cutover to the new endpoints — that's Phase 2 (#36).
- Daily refresh-token cleanup cron — research doc calls for it but it's a separate Cloud Scheduler job; can land in its own ticket once we have a baseline of real rows.
- `REFRESH_PEPPER` provisioning in Secret Manager / Terraform — falls back to `JWT_SECRET` in non-prod; production fail-fast guard is in place but the actual GSM secret + Cloud Run env wiring is a deploy-side change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)