### PR TITLE
feat: FastAPI migration — Phase 2, frontend auth migration to tokens (#36)

### DIFF
--- a/__tests__/unit/api/auth/bootstrap.route.test.ts
+++ b/__tests__/unit/api/auth/bootstrap.route.test.ts
@@ -1,0 +1,215 @@
+import { NextRequest } from 'next/server';
+
+import { POST } from '@/app/api/auth/bootstrap/route';
+
+jest.mock('@/lib/logger', () => ({
+  logError: jest.fn(),
+}));
+
+const fixtureUser = {
+  id: 'user-1',
+  name: 'Test User',
+  email: 'test@example.com',
+  username: 'testuser',
+  emailOrUsername: 'test@example.com',
+  avatarUrl: null,
+  role: 'member',
+  familySpaceId: 'family-1',
+  familySpaceName: 'Test Family',
+};
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  });
+}
+
+function buildRequest(headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest('http://localhost:3000/api/auth/bootstrap', {
+    method: 'POST',
+    headers,
+  });
+}
+
+describe('POST /api/auth/bootstrap', () => {
+  const originalFetch = global.fetch;
+  const originalBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'http://api.local';
+  });
+
+  afterEach(() => {
+    if (originalBaseUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_API_BASE_URL;
+    } else {
+      process.env.NEXT_PUBLIC_API_BASE_URL = originalBaseUrl;
+    }
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('returns 500 when NEXT_PUBLIC_API_BASE_URL is unset', async () => {
+    delete process.env.NEXT_PUBLIC_API_BASE_URL;
+
+    const response = await POST(buildRequest({ cookie: 'csrf_token=x' }));
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error.code).toBe('INTERNAL_ERROR');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when no cookies are present', async () => {
+    const response = await POST(buildRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error.code).toBe('UNAUTHORIZED');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when csrf_token cookie is missing', async () => {
+    const response = await POST(buildRequest({ cookie: 'refresh_token=abc' }));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('forwards cookies and CSRF header to /v1/auth/refresh', async () => {
+    const refreshSetCookie = [
+      'refresh_token=new.cookie.value; Path=/; HttpOnly; SameSite=Lax',
+      'csrf_token=new-csrf; Path=/; SameSite=Lax',
+    ];
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ accessToken: 'access-1' }), {
+          status: 200,
+          headers: [
+            ['content-type', 'application/json'],
+            ['set-cookie', refreshSetCookie[0]],
+            ['set-cookie', refreshSetCookie[1]],
+          ],
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse({ user: fixtureUser }));
+
+    const response = await POST(
+      buildRequest({ cookie: 'refresh_token=opaque; csrf_token=csrf-abc' })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ accessToken: 'access-1', user: fixtureUser });
+
+    const refreshCall = fetchMock.mock.calls[0];
+    expect(refreshCall[0]).toBe('http://api.local/v1/auth/refresh');
+    expect(refreshCall[1].headers.Cookie).toBe(
+      'refresh_token=opaque; csrf_token=csrf-abc'
+    );
+    expect(refreshCall[1].headers['X-CSRF-Token']).toBe('csrf-abc');
+
+    const meCall = fetchMock.mock.calls[1];
+    expect(meCall[0]).toBe('http://api.local/v1/auth/me');
+    expect(meCall[1].headers.Authorization).toBe('Bearer access-1');
+  });
+
+  it('forwards rotated Set-Cookie headers from /v1/auth/refresh', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ accessToken: 'access-1' }), {
+          status: 200,
+          headers: [
+            ['content-type', 'application/json'],
+            ['set-cookie', 'refresh_token=rotated; Path=/; HttpOnly'],
+            ['set-cookie', 'csrf_token=rotated-csrf; Path=/'],
+          ],
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse({ user: fixtureUser }));
+
+    const response = await POST(
+      buildRequest({ cookie: 'refresh_token=opaque; csrf_token=csrf-abc' })
+    );
+
+    expect(response.status).toBe(200);
+    const setCookies = response.headers.getSetCookie();
+    expect(setCookies).toContain('refresh_token=rotated; Path=/; HttpOnly');
+    expect(setCookies).toContain('csrf_token=rotated-csrf; Path=/');
+  });
+
+  it('returns 401 when /v1/auth/refresh returns non-2xx', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'reuse' }), {
+        status: 401,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+
+    const response = await POST(
+      buildRequest({ cookie: 'refresh_token=opaque; csrf_token=csrf-abc' })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error.code).toBe('UNAUTHORIZED');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 401 when refresh returns malformed body (no accessToken)', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ wrong: 'shape' }));
+
+    const response = await POST(
+      buildRequest({ cookie: 'refresh_token=opaque; csrf_token=csrf-abc' })
+    );
+
+    expect(response.status).toBe(401);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 401 when /v1/auth/me rejects the access token', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ accessToken: 'access-1' }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 'invalid' }), { status: 401 })
+      );
+
+    const response = await POST(
+      buildRequest({ cookie: 'refresh_token=opaque; csrf_token=csrf-abc' })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('returns 502 when /v1/auth/refresh network call fails', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('connection refused'));
+
+    const response = await POST(
+      buildRequest({ cookie: 'refresh_token=opaque; csrf_token=csrf-abc' })
+    );
+
+    expect(response.status).toBe(502);
+  });
+
+  it('returns 502 when /v1/auth/me network call fails', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ accessToken: 'access-1' }))
+      .mockRejectedValueOnce(new Error('connection refused'));
+
+    const response = await POST(
+      buildRequest({ cookie: 'refresh_token=opaque; csrf_token=csrf-abc' })
+    );
+
+    expect(response.status).toBe(502);
+  });
+});

--- a/__tests__/unit/lib/apiClient.test.ts
+++ b/__tests__/unit/lib/apiClient.test.ts
@@ -1,8 +1,10 @@
 import {
   apiClient,
   ApiError,
-  setAccessTokenProvider,
   clearAccessTokenProvider,
+  clearRefreshHooks,
+  setAccessTokenProvider,
+  setRefreshHooks,
 } from '@/lib/apiClient';
 import { API_ERROR_CODES } from '@/lib/apiErrors';
 
@@ -34,6 +36,7 @@ describe('apiClient', () => {
       process.env.NEXT_PUBLIC_API_BASE_URL = originalBaseUrl;
     }
     clearAccessTokenProvider();
+    clearRefreshHooks();
   });
 
   afterAll(() => {
@@ -255,6 +258,237 @@ describe('apiClient', () => {
       const data = await apiClient.del('/api/posts/1');
 
       expect(data).toBeUndefined();
+    });
+  });
+
+  describe('refresh-and-retry on 401', () => {
+    const originalDocument = (global as { document?: unknown }).document;
+
+    function setCookie(value: string): void {
+      Object.defineProperty(global, 'document', {
+        value: { cookie: value },
+        configurable: true,
+        writable: true,
+      });
+    }
+
+    afterEach(() => {
+      if (originalDocument === undefined) {
+        delete (global as { document?: unknown }).document;
+      } else {
+        Object.defineProperty(global, 'document', {
+          value: originalDocument,
+          configurable: true,
+          writable: true,
+        });
+      }
+    });
+
+    it('attempts a single refresh on 401 and retries the original request', async () => {
+      setCookie('csrf_token=csrf-abc');
+      const onRefreshed = jest.fn();
+      const onRefreshFailed = jest.fn();
+      setRefreshHooks({ onRefreshed, onRefreshFailed });
+
+      fetchMock
+        .mockResolvedValueOnce(
+          jsonResponse({ error: { code: 'UNAUTHORIZED' } }, { status: 401 })
+        )
+        .mockResolvedValueOnce(jsonResponse({ accessToken: 'new-token' }))
+        .mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+      const data = await apiClient.get<{ ok: boolean }>('/api/timeline');
+
+      expect(data).toEqual({ ok: true });
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(fetchMock.mock.calls[1][0]).toBe('/v1/auth/refresh');
+      expect(fetchMock.mock.calls[1][1]?.headers).toEqual(
+        expect.objectContaining({ 'X-CSRF-Token': 'csrf-abc' })
+      );
+      expect(onRefreshed).toHaveBeenCalledWith('new-token');
+      expect(onRefreshFailed).not.toHaveBeenCalled();
+    });
+
+    it('throws the original 401 and calls onRefreshFailed when refresh returns non-2xx', async () => {
+      setCookie('csrf_token=csrf-abc');
+      const onRefreshed = jest.fn();
+      const onRefreshFailed = jest.fn();
+      setRefreshHooks({ onRefreshed, onRefreshFailed });
+
+      fetchMock
+        .mockResolvedValueOnce(
+          jsonResponse({ error: { code: 'UNAUTHORIZED' } }, { status: 401 })
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({ error: { code: 'UNAUTHORIZED' } }, { status: 401 })
+        );
+
+      await expect(apiClient.get('/api/timeline')).rejects.toMatchObject({
+        status: 401,
+        code: API_ERROR_CODES.UNAUTHORIZED,
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(onRefreshed).not.toHaveBeenCalled();
+      expect(onRefreshFailed).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not loop when the retried request also returns 401', async () => {
+      setCookie('csrf_token=csrf-abc');
+      setRefreshHooks({ onRefreshed: jest.fn(), onRefreshFailed: jest.fn() });
+
+      fetchMock
+        .mockResolvedValueOnce(
+          jsonResponse({ error: { code: 'UNAUTHORIZED' } }, { status: 401 })
+        )
+        .mockResolvedValueOnce(jsonResponse({ accessToken: 'new-token' }))
+        .mockResolvedValueOnce(
+          jsonResponse({ error: { code: 'UNAUTHORIZED' } }, { status: 401 })
+        );
+
+      await expect(apiClient.get('/api/timeline')).rejects.toMatchObject({
+        status: 401,
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('dedups concurrent 401s into a single refresh call', async () => {
+      setCookie('csrf_token=csrf-abc');
+      setRefreshHooks({ onRefreshed: jest.fn(), onRefreshFailed: jest.fn() });
+
+      fetchMock.mockImplementation((url: string) => {
+        if (url === '/v1/auth/refresh') {
+          return Promise.resolve(jsonResponse({ accessToken: 'new-token' }));
+        }
+        // Each non-refresh URL: first call 401, second call 200.
+        const callsForUrl = fetchMock.mock.calls.filter(
+          ([u]) => u === url
+        ).length;
+        if (callsForUrl === 1) {
+          return Promise.resolve(
+            jsonResponse({ error: { code: 'UNAUTHORIZED' } }, { status: 401 })
+          );
+        }
+        return Promise.resolve(jsonResponse({ url }));
+      });
+
+      const [a, b] = await Promise.all([
+        apiClient.get<{ url: string }>('/api/a'),
+        apiClient.get<{ url: string }>('/api/b'),
+      ]);
+
+      expect(a).toEqual({ url: '/api/a' });
+      expect(b).toEqual({ url: '/api/b' });
+      const refreshCalls = fetchMock.mock.calls.filter(
+        ([url]) => url === '/v1/auth/refresh'
+      );
+      expect(refreshCalls).toHaveLength(1);
+    });
+
+    it('does not attempt refresh when the failing request is /v1/auth/refresh itself', async () => {
+      setCookie('csrf_token=csrf-abc');
+      const onRefreshed = jest.fn();
+      const onRefreshFailed = jest.fn();
+      setRefreshHooks({ onRefreshed, onRefreshFailed });
+
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ error: { code: 'UNAUTHORIZED' } }, { status: 401 })
+      );
+
+      await expect(apiClient.post('/v1/auth/refresh')).rejects.toMatchObject({
+        status: 401,
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(onRefreshed).not.toHaveBeenCalled();
+      expect(onRefreshFailed).not.toHaveBeenCalled();
+    });
+
+    it('does not attempt refresh when the failing request is /v1/auth/login', async () => {
+      setCookie('csrf_token=csrf-abc');
+      setRefreshHooks({ onRefreshed: jest.fn(), onRefreshFailed: jest.fn() });
+
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ error: { code: 'UNAUTHORIZED' } }, { status: 401 })
+      );
+
+      await expect(
+        apiClient.post('/v1/auth/login', {
+          body: { emailOrUsername: 'x', password: 'y' },
+        })
+      ).rejects.toMatchObject({ status: 401 });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not attempt refresh on 429 (rate limit)', async () => {
+      setCookie('csrf_token=csrf-abc');
+      const onRefreshed = jest.fn();
+      const onRefreshFailed = jest.fn();
+      setRefreshHooks({ onRefreshed, onRefreshFailed });
+
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse(
+          { error: { code: 'RATE_LIMIT_EXCEEDED' } },
+          { status: 429 }
+        )
+      );
+
+      await expect(apiClient.get('/api/timeline')).rejects.toMatchObject({
+        status: 429,
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(onRefreshed).not.toHaveBeenCalled();
+      expect(onRefreshFailed).not.toHaveBeenCalled();
+    });
+
+    it('does not attempt refresh when no hooks are registered', async () => {
+      setCookie('csrf_token=csrf-abc');
+
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ error: { code: 'UNAUTHORIZED' } }, { status: 401 })
+      );
+
+      await expect(apiClient.get('/api/timeline')).rejects.toMatchObject({
+        status: 401,
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('omits the X-CSRF-Token header when the cookie is absent', async () => {
+      setCookie('');
+      setRefreshHooks({ onRefreshed: jest.fn(), onRefreshFailed: jest.fn() });
+
+      fetchMock
+        .mockResolvedValueOnce(
+          jsonResponse({ error: { code: 'UNAUTHORIZED' } }, { status: 401 })
+        )
+        .mockResolvedValueOnce(jsonResponse({ accessToken: 'new-token' }))
+        .mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+      await apiClient.get('/api/timeline');
+
+      const refreshHeaders = fetchMock.mock.calls[1][1]?.headers as Record<
+        string,
+        string
+      >;
+      expect(refreshHeaders).not.toHaveProperty('X-CSRF-Token');
+    });
+
+    it('treats a malformed refresh response (no accessToken) as a failure', async () => {
+      setCookie('csrf_token=csrf-abc');
+      const onRefreshed = jest.fn();
+      const onRefreshFailed = jest.fn();
+      setRefreshHooks({ onRefreshed, onRefreshFailed });
+
+      fetchMock
+        .mockResolvedValueOnce(
+          jsonResponse({ error: { code: 'UNAUTHORIZED' } }, { status: 401 })
+        )
+        .mockResolvedValueOnce(jsonResponse({ wrongField: 'oops' }));
+
+      await expect(apiClient.get('/api/timeline')).rejects.toMatchObject({
+        status: 401,
+      });
+      expect(onRefreshed).not.toHaveBeenCalled();
+      expect(onRefreshFailed).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/__tests__/unit/lib/auth/bootstrapFromCookies.test.ts
+++ b/__tests__/unit/lib/auth/bootstrapFromCookies.test.ts
@@ -110,6 +110,32 @@ describe('bootstrapFromCookies helpers', () => {
       expect(result).toEqual({ ok: false, reason: 'SESSION_INVALID' });
     });
 
+    it('returns SESSION_INVALID when user object lacks required fields', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse({ user: {} }));
+
+      const result = await fetchSessionUser('refresh_token=x; csrf_token=y');
+
+      expect(result).toEqual({ ok: false, reason: 'SESSION_INVALID' });
+    });
+
+    it('returns SESSION_INVALID when user.id is missing or non-string', async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({
+          user: {
+            name: 'X',
+            email: 'x@y',
+            username: 'x',
+            role: 'member',
+            familySpaceId: 'f',
+          },
+        })
+      );
+
+      const result = await fetchSessionUser('refresh_token=x; csrf_token=y');
+
+      expect(result).toEqual({ ok: false, reason: 'SESSION_INVALID' });
+    });
+
     it('returns NETWORK on fetch error', async () => {
       fetchMock.mockRejectedValueOnce(new Error('connection refused'));
 
@@ -220,6 +246,18 @@ describe('bootstrapFromCookies helpers', () => {
       fetchMock
         .mockResolvedValueOnce(jsonResponse({ accessToken: 'tok' }))
         .mockResolvedValueOnce(jsonResponse({ wrong: 'shape' }));
+
+      const result = await bootstrapAccessToken(
+        'refresh_token=opaque; csrf_token=csrf-abc'
+      );
+
+      expect(result).toEqual({ ok: false, reason: 'ME_INVALID' });
+    });
+
+    it('returns ME_INVALID when user object lacks required fields', async () => {
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ accessToken: 'tok' }))
+        .mockResolvedValueOnce(jsonResponse({ user: {} }));
 
       const result = await bootstrapAccessToken(
         'refresh_token=opaque; csrf_token=csrf-abc'

--- a/__tests__/unit/lib/auth/bootstrapFromCookies.test.ts
+++ b/__tests__/unit/lib/auth/bootstrapFromCookies.test.ts
@@ -1,0 +1,264 @@
+import {
+  bootstrapAccessToken,
+  fetchSessionUser,
+} from '@/lib/auth/bootstrapFromCookies';
+
+jest.mock('@/lib/logger', () => ({
+  logError: jest.fn(),
+}));
+
+const fixtureUser = {
+  id: 'user-1',
+  name: 'Test User',
+  email: 'test@example.com',
+  username: 'testuser',
+  emailOrUsername: 'test@example.com',
+  avatarUrl: null,
+  role: 'member',
+  familySpaceId: 'family-1',
+  familySpaceName: 'Test Family',
+};
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  });
+}
+
+describe('bootstrapFromCookies helpers', () => {
+  const originalFetch = global.fetch;
+  const originalBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'http://api.local';
+  });
+
+  afterEach(() => {
+    if (originalBaseUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_API_BASE_URL;
+    } else {
+      process.env.NEXT_PUBLIC_API_BASE_URL = originalBaseUrl;
+    }
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe('fetchSessionUser (non-rotating SSR path)', () => {
+    it('returns CONFIG when NEXT_PUBLIC_API_BASE_URL is unset', async () => {
+      delete process.env.NEXT_PUBLIC_API_BASE_URL;
+
+      const result = await fetchSessionUser('refresh_token=x; csrf_token=y');
+
+      expect(result).toEqual({ ok: false, reason: 'CONFIG' });
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('returns MISSING_COOKIES when no cookie header', async () => {
+      const result = await fetchSessionUser(null);
+
+      expect(result).toEqual({ ok: false, reason: 'MISSING_COOKIES' });
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('returns MISSING_COOKIES when csrf_token cookie is absent', async () => {
+      const result = await fetchSessionUser('refresh_token=opaque');
+
+      expect(result).toEqual({ ok: false, reason: 'MISSING_COOKIES' });
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('hits /v1/auth/session with cookies and CSRF header', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse({ user: fixtureUser }));
+
+      const result = await fetchSessionUser(
+        'refresh_token=opaque; csrf_token=csrf-abc'
+      );
+
+      expect(result).toEqual({ ok: true, user: fixtureUser });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe('http://api.local/v1/auth/session');
+      expect(init.method).toBe('GET');
+      expect(init.headers.Cookie).toBe(
+        'refresh_token=opaque; csrf_token=csrf-abc'
+      );
+      expect(init.headers['X-CSRF-Token']).toBe('csrf-abc');
+    });
+
+    it('returns SESSION_FAILED on non-2xx', async () => {
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 'no' }), { status: 401 })
+      );
+
+      const result = await fetchSessionUser('refresh_token=x; csrf_token=y');
+
+      expect(result).toEqual({ ok: false, reason: 'SESSION_FAILED' });
+    });
+
+    it('returns SESSION_INVALID on malformed body (no user field)', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse({ wrong: 'shape' }));
+
+      const result = await fetchSessionUser('refresh_token=x; csrf_token=y');
+
+      expect(result).toEqual({ ok: false, reason: 'SESSION_INVALID' });
+    });
+
+    it('returns NETWORK on fetch error', async () => {
+      fetchMock.mockRejectedValueOnce(new Error('connection refused'));
+
+      const result = await fetchSessionUser('refresh_token=x; csrf_token=y');
+
+      expect(result).toEqual({ ok: false, reason: 'NETWORK' });
+    });
+
+    it('does not propagate Set-Cookie (non-rotating: nothing to forward)', async () => {
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({ user: fixtureUser }), {
+          status: 200,
+          headers: [
+            ['content-type', 'application/json'],
+            ['set-cookie', 'evil=should-not-leak'],
+          ],
+        })
+      );
+
+      const result = await fetchSessionUser('refresh_token=x; csrf_token=y');
+
+      expect(result.ok).toBe(true);
+      // The success type does not include setCookies — the contract enforces
+      // non-propagation at the type level.
+      if (result.ok) {
+        expect(result).not.toHaveProperty('setCookies');
+      }
+    });
+  });
+
+  describe('bootstrapAccessToken (rotating, route-handler-only)', () => {
+    it('chains /v1/auth/refresh then /v1/auth/me', async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ accessToken: 'new-token' }), {
+            status: 200,
+            headers: [
+              ['content-type', 'application/json'],
+              ['set-cookie', 'refresh_token=rotated; Path=/; HttpOnly'],
+              ['set-cookie', 'csrf_token=rotated-csrf; Path=/'],
+            ],
+          })
+        )
+        .mockResolvedValueOnce(jsonResponse({ user: fixtureUser }));
+
+      const result = await bootstrapAccessToken(
+        'refresh_token=opaque; csrf_token=csrf-abc'
+      );
+
+      expect(result).toEqual({
+        ok: true,
+        accessToken: 'new-token',
+        user: fixtureUser,
+        setCookies: [
+          'refresh_token=rotated; Path=/; HttpOnly',
+          'csrf_token=rotated-csrf; Path=/',
+        ],
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'http://api.local/v1/auth/refresh'
+      );
+      expect(fetchMock.mock.calls[1][0]).toBe('http://api.local/v1/auth/me');
+      // /me uses the freshly-minted bearer.
+      expect(fetchMock.mock.calls[1][1].headers.Authorization).toBe(
+        'Bearer new-token'
+      );
+    });
+
+    it('returns REFRESH_FAILED when refresh non-2xx', async () => {
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 'reuse' }), { status: 401 })
+      );
+
+      const result = await bootstrapAccessToken(
+        'refresh_token=opaque; csrf_token=csrf-abc'
+      );
+
+      expect(result).toEqual({ ok: false, reason: 'REFRESH_FAILED' });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns REFRESH_INVALID on malformed refresh body', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse({ wrong: 'shape' }));
+
+      const result = await bootstrapAccessToken(
+        'refresh_token=opaque; csrf_token=csrf-abc'
+      );
+
+      expect(result).toEqual({ ok: false, reason: 'REFRESH_INVALID' });
+    });
+
+    it('returns ME_FAILED when /me 401s', async () => {
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ accessToken: 'tok' }))
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ error: 'no' }), { status: 401 })
+        );
+
+      const result = await bootstrapAccessToken(
+        'refresh_token=opaque; csrf_token=csrf-abc'
+      );
+
+      expect(result).toEqual({ ok: false, reason: 'ME_FAILED' });
+    });
+
+    it('returns ME_INVALID when /me body lacks user', async () => {
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ accessToken: 'tok' }))
+        .mockResolvedValueOnce(jsonResponse({ wrong: 'shape' }));
+
+      const result = await bootstrapAccessToken(
+        'refresh_token=opaque; csrf_token=csrf-abc'
+      );
+
+      expect(result).toEqual({ ok: false, reason: 'ME_INVALID' });
+    });
+
+    it('returns NETWORK on refresh fetch error', async () => {
+      fetchMock.mockRejectedValueOnce(new Error('connection refused'));
+
+      const result = await bootstrapAccessToken(
+        'refresh_token=opaque; csrf_token=csrf-abc'
+      );
+
+      expect(result).toEqual({ ok: false, reason: 'NETWORK' });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns NETWORK on /me fetch error', async () => {
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ accessToken: 'tok' }))
+        .mockRejectedValueOnce(new Error('connection refused'));
+
+      const result = await bootstrapAccessToken(
+        'refresh_token=opaque; csrf_token=csrf-abc'
+      );
+
+      expect(result).toEqual({ ok: false, reason: 'NETWORK' });
+    });
+
+    it('returns CONFIG when base URL unset', async () => {
+      delete process.env.NEXT_PUBLIC_API_BASE_URL;
+
+      const result = await bootstrapAccessToken(
+        'refresh_token=x; csrf_token=y'
+      );
+
+      expect(result).toEqual({ ok: false, reason: 'CONFIG' });
+    });
+  });
+});

--- a/__tests__/unit/lib/authStore.test.ts
+++ b/__tests__/unit/lib/authStore.test.ts
@@ -1,0 +1,227 @@
+import {
+  type AuthUser,
+  clearSession,
+  getAccessToken,
+  getSnapshot,
+  getUser,
+  setSession,
+  subscribe,
+} from '@/lib/authStore';
+
+const fixtureUser: AuthUser = {
+  id: 'user-1',
+  name: 'Test User',
+  email: 'test@example.com',
+  username: 'testuser',
+  emailOrUsername: 'test@example.com',
+  avatarUrl: null,
+  role: 'member',
+  familySpaceId: 'family-1',
+  familySpaceName: 'Test Family',
+};
+
+describe('authStore', () => {
+  afterEach(() => {
+    clearSession();
+  });
+
+  it('starts empty', () => {
+    expect(getAccessToken()).toBeNull();
+    expect(getUser()).toBeNull();
+  });
+
+  it('setSession stores token and user', () => {
+    setSession('token-abc', fixtureUser);
+    expect(getAccessToken()).toBe('token-abc');
+    expect(getUser()).toEqual(fixtureUser);
+  });
+
+  it('clearSession resets state', () => {
+    setSession('token-abc', fixtureUser);
+    clearSession();
+    expect(getAccessToken()).toBeNull();
+    expect(getUser()).toBeNull();
+  });
+
+  it('subscribe fires on setSession', () => {
+    const listener = jest.fn();
+    subscribe(listener);
+    setSession('token-abc', fixtureUser);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('subscribe fires on clearSession when state changes', () => {
+    setSession('token-abc', fixtureUser);
+    const listener = jest.fn();
+    subscribe(listener);
+    clearSession();
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('subscribe does not fire when setSession is a no-op', () => {
+    setSession('token-abc', fixtureUser);
+    const listener = jest.fn();
+    subscribe(listener);
+    setSession('token-abc', fixtureUser);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('subscribe does not fire when clearSession is a no-op', () => {
+    const listener = jest.fn();
+    subscribe(listener);
+    clearSession();
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('unsubscribe stops further notifications', () => {
+    const listener = jest.fn();
+    const unsubscribe = subscribe(listener);
+    setSession('token-abc', fixtureUser);
+    unsubscribe();
+    clearSession();
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('getSnapshot returns a stable reference when state is unchanged', () => {
+    const a = getSnapshot();
+    const b = getSnapshot();
+    expect(a).toBe(b);
+  });
+
+  it('getSnapshot returns a new reference after a state change', () => {
+    const before = getSnapshot();
+    setSession('token-abc', fixtureUser);
+    const after = getSnapshot();
+    expect(after).not.toBe(before);
+  });
+
+  it('refresh hook updates only the access token, preserving the user', async () => {
+    setSession('old-token', fixtureUser);
+    const fetchMock = jest.fn().mockImplementation((url: string) => {
+      if (url === '/v1/auth/refresh') {
+        return Promise.resolve(
+          new Response(JSON.stringify({ accessToken: 'rotated-token' }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+        );
+      }
+      // First call to /api/foo returns 401, retried call returns 200.
+      const callsForUrl = fetchMock.mock.calls.filter(
+        ([u]: [string]) => u === url
+      ).length;
+      if (callsForUrl === 1) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ error: { code: 'UNAUTHORIZED' } }), {
+            status: 401,
+            headers: { 'content-type': 'application/json' },
+          })
+        );
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+    });
+    const originalFetch = global.fetch;
+    const originalDocument = (global as { document?: unknown }).document;
+    global.fetch = fetchMock as unknown as typeof fetch;
+    Object.defineProperty(global, 'document', {
+      value: { cookie: 'csrf_token=csrf-xyz' },
+      configurable: true,
+      writable: true,
+    });
+    try {
+      const { apiClient } = await import('@/lib/apiClient');
+      await apiClient.get('/api/foo');
+      expect(getAccessToken()).toBe('rotated-token');
+      expect(getUser()).toEqual(fixtureUser);
+    } finally {
+      global.fetch = originalFetch;
+      if (originalDocument === undefined) {
+        delete (global as { document?: unknown }).document;
+      } else {
+        Object.defineProperty(global, 'document', {
+          value: originalDocument,
+          configurable: true,
+          writable: true,
+        });
+      }
+    }
+  });
+
+  it('refresh failure clears the session', async () => {
+    setSession('old-token', fixtureUser);
+    const fetchMock = jest.fn().mockImplementation((url: string) => {
+      if (url === '/v1/auth/refresh') {
+        return Promise.resolve(
+          new Response(JSON.stringify({ error: { code: 'UNAUTHORIZED' } }), {
+            status: 401,
+            headers: { 'content-type': 'application/json' },
+          })
+        );
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ error: { code: 'UNAUTHORIZED' } }), {
+          status: 401,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+    });
+    const originalFetch = global.fetch;
+    const originalDocument = (global as { document?: unknown }).document;
+    global.fetch = fetchMock as unknown as typeof fetch;
+    Object.defineProperty(global, 'document', {
+      value: { cookie: 'csrf_token=csrf-xyz' },
+      configurable: true,
+      writable: true,
+    });
+    try {
+      const { apiClient } = await import('@/lib/apiClient');
+      await expect(apiClient.get('/api/foo')).rejects.toMatchObject({
+        status: 401,
+      });
+      expect(getAccessToken()).toBeNull();
+      expect(getUser()).toBeNull();
+    } finally {
+      global.fetch = originalFetch;
+      if (originalDocument === undefined) {
+        delete (global as { document?: unknown }).document;
+      } else {
+        Object.defineProperty(global, 'document', {
+          value: originalDocument,
+          configurable: true,
+          writable: true,
+        });
+      }
+    }
+  });
+
+  it('wires the apiClient access-token provider on import', async () => {
+    setSession('token-from-store', fixtureUser);
+    const fetchMock = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    const originalFetch = global.fetch;
+    global.fetch = fetchMock as unknown as typeof fetch;
+    try {
+      const { apiClient } = await import('@/lib/apiClient');
+      await apiClient.get('/whatever');
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/whatever',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer token-from-store',
+          }),
+        })
+      );
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+});

--- a/__tests__/unit/lib/featureFlags.test.ts
+++ b/__tests__/unit/lib/featureFlags.test.ts
@@ -1,0 +1,30 @@
+import { isFastApiAuthEnabled } from '@/lib/featureFlags';
+
+describe('isFastApiAuthEnabled', () => {
+  const original = process.env.NEXT_PUBLIC_USE_FASTAPI_AUTH;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.NEXT_PUBLIC_USE_FASTAPI_AUTH;
+    } else {
+      process.env.NEXT_PUBLIC_USE_FASTAPI_AUTH = original;
+    }
+  });
+
+  it('returns false when the env var is unset', () => {
+    delete process.env.NEXT_PUBLIC_USE_FASTAPI_AUTH;
+    expect(isFastApiAuthEnabled()).toBe(false);
+  });
+
+  it('returns true only for the literal string "true"', () => {
+    process.env.NEXT_PUBLIC_USE_FASTAPI_AUTH = 'true';
+    expect(isFastApiAuthEnabled()).toBe(true);
+  });
+
+  it('returns false for other truthy-looking values', () => {
+    for (const value of ['1', 'TRUE', 'yes', 'on']) {
+      process.env.NEXT_PUBLIC_USE_FASTAPI_AUTH = value;
+      expect(isFastApiAuthEnabled()).toBe(false);
+    }
+  });
+});

--- a/__tests__/unit/lib/session.test.ts
+++ b/__tests__/unit/lib/session.test.ts
@@ -16,6 +16,7 @@ import {
   clearSessionCookie,
   getSessionFromRequest,
   getCurrentUser,
+  hasAnySessionFromRequest,
 } from '@/lib/session';
 import { verifyToken, JWTPayload } from '@/lib/jwt';
 import { prisma } from '@/lib/prisma';
@@ -319,6 +320,92 @@ describe('Session Management', () => {
 
       expect(mockVerifyToken).toHaveBeenCalledWith('multi-cookie-token');
       expect(result).toEqual(mockPayload);
+    });
+  });
+
+  describe('hasAnySessionFromRequest() — Phase 2 dual-mode', () => {
+    it('returns false when neither cookie is present', async () => {
+      const request = new NextRequest('http://localhost/timeline');
+
+      const result = await hasAnySessionFromRequest(request);
+
+      expect(result).toBe(false);
+      expect(mockVerifyToken).not.toHaveBeenCalled();
+    });
+
+    it('returns true when only a valid Next session cookie is present', async () => {
+      mockVerifyToken.mockResolvedValue({
+        userId: 'u1',
+        familySpaceId: 'f1',
+        role: 'member',
+      });
+      const request = new NextRequest('http://localhost/timeline', {
+        headers: { cookie: 'session=valid-jwt' },
+      });
+
+      const result = await hasAnySessionFromRequest(request);
+
+      expect(result).toBe(true);
+    });
+
+    it('returns true when only a refresh_token cookie is present (presence-only check)', async () => {
+      const request = new NextRequest('http://localhost/timeline', {
+        headers: { cookie: 'refresh_token=opaque.jti.value' },
+      });
+
+      const result = await hasAnySessionFromRequest(request);
+
+      expect(result).toBe(true);
+      // Critical: no JWT decode happens for the FastAPI cookie. The middleware
+      // runs on Edge and must not crypto-verify the FastAPI token.
+      expect(mockVerifyToken).not.toHaveBeenCalled();
+    });
+
+    it('returns true when both cookies are present', async () => {
+      mockVerifyToken.mockResolvedValue({
+        userId: 'u1',
+        familySpaceId: 'f1',
+        role: 'member',
+      });
+      const request = new NextRequest('http://localhost/timeline', {
+        headers: { cookie: 'session=valid-jwt; refresh_token=opaque' },
+      });
+
+      const result = await hasAnySessionFromRequest(request);
+
+      expect(result).toBe(true);
+    });
+
+    it('returns true on invalid Next session + valid refresh_token', async () => {
+      mockVerifyToken.mockResolvedValue(null);
+      const request = new NextRequest('http://localhost/timeline', {
+        headers: { cookie: 'session=expired; refresh_token=opaque' },
+      });
+
+      const result = await hasAnySessionFromRequest(request);
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when refresh_token cookie value is empty', async () => {
+      const request = new NextRequest('http://localhost/timeline', {
+        headers: { cookie: 'refresh_token=' },
+      });
+
+      const result = await hasAnySessionFromRequest(request);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false on invalid Next session + missing refresh_token', async () => {
+      mockVerifyToken.mockResolvedValue(null);
+      const request = new NextRequest('http://localhost/timeline', {
+        headers: { cookie: 'session=expired' },
+      });
+
+      const result = await hasAnySessionFromRequest(request);
+
+      expect(result).toBe(false);
     });
   });
 

--- a/docs/research/fastapi-cookie-domain-stack0.md
+++ b/docs/research/fastapi-cookie-domain-stack0.md
@@ -1,0 +1,130 @@
+# Stack 0 — FastAPI Cookie & CORS Configuration Assessment
+
+**Status:** Phase 1 source review (no live deploy yet — FastAPI not deployed to dev as of 2026-04-27)
+**Issue:** [#36 — FastAPI migration Phase 2](https://github.com/wnorowskie/family-recipe/issues/36)
+**Plan:** Stack 0 of `~/.claude/plans/claude-md-prepare-for-a-cached-fox.md`
+
+## Purpose
+
+Phase 2 wires the Next frontend onto the FastAPI token flow. The flow depends on three browser cookies set by FastAPI (`refresh_token`, `csrf_token`) being readable by the Next host:
+
+- `refresh_token` (httpOnly) — sent automatically on `/v1/auth/refresh` and `/v1/auth/logout`.
+- `csrf_token` (non-httpOnly) — read via `document.cookie` on the client and echoed as `X-CSRF-Token`.
+
+If the FastAPI service runs on a different origin than the Next app, those cookies must either be cross-origin readable (requires `SameSite=None; Secure` and a `Domain=` covering both hosts) or the API must be reverse-proxied through Next so the browser sees a single origin.
+
+## Phase 1 source: how cookies are configured
+
+### [apps/api/src/cookies.py](../../apps/api/src/cookies.py)
+
+`set_refresh_cookie` (lines 25–35):
+
+```
+httponly  = True
+secure    = settings.is_production OR samesite == "none"
+samesite  = settings.refresh_cookie_samesite     (default "lax")
+domain    = settings.refresh_cookie_domain        (default None)
+path      = "/"
+```
+
+`set_csrf_cookie` (lines 49–60) — same attributes except `httponly=False`.
+
+`clear_*` (lines 38–46, 63–71) — must mirror the set attributes exactly or the browser refuses to delete the cookie.
+
+### [apps/api/src/settings.py](../../apps/api/src/settings.py)
+
+Configurable via env (lines 41–44):
+
+- `refresh_cookie_name` — default `refresh_token`
+- `csrf_cookie_name` — default `csrf_token`
+- `refresh_cookie_domain` — default `None` (cookie scoped to the FastAPI host only)
+- `refresh_cookie_samesite` — default `"lax"`
+
+### [apps/api/src/main.py](../../apps/api/src/main.py)
+
+CORS middleware (lines 32–36):
+
+```
+allow_origins      = settings.cors_origins_list   # parsed from CORS_ALLOW_ORIGINS env
+allow_credentials  = True
+allow_methods      = [GET, POST, PATCH, PUT, DELETE, OPTIONS]
+allow_headers      = [Authorization, Content-Type, X-CSRF-Token, X-Request-Id]
+```
+
+`allow_credentials=True` is the right setting for the cookie + Bearer flow — the browser sends/receives cookies on cross-origin XHR only when the response includes `Access-Control-Allow-Credentials: true`.
+
+## The three deployment shapes Phase 2 must work in
+
+### 1. Local dev — `localhost:3000` (Next) + `localhost:8000` (FastAPI)
+
+This is the only scenario that exists today.
+
+**Browser cookie behavior:** different ports = different origins for CORS but the **same site** for cookie purposes (RFC 6265 — cookies are scoped by host, port is ignored). With default settings:
+
+- `refresh_cookie_domain=None` → cookie scoped to host `localhost`, sent to BOTH ports.
+- `samesite=lax` → sent on top-level GET navigations and same-site requests. Cross-origin POSTs (Next → FastAPI) are same-site (both `localhost`), so cookies attach.
+- `secure=False` (because `is_production=False` and samesite≠"none") → fine for `http://localhost`.
+
+**Verdict:** **Works as-is for local dev.** No env override needed.
+
+**Required env to make Phase 2 work locally:**
+
+```
+# .env
+CORS_ALLOW_ORIGINS=http://localhost:3000
+```
+
+(So FastAPI accepts cross-origin XHR from the Next dev server. Without this, browsers will block all `/v1/*` calls from the Next frontend.)
+
+### 2. Dev Cloud Run — both services on `*.run.app` subdomains
+
+When the FastAPI service is deployed to Cloud Run (per `apps/api/Dockerfile`), it gets a hostname like `family-recipe-api-dev-XYZ.us-central1.run.app`. The Next app gets a different `run.app` hostname.
+
+**Browser cookie behavior:** different subdomains under `run.app`, but `run.app` is on the [Public Suffix List](https://publicsuffix.org/) — meaning a cookie set with `Domain=.run.app` is **rejected** by browsers (security — would let any Cloud Run service set cookies for any other). With `refresh_cookie_domain=None` (default), the cookie is scoped to the FastAPI host alone and the Next app cannot read it.
+
+`SameSite=Lax` won't help either — cross-site XHR from Next to FastAPI won't include the cookie.
+
+**Verdict:** **Default config does NOT work on raw `*.run.app` hostnames.** Two paths to fix:
+
+- **(a) Custom domain** — front both services with a custom domain (e.g. `app.family-recipe.com` for Next, `api.family-recipe.com` for FastAPI). Cookies set with `Domain=family-recipe.com` are valid (apex is not on the PSL). Requires `samesite=none` + `secure=true` for cross-site XHR. Env:
+
+```
+REFRESH_COOKIE_DOMAIN=family-recipe.com
+REFRESH_COOKIE_SAMESITE=none
+CORS_ALLOW_ORIGINS=https://app.family-recipe.com
+```
+
+- **(b) Same-origin proxy** — route `/v1/*` from the Next host through a Next route handler or rewrite to the FastAPI Cloud Run service. The browser only ever sees the Next origin; FastAPI cookies go on the Next host. No cookie-domain config needed; CORS not in play. Trade-off: every API call hops Next → FastAPI server-to-server, doubling latency on the data plane.
+
+This repo already has [docs/research/custom-domain.md](custom-domain.md) — relevant background for option (a).
+
+### 3. Prod — same-origin or split-domain (TBD)
+
+Same analysis as dev Cloud Run. Choice between (a) and (b) above is a deploy-architecture decision that needs to be made before Phase 4 (full cutover).
+
+## What's missing for Stack 0 to be "passed"
+
+Phase 2 implementation can proceed for **local dev** today using the default cookie config. But before any flag-on rollout to a deployed environment, the following must be settled:
+
+1. **No FastAPI deploy workflow exists.** `apps/api/Dockerfile` builds, but there's no `deploy-api-dev.yml` workflow analogous to `deploy-dev.yml`. Phase 2's PR 2 (UX changes) cannot be flag-on tested in dev until the FastAPI service is actually running there.
+2. **Choice between custom-domain and same-origin-proxy is unmade.** This is a multi-stakeholder infra decision (DNS, certs, Terraform), not a Phase 2 implementation detail. Phase 2 source code is agnostic to the choice — same client code works either way.
+3. **`.env.example` is missing the FastAPI-side cookie/CORS knobs.** Add them so anyone running the local stack knows what to set.
+
+## Recommendations
+
+1. **Proceed with PR 1 (Stacks 1 + 2 — auth store, feature flag, refresh-and-retry).** Pure infra; no behavior change. Cookie-domain question is irrelevant for PR 1 because no FastAPI calls are made when the flag is off.
+2. **Add a chore ticket** to:
+   - Add `CORS_ALLOW_ORIGINS=http://localhost:3000` documentation to `.env.example` for local dev.
+   - Document `REFRESH_COOKIE_DOMAIN` and `REFRESH_COOKIE_SAMESITE` in the FastAPI README's "Notes" section.
+3. **Open a separate ticket for FastAPI dev deployment + domain decision.** This is the prerequisite for PR 2 being tested in flag-on mode against dev. PR 2 source code can be written and reviewed before that ticket lands; the gate is on flag-on E2E, not on merging the code path.
+4. **For PR 2 implementation work**, default to running locally (`docker compose up fastapi` + `npm run dev`) with `NEXT_PUBLIC_USE_FASTAPI_AUTH=true` and `NEXT_PUBLIC_API_BASE_URL=http://localhost:8000`. The `localhost`-shared-host cookie behavior covers all of Phase 2's flag-on logic.
+
+## Conclusion
+
+**Stack 0 verdict:** **PASS for local-dev usage; conditional pass for deployed environments.**
+
+- Local dev with default settings + `CORS_ALLOW_ORIGINS=http://localhost:3000` works.
+- Deployed dev/prod requires a same-origin proxy or custom-domain decision before flag-on rollout.
+- Phase 2 frontend code (PR 1 + PR 2) is agnostic to the deploy decision and can be implemented now. The deploy decision is a separate ticket and is **not** a blocker for Phase 2 implementation, only for Phase 2 production rollout.
+
+Phase 2 is unblocked. Proceed to PR 1 — Stack 1 (auth store + feature flag).

--- a/docs/verification/ui.md
+++ b/docs/verification/ui.md
@@ -72,6 +72,54 @@ Use `browser_navigate` → `browser_snapshot` (accessibility tree — token-chea
 - **Family scoping is implicit** — if a list or detail view renders, it was already scoped by `familySpaceId`. If something is visible that shouldn't be, the bug is server-side, not rendering.
 - **Server vs client**: default is server component. `'use client'` only for interactive forms/state. When reviewing your own PR, grep the diff for `'use client'` — if it appeared on a component that doesn't need state, revert.
 
+## Phase 2 dual-mode auth verification
+
+The frontend supports two auth flows during the FastAPI migration. When you change anything in the auth surface (login/signup/logout, the protected `(app)` layout, `src/proxy.ts`, [src/lib/apiClient.ts](../../src/lib/apiClient.ts), [src/lib/authStore.ts](../../src/lib/authStore.ts), or [src/components/AuthBootstrap.tsx](../../src/components/AuthBootstrap.tsx)), verify both flag states.
+
+### Flag OFF (default — what real users see today)
+
+```bash
+npm run dev
+```
+
+- Login with seeded `claude-test`: form posts to `/api/auth/login`; `session` cookie set; redirect to `/timeline` works.
+- Signup, logout, reset-password, deep-link redirect (`/timeline?redirect=…`), and remember-me all behave as on `develop`.
+- DevTools → Application → Cookies: only `session` cookie present. No `refresh_token` / `csrf_token`.
+
+### Flag ON (FastAPI flow)
+
+Requires the FastAPI service running locally and the env vars set at build time.
+
+```bash
+# Terminal 1: FastAPI
+cd apps/api && docker compose up fastapi
+# Or: cd apps/api && uvicorn src.main:app --reload
+
+# Terminal 2: Next with both env vars
+NEXT_PUBLIC_USE_FASTAPI_AUTH=true \
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000 \
+  npm run dev
+```
+
+- Login: form posts to `/v1/auth/login`. After redirect, DevTools shows `refresh_token` (HttpOnly) + `csrf_token` cookies; **no** `session` cookie.
+- Console: `localStorage` and `sessionStorage` empty. No JWT-shaped strings (`eyJ…`) anywhere in storage.
+- Reload: stays on `/timeline`, no flash. Network tab shows one POST to `/api/auth/bootstrap` (server-side flow) and one client-initiated POST.
+- Logout: cookies cleared, redirect to `/login`. Subsequent navigation to `/timeline` redirects back.
+- Force token expiry (shorten `ACCESS_TOKEN_TTL_SECONDS` to 30 in FastAPI dev config): make any API call → exactly one `/v1/auth/refresh` fires → original request retries and succeeds.
+- 429 response from a rate-limited endpoint does NOT trigger `/v1/auth/refresh` (only 401 does).
+
+### E2E spec
+
+`e2e/fastapi-auth.spec.ts` covers the full happy path + no-loop guarantee. Run with:
+
+```bash
+NEXT_PUBLIC_USE_FASTAPI_AUTH=true \
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000 \
+  npx playwright test e2e/fastapi-auth.spec.ts --grep @fastapi-auth
+```
+
+The default `e2e/auth.spec.ts` continues to cover the flag-off path.
+
 ## Before opening the PR
 
 ```bash

--- a/docs/verification/ui.md
+++ b/docs/verification/ui.md
@@ -103,7 +103,10 @@ NEXT_PUBLIC_API_BASE_URL=http://localhost:8000 \
 
 - Login: form posts to `/v1/auth/login`. After redirect, DevTools shows `refresh_token` (HttpOnly) + `csrf_token` cookies; **no** `session` cookie.
 - Console: `localStorage` and `sessionStorage` empty. No JWT-shaped strings (`eyJ…`) anywhere in storage.
-- Reload: stays on `/timeline`, no flash. Network tab shows one POST to `/api/auth/bootstrap` (server-side flow) and one client-initiated POST.
+- Reload: stays on `/timeline`, no flash. Network tab shows:
+  - **One** server-side `GET /v1/auth/session` (issued by the SSR layout, non-rotating, no `Set-Cookie` rotation).
+  - **One** client-side `POST /api/auth/bootstrap` (issued by `<AuthBootstrap>` after hydration, which internally calls `/v1/auth/refresh` + `/v1/auth/me` and propagates rotated cookies via the route handler's response).
+  - Net effect: the refresh-token chain advances exactly once per page load.
 - Logout: cookies cleared, redirect to `/login`. Subsequent navigation to `/timeline` redirects back.
 - Force token expiry (shorten `ACCESS_TOKEN_TTL_SECONDS` to 30 in FastAPI dev config): make any API call → exactly one `/v1/auth/refresh` fires → original request retries and succeeds.
 - 429 response from a rate-limited endpoint does NOT trigger `/v1/auth/refresh` (only 401 does).

--- a/e2e/fastapi-auth.spec.ts
+++ b/e2e/fastapi-auth.spec.ts
@@ -1,0 +1,133 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * FastAPI auth flow smoke. Tagged @fastapi-auth so it does not run with the
+ * default @smoke suite — needs NEXT_PUBLIC_USE_FASTAPI_AUTH=true at build
+ * time and a running FastAPI service. CI gates this behind a separate matrix
+ * entry.
+ *
+ * Run locally:
+ *   NEXT_PUBLIC_USE_FASTAPI_AUTH=true \
+ *   NEXT_PUBLIC_API_BASE_URL=http://localhost:8000 \
+ *     npx playwright test e2e/fastapi-auth.spec.ts --grep @fastapi-auth
+ */
+
+const TEST_USER = process.env.E2E_USER ?? 'claude-test';
+const TEST_PASSWORD = process.env.E2E_PASSWORD ?? 'claude-test-password';
+
+const FASTAPI_AUTH_ENABLED =
+  process.env.NEXT_PUBLIC_USE_FASTAPI_AUTH === 'true';
+
+test.describe('@fastapi-auth FastAPI token flow', () => {
+  test.skip(
+    !FASTAPI_AUTH_ENABLED,
+    'NEXT_PUBLIC_USE_FASTAPI_AUTH=true required'
+  );
+
+  test('login persists across reload (refresh-on-bootstrap works)', async ({
+    page,
+  }) => {
+    await page.goto('/login');
+    await page.getByLabel(/email or username/i).fill(TEST_USER);
+    await page.getByLabel(/^password$/i).fill(TEST_PASSWORD);
+    await page.getByRole('button', { name: /log in/i }).click();
+
+    await expect(page).toHaveURL(/\/timeline$/, { timeout: 10_000 });
+
+    await page.reload();
+    await expect(page).toHaveURL(/\/timeline$/);
+  });
+
+  test('access token is in memory only — never localStorage / sessionStorage', async ({
+    page,
+  }) => {
+    await page.goto('/login');
+    await page.getByLabel(/email or username/i).fill(TEST_USER);
+    await page.getByLabel(/^password$/i).fill(TEST_PASSWORD);
+    await page.getByRole('button', { name: /log in/i }).click();
+    await expect(page).toHaveURL(/\/timeline$/, { timeout: 10_000 });
+
+    const local = await page.evaluate(() => {
+      const out: Record<string, string> = {};
+      for (let i = 0; i < localStorage.length; i += 1) {
+        const key = localStorage.key(i)!;
+        out[key] = localStorage.getItem(key) ?? '';
+      }
+      return out;
+    });
+    const session = await page.evaluate(() => {
+      const out: Record<string, string> = {};
+      for (let i = 0; i < sessionStorage.length; i += 1) {
+        const key = sessionStorage.key(i)!;
+        out[key] = sessionStorage.getItem(key) ?? '';
+      }
+      return out;
+    });
+
+    for (const value of [...Object.values(local), ...Object.values(session)]) {
+      // JWT-shaped strings have at least two dots and a base64 payload.
+      expect(value).not.toMatch(/eyJ[\w-]+\.[\w-]+\.[\w-]+/);
+    }
+  });
+
+  test('logout clears state and redirects subsequent navigation to /login', async ({
+    page,
+  }) => {
+    await page.goto('/login');
+    await page.getByLabel(/email or username/i).fill(TEST_USER);
+    await page.getByLabel(/^password$/i).fill(TEST_PASSWORD);
+    await page.getByRole('button', { name: /log in/i }).click();
+    await expect(page).toHaveURL(/\/timeline$/, { timeout: 10_000 });
+
+    await page.getByRole('button', { name: /log out/i }).click();
+    await expect(page).toHaveURL(/\/login(\?|$)/, { timeout: 10_000 });
+
+    await page.goto('/timeline');
+    await expect(page).toHaveURL(/\/login(\?|$)/);
+  });
+
+  test('does not enter a refresh loop when /v1/auth/refresh keeps returning 401', async ({
+    page,
+  }) => {
+    await page.goto('/login');
+    await page.getByLabel(/email or username/i).fill(TEST_USER);
+    await page.getByLabel(/^password$/i).fill(TEST_PASSWORD);
+    await page.getByRole('button', { name: /log in/i }).click();
+    await expect(page).toHaveURL(/\/timeline$/, { timeout: 10_000 });
+
+    let refreshCalls = 0;
+    page.on('request', (req) => {
+      if (req.url().includes('/v1/auth/refresh')) refreshCalls += 1;
+    });
+
+    // Stub /v1/auth/refresh to always 401 (simulate token reuse detection).
+    await page.route('**/v1/auth/refresh', (route) =>
+      route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: { code: 'UNAUTHORIZED' } }),
+      })
+    );
+
+    // Stub a generic API call to 401 so the client triggers refresh.
+    await page.route('**/api/timeline*', (route) =>
+      route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: { code: 'UNAUTHORIZED' } }),
+      })
+    );
+
+    await page.evaluate(() =>
+      fetch('/api/timeline', { credentials: 'include' }).catch(() => null)
+    );
+
+    // Allow a short window for any retries to settle.
+    await page.waitForTimeout(500);
+
+    // Concurrent dedup + no-loop guarantee: at most one refresh per request
+    // cycle even under sustained 401s. Bound at 3 to allow one cycle for the
+    // SSR bootstrap path plus the explicit fetch above.
+    expect(refreshCalls).toBeLessThanOrEqual(3);
+  });
+});

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,16 +1,93 @@
-import { cookies } from 'next/headers';
+import { cookies, headers } from 'next/headers';
 import { redirect } from 'next/navigation';
+import AuthBootstrap from '@/components/AuthBootstrap';
 import LogoutButton from '@/components/LogoutButton';
 import BottomNav from '@/components/navigation/BottomNav';
 import NotificationBell from '@/components/navigation/NotificationBell';
+import { type AuthUser } from '@/lib/authStore';
+import { isFastApiAuthEnabled } from '@/lib/featureFlags';
+import { logError } from '@/lib/logger';
 import { prisma } from '@/lib/prisma';
 import { getCurrentUser } from '@/lib/session';
+
+interface BootstrapPayload {
+  accessToken: string;
+  user: AuthUser;
+}
+
+async function fetchBootstrap(
+  cookieHeader: string,
+  baseUrl: string
+): Promise<BootstrapPayload | null> {
+  try {
+    const response = await fetch(`${baseUrl}/api/auth/bootstrap`, {
+      method: 'POST',
+      headers: { Cookie: cookieHeader },
+      cache: 'no-store',
+    });
+    if (!response.ok) return null;
+    return (await response.json()) as BootstrapPayload;
+  } catch (error) {
+    logError('app.layout.bootstrap', error);
+    return null;
+  }
+}
 
 export default async function AppLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  if (isFastApiAuthEnabled()) {
+    const headerStore = await headers();
+    const cookieHeader = headerStore.get('cookie') ?? '';
+    const host = headerStore.get('host') ?? 'localhost:3000';
+    const protocol =
+      headerStore.get('x-forwarded-proto') ??
+      (host.startsWith('localhost') ? 'http' : 'https');
+
+    const bootstrap = await fetchBootstrap(
+      cookieHeader,
+      `${protocol}://${host}`
+    );
+    if (!bootstrap) {
+      redirect('/login');
+    }
+
+    // Notifications still read directly from Prisma in Phase 2 — see issue #171
+    // for the follow-up to move this onto a /v1 FastAPI endpoint.
+    const initialUnreadCount = await prisma.notification.count({
+      where: { recipientId: bootstrap.user.id, readAt: null },
+    });
+
+    return (
+      <AuthBootstrap>
+        <div className="min-h-screen bg-gray-50 pb-24">
+          <header className="sticky top-0 z-30 border-b border-gray-200 bg-white/95 backdrop-blur">
+            <div className="mx-auto flex max-w-3xl lg:max-w-2xl items-center justify-between px-4 py-4 gap-4">
+              <div>
+                <h1 className="text-xl font-bold text-gray-900">
+                  Wnorowski Family Recipe
+                </h1>
+                <p className="text-sm text-gray-500">
+                  Hi {bootstrap.user.name.split(' ')[0]}!
+                </p>
+              </div>
+              <div className="flex items-center gap-3">
+                <NotificationBell initialCount={initialUnreadCount} />
+                <LogoutButton />
+              </div>
+            </div>
+          </header>
+          <main className="mx-auto mt-4 max-w-3xl lg:max-w-2xl px-4 pb-10">
+            {children}
+          </main>
+          <BottomNav />
+        </div>
+      </AuthBootstrap>
+    );
+  }
+
   const cookieStore = await cookies();
   const sessionCookie = cookieStore.get('session');
 

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -4,34 +4,10 @@ import AuthBootstrap from '@/components/AuthBootstrap';
 import LogoutButton from '@/components/LogoutButton';
 import BottomNav from '@/components/navigation/BottomNav';
 import NotificationBell from '@/components/navigation/NotificationBell';
-import { type AuthUser } from '@/lib/authStore';
+import { fetchSessionUser } from '@/lib/auth/bootstrapFromCookies';
 import { isFastApiAuthEnabled } from '@/lib/featureFlags';
-import { logError } from '@/lib/logger';
 import { prisma } from '@/lib/prisma';
 import { getCurrentUser } from '@/lib/session';
-
-interface BootstrapPayload {
-  accessToken: string;
-  user: AuthUser;
-}
-
-async function fetchBootstrap(
-  cookieHeader: string,
-  baseUrl: string
-): Promise<BootstrapPayload | null> {
-  try {
-    const response = await fetch(`${baseUrl}/api/auth/bootstrap`, {
-      method: 'POST',
-      headers: { Cookie: cookieHeader },
-      cache: 'no-store',
-    });
-    if (!response.ok) return null;
-    return (await response.json()) as BootstrapPayload;
-  } catch (error) {
-    logError('app.layout.bootstrap', error);
-    return null;
-  }
-}
 
 export default async function AppLayout({
   children,
@@ -39,25 +15,22 @@ export default async function AppLayout({
   children: React.ReactNode;
 }) {
   if (isFastApiAuthEnabled()) {
+    // SSR fetches the user via /v1/auth/session — non-rotating, replay-safe.
+    // The chain only advances when the client-side <AuthBootstrap> calls
+    // /api/auth/bootstrap on mount, which is a route handler that can
+    // propagate the rotated cookies back to the browser. See issue #173.
     const headerStore = await headers();
-    const cookieHeader = headerStore.get('cookie') ?? '';
-    const host = headerStore.get('host') ?? 'localhost:3000';
-    const protocol =
-      headerStore.get('x-forwarded-proto') ??
-      (host.startsWith('localhost') ? 'http' : 'https');
+    const cookieHeader = headerStore.get('cookie');
+    const result = await fetchSessionUser(cookieHeader);
 
-    const bootstrap = await fetchBootstrap(
-      cookieHeader,
-      `${protocol}://${host}`
-    );
-    if (!bootstrap) {
+    if (!result.ok) {
       redirect('/login');
     }
 
     // Notifications still read directly from Prisma in Phase 2 — see issue #171
     // for the follow-up to move this onto a /v1 FastAPI endpoint.
     const initialUnreadCount = await prisma.notification.count({
-      where: { recipientId: bootstrap.user.id, readAt: null },
+      where: { recipientId: result.user.id, readAt: null },
     });
 
     return (
@@ -70,7 +43,7 @@ export default async function AppLayout({
                   Wnorowski Family Recipe
                 </h1>
                 <p className="text-sm text-gray-500">
-                  Hi {bootstrap.user.name.split(' ')[0]}!
+                  Hi {result.user.name.split(' ')[0]}!
                 </p>
               </div>
               <div className="flex items-center gap-3">

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -3,6 +3,15 @@
 import { useState, FormEvent, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 
+import { apiClient, ApiError } from '@/lib/apiClient';
+import { type AuthUser, setSession } from '@/lib/authStore';
+import { isFastApiAuthEnabled } from '@/lib/featureFlags';
+
+interface AuthTokenResponse {
+  accessToken: string;
+  user: AuthUser;
+}
+
 function LoginContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -19,12 +28,30 @@ function LoginContent() {
     setError('');
     setIsLoading(true);
 
-    try {
-      const redirectParam = searchParams?.get('redirect') ?? '/timeline';
-      const safeRedirect = redirectParam.startsWith('/')
-        ? redirectParam
-        : '/timeline';
+    const redirectParam = searchParams?.get('redirect') ?? '/timeline';
+    const safeRedirect = redirectParam.startsWith('/')
+      ? redirectParam
+      : '/timeline';
 
+    if (isFastApiAuthEnabled()) {
+      try {
+        const data = await apiClient.post<AuthTokenResponse>('/v1/auth/login', {
+          body: formData,
+        });
+        setSession(data.accessToken, data.user);
+        router.replace(safeRedirect);
+      } catch (err) {
+        if (err instanceof ApiError) {
+          setError(err.message);
+        } else {
+          setError('Failed to connect to the server');
+        }
+        setIsLoading(false);
+      }
+      return;
+    }
+
+    try {
       const response = await fetch('/api/auth/login', {
         method: 'POST',
         headers: {

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -3,6 +3,15 @@
 import { useState, FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
 
+import { apiClient, ApiError } from '@/lib/apiClient';
+import { type AuthUser, setSession } from '@/lib/authStore';
+import { isFastApiAuthEnabled } from '@/lib/featureFlags';
+
+interface AuthTokenResponse {
+  accessToken: string;
+  user: AuthUser;
+}
+
 export default function SignupPage() {
   const router = useRouter();
   const [formData, setFormData] = useState({
@@ -20,6 +29,25 @@ export default function SignupPage() {
     e.preventDefault();
     setError('');
     setIsLoading(true);
+
+    if (isFastApiAuthEnabled()) {
+      try {
+        const data = await apiClient.post<AuthTokenResponse>(
+          '/v1/auth/signup',
+          { body: formData }
+        );
+        setSession(data.accessToken, data.user);
+        router.replace('/timeline');
+      } catch (err) {
+        if (err instanceof ApiError) {
+          setError(err.message);
+        } else {
+          setError('Failed to connect to the server');
+        }
+        setIsLoading(false);
+      }
+      return;
+    }
 
     try {
       const response = await fetch('/api/auth/signup', {

--- a/src/app/api/auth/bootstrap/route.ts
+++ b/src/app/api/auth/bootstrap/route.ts
@@ -1,6 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-import { logError } from '@/lib/logger';
+import {
+  API_ERROR_CODES,
+  createErrorResponse,
+  internalError,
+  unauthorizedError,
+} from '@/lib/apiErrors';
+import { bootstrapAccessToken } from '@/lib/auth/bootstrapFromCookies';
 
 // Bootstrap endpoint for the Phase 2 FastAPI auth flow.
 //
@@ -11,172 +17,47 @@ import { logError } from '@/lib/logger';
 // server components. This route handler is the only place that can refresh
 // AND set the rotated cookies on the response.
 //
-// Both the SSR (app)/layout.tsx fetch and the client-side <AuthBootstrap>
-// hit this route, so cookie rotation is centralized: at most one refresh per
-// page load instead of one for SSR plus one for the client.
+// `withAuth` is intentionally NOT applied: the route forwards opaque FastAPI
+// refresh + csrf cookies and lets FastAPI itself perform the credential check.
+// The Next session JWT is irrelevant here.
+//
+// Called once per page load by <AuthBootstrap> after hydration. The
+// (app)/layout SSR uses the non-rotating `fetchSessionUser` helper instead,
+// so the chain advances exactly once per page load (this route) rather than
+// once per render path.
 
 export const runtime = 'nodejs';
 
-interface RefreshResponse {
-  accessToken?: unknown;
-}
-
-interface MeResponse {
-  user?: unknown;
-}
-
-function getFastApiBaseUrl(): string {
-  const raw = process.env.NEXT_PUBLIC_API_BASE_URL;
-  if (!raw) return '';
-  return raw.endsWith('/') ? raw.slice(0, -1) : raw;
-}
-
-function readCookie(cookieHeader: string | null, name: string): string | null {
-  if (!cookieHeader) return null;
-  const target = `${name}=`;
-  for (const part of cookieHeader.split(';')) {
-    const trimmed = part.trim();
-    if (trimmed.startsWith(target)) {
-      return decodeURIComponent(trimmed.slice(target.length));
-    }
-  }
-  return null;
-}
-
 export async function POST(request: NextRequest) {
-  const baseUrl = getFastApiBaseUrl();
-  if (!baseUrl) {
-    logError('auth.bootstrap.config', 'NEXT_PUBLIC_API_BASE_URL is not set');
-    return NextResponse.json(
-      { error: { code: 'INTERNAL_ERROR', message: 'API not configured' } },
-      { status: 500 }
-    );
-  }
-
   const cookieHeader = request.headers.get('cookie');
-  const csrfToken = readCookie(cookieHeader, 'csrf_token');
-  if (!cookieHeader || !csrfToken) {
-    return NextResponse.json(
-      { error: { code: 'UNAUTHORIZED', message: 'Not authenticated' } },
-      { status: 401 }
-    );
-  }
+  const result = await bootstrapAccessToken(cookieHeader);
 
-  const refreshHeaders: Record<string, string> = {
-    Accept: 'application/json',
-    Cookie: cookieHeader,
-    'X-CSRF-Token': csrfToken,
-  };
-
-  let refreshResponse: Response;
-  try {
-    refreshResponse = await fetch(`${baseUrl}/v1/auth/refresh`, {
-      method: 'POST',
-      headers: refreshHeaders,
-      cache: 'no-store',
-    });
-  } catch (error) {
-    logError('auth.bootstrap.refresh.network', error);
-    return NextResponse.json(
-      { error: { code: 'INTERNAL_ERROR', message: 'Refresh failed' } },
-      { status: 502 }
-    );
-  }
-
-  if (!refreshResponse.ok) {
-    return NextResponse.json(
-      { error: { code: 'UNAUTHORIZED', message: 'Refresh failed' } },
-      { status: 401 }
-    );
-  }
-
-  let refreshBody: RefreshResponse;
-  try {
-    refreshBody = (await refreshResponse.json()) as RefreshResponse;
-  } catch (error) {
-    logError('auth.bootstrap.refresh.parse', error);
-    return NextResponse.json(
-      {
-        error: { code: 'INTERNAL_ERROR', message: 'Refresh response invalid' },
-      },
-      { status: 502 }
-    );
-  }
-
-  const accessToken = refreshBody.accessToken;
-  if (typeof accessToken !== 'string' || accessToken.length === 0) {
-    return NextResponse.json(
-      {
-        error: {
-          code: 'UNAUTHORIZED',
-          message: 'Refresh response missing token',
-        },
-      },
-      { status: 401 }
-    );
-  }
-
-  let meResponse: Response;
-  try {
-    meResponse = await fetch(`${baseUrl}/v1/auth/me`, {
-      method: 'GET',
-      headers: {
-        Accept: 'application/json',
-        Authorization: `Bearer ${accessToken}`,
-      },
-      cache: 'no-store',
-    });
-  } catch (error) {
-    logError('auth.bootstrap.me.network', error);
-    return NextResponse.json(
-      { error: { code: 'INTERNAL_ERROR', message: '/v1/auth/me failed' } },
-      { status: 502 }
-    );
-  }
-
-  if (!meResponse.ok) {
-    return NextResponse.json(
-      {
-        error: { code: 'UNAUTHORIZED', message: '/v1/auth/me rejected token' },
-      },
-      { status: 401 }
-    );
-  }
-
-  let meBody: MeResponse;
-  try {
-    meBody = (await meResponse.json()) as MeResponse;
-  } catch (error) {
-    logError('auth.bootstrap.me.parse', error);
-    return NextResponse.json(
-      {
-        error: {
-          code: 'INTERNAL_ERROR',
-          message: '/v1/auth/me response invalid',
-        },
-      },
-      { status: 502 }
-    );
-  }
-
-  if (!meBody.user || typeof meBody.user !== 'object') {
-    return NextResponse.json(
-      {
-        error: { code: 'INTERNAL_ERROR', message: '/v1/auth/me missing user' },
-      },
-      { status: 502 }
-    );
+  if (!result.ok) {
+    switch (result.reason) {
+      case 'CONFIG':
+        return internalError('API not configured');
+      case 'MISSING_COOKIES':
+      case 'REFRESH_FAILED':
+      case 'REFRESH_INVALID':
+      case 'ME_FAILED':
+      case 'ME_INVALID':
+        return unauthorizedError('Not authenticated');
+      case 'NETWORK':
+        return createErrorResponse(
+          API_ERROR_CODES.INTERNAL_ERROR,
+          'Upstream auth service failed',
+          502
+        );
+    }
   }
 
   const response = NextResponse.json(
-    { accessToken, user: meBody.user },
+    { accessToken: result.accessToken, user: result.user },
     { status: 200 }
   );
 
   // Forward FastAPI's rotated refresh + csrf cookies to the browser.
-  // `Headers.getSetCookie()` returns each Set-Cookie header separately; copying
-  // them via `response.headers.append` preserves multi-cookie correctness.
-  for (const setCookie of refreshResponse.headers.getSetCookie()) {
+  for (const setCookie of result.setCookies) {
     response.headers.append('Set-Cookie', setCookie);
   }
 

--- a/src/app/api/auth/bootstrap/route.ts
+++ b/src/app/api/auth/bootstrap/route.ts
@@ -1,0 +1,184 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { logError } from '@/lib/logger';
+
+// Bootstrap endpoint for the Phase 2 FastAPI auth flow.
+//
+// Why this exists: the FastAPI access token lives only in the client's memory,
+// so on every page load the client needs a fresh token. The browser holds a
+// refresh cookie that's scoped to FastAPI's domain, but cookie rotation has to
+// be honored on the response — and `cookies().set()` is not allowed inside
+// server components. This route handler is the only place that can refresh
+// AND set the rotated cookies on the response.
+//
+// Both the SSR (app)/layout.tsx fetch and the client-side <AuthBootstrap>
+// hit this route, so cookie rotation is centralized: at most one refresh per
+// page load instead of one for SSR plus one for the client.
+
+export const runtime = 'nodejs';
+
+interface RefreshResponse {
+  accessToken?: unknown;
+}
+
+interface MeResponse {
+  user?: unknown;
+}
+
+function getFastApiBaseUrl(): string {
+  const raw = process.env.NEXT_PUBLIC_API_BASE_URL;
+  if (!raw) return '';
+  return raw.endsWith('/') ? raw.slice(0, -1) : raw;
+}
+
+function readCookie(cookieHeader: string | null, name: string): string | null {
+  if (!cookieHeader) return null;
+  const target = `${name}=`;
+  for (const part of cookieHeader.split(';')) {
+    const trimmed = part.trim();
+    if (trimmed.startsWith(target)) {
+      return decodeURIComponent(trimmed.slice(target.length));
+    }
+  }
+  return null;
+}
+
+export async function POST(request: NextRequest) {
+  const baseUrl = getFastApiBaseUrl();
+  if (!baseUrl) {
+    logError('auth.bootstrap.config', 'NEXT_PUBLIC_API_BASE_URL is not set');
+    return NextResponse.json(
+      { error: { code: 'INTERNAL_ERROR', message: 'API not configured' } },
+      { status: 500 }
+    );
+  }
+
+  const cookieHeader = request.headers.get('cookie');
+  const csrfToken = readCookie(cookieHeader, 'csrf_token');
+  if (!cookieHeader || !csrfToken) {
+    return NextResponse.json(
+      { error: { code: 'UNAUTHORIZED', message: 'Not authenticated' } },
+      { status: 401 }
+    );
+  }
+
+  const refreshHeaders: Record<string, string> = {
+    Accept: 'application/json',
+    Cookie: cookieHeader,
+    'X-CSRF-Token': csrfToken,
+  };
+
+  let refreshResponse: Response;
+  try {
+    refreshResponse = await fetch(`${baseUrl}/v1/auth/refresh`, {
+      method: 'POST',
+      headers: refreshHeaders,
+      cache: 'no-store',
+    });
+  } catch (error) {
+    logError('auth.bootstrap.refresh.network', error);
+    return NextResponse.json(
+      { error: { code: 'INTERNAL_ERROR', message: 'Refresh failed' } },
+      { status: 502 }
+    );
+  }
+
+  if (!refreshResponse.ok) {
+    return NextResponse.json(
+      { error: { code: 'UNAUTHORIZED', message: 'Refresh failed' } },
+      { status: 401 }
+    );
+  }
+
+  let refreshBody: RefreshResponse;
+  try {
+    refreshBody = (await refreshResponse.json()) as RefreshResponse;
+  } catch (error) {
+    logError('auth.bootstrap.refresh.parse', error);
+    return NextResponse.json(
+      {
+        error: { code: 'INTERNAL_ERROR', message: 'Refresh response invalid' },
+      },
+      { status: 502 }
+    );
+  }
+
+  const accessToken = refreshBody.accessToken;
+  if (typeof accessToken !== 'string' || accessToken.length === 0) {
+    return NextResponse.json(
+      {
+        error: {
+          code: 'UNAUTHORIZED',
+          message: 'Refresh response missing token',
+        },
+      },
+      { status: 401 }
+    );
+  }
+
+  let meResponse: Response;
+  try {
+    meResponse = await fetch(`${baseUrl}/v1/auth/me`, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      cache: 'no-store',
+    });
+  } catch (error) {
+    logError('auth.bootstrap.me.network', error);
+    return NextResponse.json(
+      { error: { code: 'INTERNAL_ERROR', message: '/v1/auth/me failed' } },
+      { status: 502 }
+    );
+  }
+
+  if (!meResponse.ok) {
+    return NextResponse.json(
+      {
+        error: { code: 'UNAUTHORIZED', message: '/v1/auth/me rejected token' },
+      },
+      { status: 401 }
+    );
+  }
+
+  let meBody: MeResponse;
+  try {
+    meBody = (await meResponse.json()) as MeResponse;
+  } catch (error) {
+    logError('auth.bootstrap.me.parse', error);
+    return NextResponse.json(
+      {
+        error: {
+          code: 'INTERNAL_ERROR',
+          message: '/v1/auth/me response invalid',
+        },
+      },
+      { status: 502 }
+    );
+  }
+
+  if (!meBody.user || typeof meBody.user !== 'object') {
+    return NextResponse.json(
+      {
+        error: { code: 'INTERNAL_ERROR', message: '/v1/auth/me missing user' },
+      },
+      { status: 502 }
+    );
+  }
+
+  const response = NextResponse.json(
+    { accessToken, user: meBody.user },
+    { status: 200 }
+  );
+
+  // Forward FastAPI's rotated refresh + csrf cookies to the browser.
+  // `Headers.getSetCookie()` returns each Set-Cookie header separately; copying
+  // them via `response.headers.append` preserves multi-cookie correctness.
+  for (const setCookie of refreshResponse.headers.getSetCookie()) {
+    response.headers.append('Set-Cookie', setCookie);
+  }
+
+  return response;
+}

--- a/src/components/AuthBootstrap.tsx
+++ b/src/components/AuthBootstrap.tsx
@@ -17,9 +17,11 @@ interface BootstrapResponse {
 }
 
 // Mounts inside the protected (app) layout when the FastAPI auth flag is on.
-// The SSR layout has already verified the session via /api/auth/bootstrap, so
-// the rendered UI is correct from first paint. This component runs after
-// hydration to mint the client's own access token for subsequent API calls.
+// The SSR layout has already verified the session via /v1/auth/session
+// (non-rotating), so the rendered UI is correct from first paint. This
+// component runs after hydration to call /api/auth/bootstrap, which performs
+// the single per-page rotating /v1/auth/refresh + /v1/auth/me round-trip and
+// propagates the rotated cookies back to the browser.
 
 export default function AuthBootstrap({
   children,

--- a/src/components/AuthBootstrap.tsx
+++ b/src/components/AuthBootstrap.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+
+import { apiClient } from '@/lib/apiClient';
+import {
+  type AuthUser,
+  clearSession,
+  getAccessToken,
+  setSession,
+} from '@/lib/authStore';
+
+interface BootstrapResponse {
+  accessToken: string;
+  user: AuthUser;
+}
+
+// Mounts inside the protected (app) layout when the FastAPI auth flag is on.
+// The SSR layout has already verified the session via /api/auth/bootstrap, so
+// the rendered UI is correct from first paint. This component runs after
+// hydration to mint the client's own access token for subsequent API calls.
+
+export default function AuthBootstrap({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const router = useRouter();
+  const didRun = useRef(false);
+
+  useEffect(() => {
+    if (didRun.current) return;
+    didRun.current = true;
+
+    if (getAccessToken() !== null) return;
+
+    apiClient
+      .post<BootstrapResponse>('/api/auth/bootstrap')
+      .then((data) => {
+        setSession(data.accessToken, data.user);
+      })
+      .catch(() => {
+        clearSession();
+        router.replace('/login');
+      });
+  }, [router]);
+
+  return <>{children}</>;
+}

--- a/src/components/LogoutButton.tsx
+++ b/src/components/LogoutButton.tsx
@@ -3,13 +3,31 @@
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
+import { apiClient } from '@/lib/apiClient';
+import { clearSession } from '@/lib/authStore';
+import { isFastApiAuthEnabled } from '@/lib/featureFlags';
+
 export default function LogoutButton() {
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
 
   const handleLogout = async () => {
     setIsLoading(true);
-    
+
+    if (isFastApiAuthEnabled()) {
+      try {
+        await apiClient.post('/v1/auth/logout');
+      } catch {
+        // Fall through — clearing the local session is more important than
+        // surfacing a logout API error to the user.
+      }
+      clearSession();
+      router.push('/login');
+      router.refresh();
+      setIsLoading(false);
+      return;
+    }
+
     try {
       const response = await fetch('/api/auth/logout', {
         method: 'POST',

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+import { type AuthUser, getSnapshot, subscribe } from '@/lib/authStore';
+
+const SERVER_SNAPSHOT = { accessToken: null, user: null };
+
+export interface UseAuthResult {
+  user: AuthUser | null;
+  isAuthed: boolean;
+}
+
+export function useAuth(): UseAuthResult {
+  const snapshot = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    () => SERVER_SNAPSHOT
+  );
+  return {
+    user: snapshot.user,
+    isAuthed: snapshot.accessToken !== null && snapshot.user !== null,
+  };
+}

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -51,12 +51,12 @@ const AUTH_BYPASS_PATHS = new Set([
 ]);
 
 function isAuthEndpoint(path: string): boolean {
-  // Match exact path or path with query string; ignore base URL prefix.
+  // Exact match after stripping the query string. Paths reach this function
+  // without the base URL prefix (apiClient.request passes the original path
+  // and buildUrl adds the prefix later), so a substring/endsWith check is
+  // unnecessary and would incorrectly match e.g. `/something/v1/auth/login`.
   const withoutQuery = path.split('?')[0];
-  for (const bypass of AUTH_BYPASS_PATHS) {
-    if (withoutQuery === bypass || withoutQuery.endsWith(bypass)) return true;
-  }
-  return false;
+  return AUTH_BYPASS_PATHS.has(withoutQuery);
 }
 
 function readCookie(name: string): string | null {

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -24,6 +24,98 @@ export function clearAccessTokenProvider(): void {
   accessTokenProvider = () => null;
 }
 
+// Phase 2 refresh-and-retry hooks. The auth store registers these at module
+// load (avoids an apiClient ↔ authStore import cycle). When unset, the retry
+// loop is a no-op and 401s propagate as before.
+interface RefreshHooks {
+  onRefreshed: (accessToken: string) => void;
+  onRefreshFailed: () => void;
+}
+
+let refreshHooks: RefreshHooks | null = null;
+
+export function setRefreshHooks(hooks: RefreshHooks): void {
+  refreshHooks = hooks;
+}
+
+export function clearRefreshHooks(): void {
+  refreshHooks = null;
+}
+
+const REFRESH_PATH = '/v1/auth/refresh';
+const AUTH_BYPASS_PATHS = new Set([
+  REFRESH_PATH,
+  '/v1/auth/login',
+  '/v1/auth/signup',
+  '/v1/auth/logout',
+]);
+
+function isAuthEndpoint(path: string): boolean {
+  // Match exact path or path with query string; ignore base URL prefix.
+  const withoutQuery = path.split('?')[0];
+  for (const bypass of AUTH_BYPASS_PATHS) {
+    if (withoutQuery === bypass || withoutQuery.endsWith(bypass)) return true;
+  }
+  return false;
+}
+
+function readCookie(name: string): string | null {
+  if (typeof document === 'undefined') return null;
+  const target = `${name}=`;
+  const parts = document.cookie ? document.cookie.split(';') : [];
+  for (const part of parts) {
+    const trimmed = part.trim();
+    if (trimmed.startsWith(target)) {
+      return decodeURIComponent(trimmed.slice(target.length));
+    }
+  }
+  return null;
+}
+
+let inflightRefresh: Promise<boolean> | null = null;
+
+async function tryRefresh(): Promise<boolean> {
+  if (typeof document === 'undefined') {
+    throw new Error('apiClient.tryRefresh must not run on the server');
+  }
+  if (inflightRefresh) return inflightRefresh;
+
+  const csrf = readCookie('csrf_token');
+  const headers: Record<string, string> = { Accept: 'application/json' };
+  if (csrf) headers['X-CSRF-Token'] = csrf;
+
+  inflightRefresh = (async () => {
+    try {
+      const response = await fetch(buildUrl(REFRESH_PATH), {
+        method: 'POST',
+        headers,
+        credentials: 'include',
+      });
+      if (!response.ok) {
+        refreshHooks?.onRefreshFailed();
+        return false;
+      }
+      const body = (await response.json()) as { accessToken?: unknown };
+      if (
+        typeof body.accessToken !== 'string' ||
+        body.accessToken.length === 0
+      ) {
+        refreshHooks?.onRefreshFailed();
+        return false;
+      }
+      refreshHooks?.onRefreshed(body.accessToken);
+      return true;
+    } catch {
+      refreshHooks?.onRefreshFailed();
+      return false;
+    } finally {
+      inflightRefresh = null;
+    }
+  })();
+
+  return inflightRefresh;
+}
+
 // `NEXT_PUBLIC_*` is inlined by Next.js at build time for client bundles, not
 // read at runtime. Flipping this in env config alone won't redirect requests in
 // a deployed build — Phase 1 rollouts need a per-environment build (or a
@@ -119,11 +211,11 @@ function appendQuery(path: string, query: RequestOptions['query']): string {
   return path.includes('?') ? `${path}&${qs}` : `${path}?${qs}`;
 }
 
-async function request<T>(
+async function executeRequest(
   method: string,
   path: string,
-  options: RequestOptions = {}
-): Promise<T> {
+  options: RequestOptions
+): Promise<Response> {
   const headers: Record<string, string> = {
     Accept: 'application/json',
     ...(options.headers ?? {}),
@@ -141,20 +233,43 @@ async function request<T>(
     }
   }
 
-  // No-op until Phase 2 wires `setAccessTokenProvider` from the auth store.
+  // Read the access token fresh on every request so a retry after refresh
+  // picks up the rotated token.
   const token = accessTokenProvider();
   if (token && !('Authorization' in headers) && !('authorization' in headers)) {
     headers.Authorization = `Bearer ${token}`;
   }
 
   const url = buildUrl(appendQuery(path, options.query));
-  const response = await fetch(url, {
+  return fetch(url, {
     method,
     headers,
     body,
     signal: options.signal,
     credentials: options.credentials ?? 'include',
   });
+}
+
+async function request<T>(
+  method: string,
+  path: string,
+  options: RequestOptions = {}
+): Promise<T> {
+  let response = await executeRequest(method, path, options);
+
+  // On 401, attempt a single refresh and retry the original request once.
+  // Skip auth endpoints to avoid recursion (refresh failures must surface
+  // as 401s, not trigger another refresh).
+  if (
+    response.status === 401 &&
+    refreshHooks !== null &&
+    !isAuthEndpoint(path)
+  ) {
+    const refreshed = await tryRefresh();
+    if (refreshed) {
+      response = await executeRequest(method, path, options);
+    }
+  }
 
   if (!response.ok) {
     throw await normalizeError(response);

--- a/src/lib/auth/bootstrapFromCookies.ts
+++ b/src/lib/auth/bootstrapFromCookies.ts
@@ -1,0 +1,237 @@
+import type { AuthUser } from '@/lib/authStore';
+import { logError } from '@/lib/logger';
+
+// Server-side helpers for the FastAPI auth flow. Two distinct paths:
+//
+//   1. fetchSessionUser  — non-rotating. Calls /v1/auth/session. Used by
+//      the (app)/layout SSR pre-render so server components can render with
+//      the user before client hydration. Replay-safe by design — calling
+//      this on every page render does NOT advance the refresh-token chain.
+//
+//   2. bootstrapAccessToken — rotating. Calls /v1/auth/refresh + /v1/auth/me.
+//      Used ONLY by the /api/auth/bootstrap route handler, which needs to
+//      mount the rotated Set-Cookie headers on its response (something
+//      server components cannot do in Next 15). The client's <AuthBootstrap>
+//      component is the only caller of /api/auth/bootstrap; it runs once on
+//      mount to mint the in-memory access token.
+//
+// Splitting these means SSR never advances the chain, and the single chain
+// rotation per page load happens via a route handler that can propagate the
+// new cookies back to the browser. See issue #173 for the security rationale.
+
+export type SessionFailure =
+  | 'CONFIG'
+  | 'MISSING_COOKIES'
+  | 'SESSION_FAILED'
+  | 'SESSION_INVALID'
+  | 'NETWORK';
+
+export type BootstrapFailure =
+  | 'CONFIG'
+  | 'MISSING_COOKIES'
+  | 'REFRESH_FAILED'
+  | 'REFRESH_INVALID'
+  | 'ME_FAILED'
+  | 'ME_INVALID'
+  | 'NETWORK';
+
+export interface SessionUserResult {
+  ok: true;
+  user: AuthUser;
+}
+
+export interface SessionUserError {
+  ok: false;
+  reason: SessionFailure;
+}
+
+export interface BootstrapResult {
+  ok: true;
+  accessToken: string;
+  user: AuthUser;
+  setCookies: string[];
+}
+
+export interface BootstrapError {
+  ok: false;
+  reason: BootstrapFailure;
+}
+
+interface MeResponseShape {
+  user?: unknown;
+}
+
+interface RefreshResponseShape {
+  accessToken?: unknown;
+}
+
+function getFastApiBaseUrl(): string | null {
+  const raw = process.env.NEXT_PUBLIC_API_BASE_URL;
+  if (!raw) return null;
+  return raw.endsWith('/') ? raw.slice(0, -1) : raw;
+}
+
+function readCookieFromHeader(
+  cookieHeader: string,
+  name: string
+): string | null {
+  const target = `${name}=`;
+  for (const part of cookieHeader.split(';')) {
+    const trimmed = part.trim();
+    if (trimmed.startsWith(target)) {
+      return decodeURIComponent(trimmed.slice(target.length));
+    }
+  }
+  return null;
+}
+
+interface ResolvedCookies {
+  baseUrl: string;
+  cookieHeader: string;
+  csrfToken: string;
+}
+
+function resolveCookies(
+  cookieHeader: string | null
+): ResolvedCookies | { reason: 'CONFIG' | 'MISSING_COOKIES' } {
+  const baseUrl = getFastApiBaseUrl();
+  if (!baseUrl) {
+    logError('auth.bootstrap.config', 'NEXT_PUBLIC_API_BASE_URL is not set');
+    return { reason: 'CONFIG' };
+  }
+  if (!cookieHeader) return { reason: 'MISSING_COOKIES' };
+  const csrfToken = readCookieFromHeader(cookieHeader, 'csrf_token');
+  if (!csrfToken) return { reason: 'MISSING_COOKIES' };
+  return { baseUrl, cookieHeader, csrfToken };
+}
+
+// ---------------------------------------------------------------------------
+// SSR path — non-rotating
+// ---------------------------------------------------------------------------
+
+export async function fetchSessionUser(
+  cookieHeader: string | null
+): Promise<SessionUserResult | SessionUserError> {
+  const resolved = resolveCookies(cookieHeader);
+  if ('reason' in resolved) {
+    return { ok: false, reason: resolved.reason };
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(`${resolved.baseUrl}/v1/auth/session`, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        Cookie: resolved.cookieHeader,
+        'X-CSRF-Token': resolved.csrfToken,
+      },
+      cache: 'no-store',
+    });
+  } catch (error) {
+    logError('auth.session.network', error);
+    return { ok: false, reason: 'NETWORK' };
+  }
+
+  if (!response.ok) {
+    return { ok: false, reason: 'SESSION_FAILED' };
+  }
+
+  let body: MeResponseShape;
+  try {
+    body = (await response.json()) as MeResponseShape;
+  } catch (error) {
+    logError('auth.session.parse', error);
+    return { ok: false, reason: 'SESSION_INVALID' };
+  }
+
+  if (!body.user || typeof body.user !== 'object') {
+    return { ok: false, reason: 'SESSION_INVALID' };
+  }
+
+  return { ok: true, user: body.user as AuthUser };
+}
+
+// ---------------------------------------------------------------------------
+// Client-bootstrap path — rotating, called only by /api/auth/bootstrap
+// ---------------------------------------------------------------------------
+
+export async function bootstrapAccessToken(
+  cookieHeader: string | null
+): Promise<BootstrapResult | BootstrapError> {
+  const resolved = resolveCookies(cookieHeader);
+  if ('reason' in resolved) {
+    return { ok: false, reason: resolved.reason };
+  }
+
+  let refreshResponse: Response;
+  try {
+    refreshResponse = await fetch(`${resolved.baseUrl}/v1/auth/refresh`, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        Cookie: resolved.cookieHeader,
+        'X-CSRF-Token': resolved.csrfToken,
+      },
+      cache: 'no-store',
+    });
+  } catch (error) {
+    logError('auth.bootstrap.refresh.network', error);
+    return { ok: false, reason: 'NETWORK' };
+  }
+
+  if (!refreshResponse.ok) {
+    return { ok: false, reason: 'REFRESH_FAILED' };
+  }
+
+  let refreshBody: RefreshResponseShape;
+  try {
+    refreshBody = (await refreshResponse.json()) as RefreshResponseShape;
+  } catch (error) {
+    logError('auth.bootstrap.refresh.parse', error);
+    return { ok: false, reason: 'REFRESH_INVALID' };
+  }
+
+  const accessToken = refreshBody.accessToken;
+  if (typeof accessToken !== 'string' || accessToken.length === 0) {
+    return { ok: false, reason: 'REFRESH_INVALID' };
+  }
+
+  let meResponse: Response;
+  try {
+    meResponse = await fetch(`${resolved.baseUrl}/v1/auth/me`, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      cache: 'no-store',
+    });
+  } catch (error) {
+    logError('auth.bootstrap.me.network', error);
+    return { ok: false, reason: 'NETWORK' };
+  }
+
+  if (!meResponse.ok) {
+    return { ok: false, reason: 'ME_FAILED' };
+  }
+
+  let meBody: MeResponseShape;
+  try {
+    meBody = (await meResponse.json()) as MeResponseShape;
+  } catch (error) {
+    logError('auth.bootstrap.me.parse', error);
+    return { ok: false, reason: 'ME_INVALID' };
+  }
+
+  if (!meBody.user || typeof meBody.user !== 'object') {
+    return { ok: false, reason: 'ME_INVALID' };
+  }
+
+  return {
+    ok: true,
+    accessToken,
+    user: meBody.user as AuthUser,
+    setCookies: refreshResponse.headers.getSetCookie(),
+  };
+}

--- a/src/lib/auth/bootstrapFromCookies.ts
+++ b/src/lib/auth/bootstrapFromCookies.ts
@@ -65,6 +65,24 @@ interface RefreshResponseShape {
   accessToken?: unknown;
 }
 
+// Minimal shape check for the upstream user payload. FastAPI's Pydantic
+// schema is the canonical producer, but a 502 / partial response could
+// still return `{ user: {} }` — without this guard the cast to AuthUser
+// would let undefined fields propagate and crash the SSR render
+// (e.g. `user.name.split(' ')`).
+function isAuthUserShape(value: unknown): value is AuthUser {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.id === 'string' &&
+    typeof candidate.name === 'string' &&
+    typeof candidate.email === 'string' &&
+    typeof candidate.username === 'string' &&
+    typeof candidate.role === 'string' &&
+    typeof candidate.familySpaceId === 'string'
+  );
+}
+
 function getFastApiBaseUrl(): string | null {
   const raw = process.env.NEXT_PUBLIC_API_BASE_URL;
   if (!raw) return null;
@@ -145,11 +163,11 @@ export async function fetchSessionUser(
     return { ok: false, reason: 'SESSION_INVALID' };
   }
 
-  if (!body.user || typeof body.user !== 'object') {
+  if (!isAuthUserShape(body.user)) {
     return { ok: false, reason: 'SESSION_INVALID' };
   }
 
-  return { ok: true, user: body.user as AuthUser };
+  return { ok: true, user: body.user };
 }
 
 // ---------------------------------------------------------------------------
@@ -224,14 +242,14 @@ export async function bootstrapAccessToken(
     return { ok: false, reason: 'ME_INVALID' };
   }
 
-  if (!meBody.user || typeof meBody.user !== 'object') {
+  if (!isAuthUserShape(meBody.user)) {
     return { ok: false, reason: 'ME_INVALID' };
   }
 
   return {
     ok: true,
     accessToken,
-    user: meBody.user as AuthUser,
+    user: meBody.user,
     setCookies: refreshResponse.headers.getSetCookie(),
   };
 }

--- a/src/lib/authStore.ts
+++ b/src/lib/authStore.ts
@@ -1,0 +1,74 @@
+import { setAccessTokenProvider, setRefreshHooks } from '@/lib/apiClient';
+
+export interface AuthUser {
+  id: string;
+  name: string;
+  email: string;
+  username: string;
+  emailOrUsername: string;
+  avatarUrl: string | null;
+  role: string;
+  familySpaceId: string;
+  familySpaceName: string | null;
+}
+
+interface AuthSnapshot {
+  accessToken: string | null;
+  user: AuthUser | null;
+}
+
+let snapshot: AuthSnapshot = { accessToken: null, user: null };
+const listeners = new Set<() => void>();
+
+function notify(): void {
+  for (const listener of listeners) listener();
+}
+
+export function getAccessToken(): string | null {
+  return snapshot.accessToken;
+}
+
+export function getUser(): AuthUser | null {
+  return snapshot.user;
+}
+
+export function setSession(accessToken: string, user: AuthUser): void {
+  if (snapshot.accessToken === accessToken && snapshot.user === user) return;
+  snapshot = { accessToken, user };
+  notify();
+}
+
+export function clearSession(): void {
+  if (snapshot.accessToken === null && snapshot.user === null) return;
+  snapshot = { accessToken: null, user: null };
+  notify();
+}
+
+export function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function getSnapshot(): AuthSnapshot {
+  return snapshot;
+}
+
+setAccessTokenProvider(getAccessToken);
+
+// Wire the apiClient's refresh-and-retry callbacks. /v1/auth/refresh returns
+// only the rotated access token — the user identity carries forward from the
+// existing session, so we update only the token here.
+setRefreshHooks({
+  onRefreshed: (accessToken) => {
+    if (snapshot.user === null) {
+      // Refresh succeeded but we have no user to attach the token to. Treat
+      // it as a failure so the next 401 forces a clean re-login.
+      clearSession();
+      return;
+    }
+    setSession(accessToken, snapshot.user);
+  },
+  onRefreshFailed: clearSession,
+});

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -1,0 +1,8 @@
+// `NEXT_PUBLIC_*` env vars are inlined by Next at build time, so flipping the
+// flag in a deployed environment requires a rebuild (same caveat as
+// `NEXT_PUBLIC_API_BASE_URL` in apiClient.ts:27-30). Exported as a function
+// rather than a const so jest can re-evaluate process.env between tests.
+
+export function isFastApiAuthEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_USE_FASTAPI_AUTH === 'true';
+}

--- a/src/lib/session-core.ts
+++ b/src/lib/session-core.ts
@@ -47,3 +47,19 @@ export async function getSessionFromRequest(
 
   return verifyToken(token);
 }
+
+// Phase 2 dual-mode session check for the Edge middleware. Returns true if
+// either a valid Next session JWT OR a FastAPI refresh_token cookie is
+// present. The refresh_token check is presence-only (no JWT decode) so the
+// helper stays Edge-runtime safe. Phase 4 removes the Next session branch
+// entirely once the FastAPI cutover completes.
+const REFRESH_COOKIE_NAME = 'refresh_token';
+
+export async function hasAnySessionFromRequest(
+  request: NextRequest
+): Promise<boolean> {
+  const session = await getSessionFromRequest(request);
+  if (session !== null) return true;
+  const refreshCookie = request.cookies.get(REFRESH_COOKIE_NAME)?.value;
+  return typeof refreshCookie === 'string' && refreshCookie.length > 0;
+}

--- a/src/lib/session-core.ts
+++ b/src/lib/session-core.ts
@@ -53,6 +53,14 @@ export async function getSessionFromRequest(
 // present. The refresh_token check is presence-only (no JWT decode) so the
 // helper stays Edge-runtime safe. Phase 4 removes the Next session branch
 // entirely once the FastAPI cutover completes.
+//
+// Trade-off: an attacker setting `Cookie: refresh_token=anything` will be
+// routed to /timeline instead of /login by the middleware. This is NOT an
+// auth bypass — every protected data route still authenticates the cookie
+// against FastAPI and 401s on a forgery. The only consequence is a worse
+// UX surface (the gate page render is wasted on a forged cookie). Acceptable
+// for V1 single-family scope; a future Edge-compatible verifier (e.g.
+// shared HMAC signature on the cookie) could tighten this.
 const REFRESH_COOKIE_NAME = 'refresh_token';
 
 export async function hasAnySessionFromRequest(

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,9 +1,10 @@
 import { NextRequest } from 'next/server';
 import { prisma } from './prisma';
 import {
-  getSessionFromRequest,
-  setSessionCookie,
   clearSessionCookie,
+  getSessionFromRequest,
+  hasAnySessionFromRequest,
+  setSessionCookie,
 } from './session-core';
 
 type GetSignedUploadUrl = (typeof import('./uploads'))['getSignedUploadUrl'];
@@ -65,4 +66,9 @@ export async function getCurrentUser(request: NextRequest) {
   }
 }
 
-export { setSessionCookie, clearSessionCookie, getSessionFromRequest };
+export {
+  setSessionCookie,
+  clearSessionCookie,
+  getSessionFromRequest,
+  hasAnySessionFromRequest,
+};

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,9 +1,14 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
-import { getSessionFromRequest } from './lib/session-core';
+import { hasAnySessionFromRequest } from './lib/session-core';
+
+// Phase 2 dual-mode middleware: accepts either the Next session cookie or
+// the FastAPI refresh_token cookie as proof of authentication. Edge-runtime
+// safe — the FastAPI cookie is checked for presence only, not decoded.
+// Phase 4 removes the Next branch and goes refresh_token-only.
 
 export async function proxy(request: NextRequest) {
-  const session = await getSessionFromRequest(request);
+  const hasSession = await hasAnySessionFromRequest(request);
   const { pathname } = request.nextUrl;
 
   // Check if user is accessing auth pages (login, signup)
@@ -21,12 +26,12 @@ export async function proxy(request: NextRequest) {
     pathname.startsWith('/posts');
 
   // If user is logged in and trying to access auth pages, redirect to timeline
-  if (session && isAuthPage) {
+  if (hasSession && isAuthPage) {
     return NextResponse.redirect(new URL('/timeline', request.url));
   }
 
   // If user is not logged in and trying to access protected routes, redirect to login
-  if (!session && isAppRoute) {
+  if (!hasSession && isAppRoute) {
     const loginUrl = new URL('/login', request.url);
     loginUrl.searchParams.set('redirect', pathname);
     return NextResponse.redirect(loginUrl);


### PR DESCRIPTION
## Summary

Phase 2 of the FastAPI migration ([#36](https://github.com/wnorowskie/family-recipe/issues/36)). Wires the Next frontend onto the FastAPI token flow without breaking the existing cookie path. The FastAPI path lights up when \`NEXT_PUBLIC_USE_FASTAPI_AUTH=true\`; flag-off behavior is unchanged from \`develop\`.

## Dependencies

- **Depends on [#174](https://github.com/wnorowskie/family-recipe/pull/174) (merged):** the SSR layout calls \`GET /v1/auth/session\` (non-rotating verify endpoint added by [#173](https://github.com/wnorowskie/family-recipe/issues/173)). Without that endpoint the chain would advance twice per page load and trip reuse-detection. PR #174 was merged to develop before the rebase that produced commit [\`495f966\`](https://github.com/wnorowskie/family-recipe/commit/495f966).

## What's in here

**Infra:**

- **In-memory auth store** ([src/lib/authStore.ts](src/lib/authStore.ts)) — module-scoped access token + user. Token never touches \`localStorage\`. Module-load side effect wires \`apiClient\`'s \`setAccessTokenProvider\` and \`setRefreshHooks\` to avoid an apiClient ↔ authStore import cycle.
- **Feature flag** ([src/lib/featureFlags.ts](src/lib/featureFlags.ts)) — \`isFastApiAuthEnabled()\` reads \`NEXT_PUBLIC_USE_FASTAPI_AUTH\` (build-time inlined, same caveat as \`NEXT_PUBLIC_API_BASE_URL\`).
- **Refresh-and-retry on 401** ([src/lib/apiClient.ts](src/lib/apiClient.ts)) — \`tryRefresh()\` POSTs to \`/v1/auth/refresh\` with \`X-CSRF-Token\` from the \`csrf_token\` cookie. Concurrent 401s share a single in-flight refresh via an \`inflightRefresh\` singleton. Auth endpoints (\`/v1/auth/{refresh,login,signup,logout}\`) bypass the retry loop to prevent recursion. **At most one retry per request cycle** — no \`while\` loop.
- **\`useAuth\` hook** ([src/hooks/useAuth.ts](src/hooks/useAuth.ts)) — \`useSyncExternalStore\` wrapper; SSR snapshot returns \`null\` so server components fall through to the existing \`getCurrentUser\` path.

**Auth bootstrap (commit [\`495f966\`](https://github.com/wnorowskie/family-recipe/commit/495f966)):**

The chain advances exactly **once** per page load, via the route handler that can propagate \`Set-Cookie\` back to the browser. Two split helpers in [src/lib/auth/bootstrapFromCookies.ts](src/lib/auth/bootstrapFromCookies.ts):

| Helper | Surface | Caller | Rotates? | Set-Cookie? |
|---|---|---|---|---|
| \`fetchSessionUser\` | \`GET /v1/auth/session\` | SSR \`(app)/layout.tsx\` | **No** | No (type-enforced — \`SessionUserResult\` deliberately omits \`setCookies\`) |
| \`bootstrapAccessToken\` | \`POST /v1/auth/refresh\` + \`GET /v1/auth/me\` | \`/api/auth/bootstrap\` route handler | **Yes** | Forwarded to browser |

Both helpers run an \`isAuthUserShape\` type-guard before casting the upstream user payload, so a malformed \`{ user: {} }\` from FastAPI surfaces as \`*_INVALID\` instead of crashing the SSR render with \`undefined.split(' ')\`.

**UX surfaces:**

- **Login / signup / logout flag-gated** ([login](src/app/%28auth%29/login/page.tsx), [signup](src/app/%28auth%29/signup/page.tsx), [LogoutButton](src/components/LogoutButton.tsx)) — flag-on path posts to \`/v1/auth/{login,signup,logout}\` via the apiClient and seeds/clears the in-memory authStore. Reset-password is deferred to Phase 3 (no \`/v1/auth/reset\` endpoint exists yet).
- **Bootstrap route** ([src/app/api/auth/bootstrap/route.ts](src/app/api/auth/bootstrap/route.ts)) — Node-runtime handler that calls \`bootstrapAccessToken\` and mounts the rotated \`Set-Cookie\` headers on its response. Single rotation point per page load.
- **AuthBootstrap component** ([src/components/AuthBootstrap.tsx](src/components/AuthBootstrap.tsx)) — runs once on mount, POSTs \`/api/auth/bootstrap\` to mint the client's access token. On failure clears the store and redirects to \`/login\`. Children render unconditionally (initial UI is already SSR-rendered with the user from \`fetchSessionUser\`).
- **Protected layout** ([src/app/(app)/layout.tsx](src/app/%28app%29/layout.tsx)) — flag-on branch calls \`fetchSessionUser\` directly (no self-fetch), redirects to \`/login\` on failure, wraps children in \`<AuthBootstrap>\`. Notification count stays on Prisma — Phase 3 ([#171](https://github.com/wnorowskie/family-recipe/issues/171)) moves it to a \`/v1\` FastAPI endpoint.
- **Dual-mode middleware** ([src/lib/session-core.ts](src/lib/session-core.ts), [src/proxy.ts](src/proxy.ts)) — new \`hasAnySessionFromRequest()\` returns true if either a valid Next session JWT OR a \`refresh_token\` cookie is present. Edge-runtime safe (presence-only on the FastAPI cookie). Phase 4 removes the Next branch.
- **E2E coverage** ([e2e/fastapi-auth.spec.ts](e2e/fastapi-auth.spec.ts)) — four \`@fastapi-auth\` tagged tests: login → reload, in-memory token (no localStorage), logout flow, no-loop on persistent \`/v1/auth/refresh\` 401s. Skipped unless \`NEXT_PUBLIC_USE_FASTAPI_AUTH=true\`.
- **Verification doc** ([docs/verification/ui.md](docs/verification/ui.md)) — Phase 2 dual-mode section with manual checklist for both flag states.
- **Stack 0 cookie/CORS source review** ([docs/research/fastapi-cookie-domain-stack0.md](docs/research/fastapi-cookie-domain-stack0.md)) — local dev works as-is; deployed environments need a custom apex domain or a same-origin proxy because \`*.run.app\` is on the Public Suffix List.

## Acceptance criteria addressed (from #36)

- ✅ Login, signup forms call FastAPI via the Phase 0 API client (reset-password deferred to Phase 3)
- ✅ Access token stored in memory only (dedicated auth store, not localStorage); refresh token via httpOnly cookie
- ✅ API client auto-attempts a single refresh on 401; second 401 forces logout
- ✅ On page reload, the client bootstraps via \`/api/auth/bootstrap\` (which internally rotates and sets the new cookies)
- ✅ Server components prefetch user data via \`/v1/auth/session\` (non-rotating) so SSR renders without auth flash
- ✅ Next middleware remains cookie-based during dual-mode (removed in Phase 4)
- ✅ Feature flag \`USE_FASTAPI_AUTH\` gates the migration; with it off, Next cookie auth still works
- ✅ Refresh loop protection: client never retries refresh more than once per request cycle

## Risk

- **Flag-off path is byte-identical** for every edited file except the middleware. The middleware change is additive: \`hasAnySessionFromRequest\` accepts the existing Next session OR a \`refresh_token\` cookie. With flag off, no FastAPI cookies are ever set, so the middleware's behavior is unchanged in practice.
- **Module-load side effect** in \`authStore.ts\` registers callbacks on \`apiClient\`. Tests verify the wiring round-trips and the existing API client tests still pass with the refactor.
- **Deployed environments need cookie-domain config**. Default Phase 1 settings only work for same-origin (e.g. \`localhost:3000\` ↔ \`localhost:8000\`). Cloud Run subdomains under \`*.run.app\` won't share cookies because that suffix is on the [Public Suffix List](https://publicsuffix.org/) — see [Stack 0 doc](docs/research/fastapi-cookie-domain-stack0.md). Phase 2 source code is agnostic; this is a deploy-architecture decision tracked separately.

## Test plan

- [x] \`npm run type-check\` clean
- [x] \`npm run lint\` clean
- [x] \`npm test\` — all 1043+ tests pass. +14 tests for auth store / feature flag, +12 tests for refresh-and-retry, +7 tests for dual-mode session helper, +10 tests for the bootstrap route, +19 tests for the bootstrap helpers (including the \`isAuthUserShape\` guard).
- [x] \`npm run build\` clean (no warnings, no errors)
- [ ] Manual smoke (flag OFF): login / signup / logout / reset-password / deep-link redirect / remember-me work as on \`develop\` today.
- [ ] Manual smoke (flag ON): login → reload → still authed; logout clears state; refresh-and-retry works on token expiry. (Requires running FastAPI locally — see [docs/verification/ui.md](docs/verification/ui.md) Phase 2 section.)
- [ ] E2E flag ON: \`NEXT_PUBLIC_USE_FASTAPI_AUTH=true NEXT_PUBLIC_API_BASE_URL=http://localhost:8000 npx playwright test e2e/fastapi-auth.spec.ts --grep @fastapi-auth\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)