### PR TITLE
chore(api): fail-fast startup validation + tighten broad except blocks (#170)

### DIFF
--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -7,11 +7,15 @@ from .db import connect_db, disconnect_db
 from .errors import ApiError, error_response
 from .routers import auth, comments, family, health, me, posts, profile, reactions, recipes, tags, timeline
 from .routers.v1 import auth as auth_v1
-from .settings import settings
+from .settings import settings, validate_settings
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    # Fail-fast on misconfigured prod env BEFORE accepting traffic. A bad
+    # config used to surface lazily on the first /v1/auth/login call (silent
+    # 500s); now uvicorn exits non-zero before /health becomes reachable.
+    validate_settings(settings)
     await connect_db()
     try:
         yield

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -1,5 +1,6 @@
 import logging
 
+import jwt
 from fastapi import APIRouter, Depends, Response, status
 from prisma.errors import PrismaError
 
@@ -85,7 +86,7 @@ async def signup(payload: SignupRequest, response: Response):
     except PrismaError as error:
         logger.exception("auth.signup.prisma_error: %s", error)
         return internal_error("Database error during signup")
-    except Exception as error:  # noqa: BLE001
+    except (jwt.PyJWTError, ValueError) as error:
         logger.exception("auth.signup.error: %s", error)
         return internal_error("Failed to signup")
 
@@ -154,7 +155,7 @@ async def login(payload: LoginRequest, response: Response):
     except PrismaError as error:
         logger.exception("auth.login.prisma_error: %s", error)
         return internal_error("Database error during login")
-    except Exception as error:  # noqa: BLE001
+    except (jwt.PyJWTError, ValueError) as error:
         logger.exception("auth.login.error: %s", error)
         return internal_error("Failed to login")
 
@@ -166,9 +167,5 @@ async def me(user: UserResponse = Depends(get_current_user)):
 
 @router.post("/logout", response_model=dict[str, str])
 async def logout(response: Response, user: UserResponse = Depends(get_current_user)):
-    try:
-        clear_session_cookie(response)
-        return {"message": "Logged out successfully"}
-    except Exception as error:  # noqa: BLE001
-        logger.exception("auth.logout.error: %s", error)
-        return internal_error("Failed to logout")
+    clear_session_cookie(response)
+    return {"message": "Logged out successfully"}

--- a/apps/api/src/routers/v1/auth.py
+++ b/apps/api/src/routers/v1/auth.py
@@ -13,6 +13,7 @@ import logging
 from datetime import datetime, timezone
 from typing import Optional
 
+import jwt
 from fastapi import APIRouter, Depends, Header, Request, Response, status
 from prisma.errors import PrismaError
 
@@ -213,7 +214,10 @@ async def signup(payload: SignupRequest, request: Request, response: Response):
     except PrismaError as error:
         logger.exception("auth_v1.signup.prisma_error: %s", error)
         return internal_error("Database error during signup")
-    except Exception as error:  # noqa: BLE001
+    except (jwt.PyJWTError, ValueError) as error:
+        # JWT mint failure or input-shape errors (e.g. bcrypt rejecting an
+        # over-long password). Genuinely unexpected exceptions propagate so
+        # we get a real stack trace instead of a sanitized 500.
         logger.exception("auth_v1.signup.error: %s", error)
         return internal_error("Failed to signup")
 
@@ -265,7 +269,7 @@ async def login(payload: LoginRequest, request: Request, response: Response):
     except PrismaError as error:
         logger.exception("auth_v1.login.prisma_error: %s", error)
         return internal_error("Database error during login")
-    except Exception as error:  # noqa: BLE001
+    except (jwt.PyJWTError, ValueError) as error:
         logger.exception("auth_v1.login.error: %s", error)
         return internal_error("Failed to login")
 
@@ -396,7 +400,7 @@ async def refresh(
     except PrismaError as error:
         logger.exception("auth_v1.refresh.prisma_error: %s", error)
         return internal_error("Database error during refresh")
-    except Exception as error:  # noqa: BLE001
+    except (jwt.PyJWTError, ValueError) as error:
         logger.exception("auth_v1.refresh.error: %s", error)
         return internal_error("Failed to refresh")
 
@@ -486,6 +490,6 @@ async def session(
     except PrismaError as error:
         logger.exception("auth_v1.session.prisma_error: %s", error)
         return internal_error("Database error during session check")
-    except Exception as error:  # noqa: BLE001
+    except (jwt.PyJWTError, ValueError) as error:
         logger.exception("auth_v1.session.error: %s", error)
         return internal_error("Failed to validate session")

--- a/apps/api/src/settings.py
+++ b/apps/api/src/settings.py
@@ -81,11 +81,14 @@ class Settings(BaseSettings):
     def effective_refresh_pepper(self) -> str:
         """Required pepper; falls back to jwt_secret in non-production.
 
-        In production, validate_settings() guarantees `refresh_pepper` is set
-        at startup, so the fallback branch is unreachable when ENVIRONMENT=production.
+        validate_settings() enforces this at startup in production, but we
+        keep a local raise too: defense-in-depth for code paths that construct
+        Settings outside the lifespan (tests, scripts, future entrypoints).
         """
         if self.refresh_pepper:
             return self.refresh_pepper
+        if self.is_production:
+            raise RuntimeError("REFRESH_PEPPER must be set in production")
         return self.jwt_secret
 
     @property
@@ -98,7 +101,7 @@ class Settings(BaseSettings):
 _MIN_PROD_SECRET_LEN = 32
 
 
-def validate_settings(s: "Settings") -> None:
+def validate_settings(s: Settings) -> None:
     """Fail-fast validation called from main.py's lifespan in production.
 
     Raises RuntimeError with all problems concatenated so a misconfigured

--- a/apps/api/src/settings.py
+++ b/apps/api/src/settings.py
@@ -79,16 +79,69 @@ class Settings(BaseSettings):
 
     @property
     def effective_refresh_pepper(self) -> str:
-        """Required pepper; falls back to jwt_secret in non-production."""
+        """Required pepper; falls back to jwt_secret in non-production.
+
+        In production, validate_settings() guarantees `refresh_pepper` is set
+        at startup, so the fallback branch is unreachable when ENVIRONMENT=production.
+        """
         if self.refresh_pepper:
             return self.refresh_pepper
-        if self.is_production:
-            raise RuntimeError("REFRESH_PEPPER must be set in production")
         return self.jwt_secret
 
     @property
     def cors_origins_list(self) -> list[str]:
         return [o.strip() for o in self.cors_allow_origins.split(",") if o.strip()]
+
+
+# Minimum entropy for HMAC secrets in production. 32 bytes ≈ 256 bits, the
+# standard floor for HMAC-SHA256 keying material.
+_MIN_PROD_SECRET_LEN = 32
+
+
+def validate_settings(s: "Settings") -> None:
+    """Fail-fast validation called from main.py's lifespan in production.
+
+    Raises RuntimeError with all problems concatenated so a misconfigured
+    deploy surfaces every issue at once instead of fixing them one at a time.
+    No-op outside production — dev runs intentionally tolerate weak/missing
+    values so a fresh clone works without ceremony.
+    """
+    if not s.is_production:
+        return
+
+    problems: list[str] = []
+
+    if not s.refresh_pepper:
+        problems.append("REFRESH_PEPPER must be set in production")
+    elif len(s.refresh_pepper) < _MIN_PROD_SECRET_LEN:
+        problems.append(
+            f"REFRESH_PEPPER must be at least {_MIN_PROD_SECRET_LEN} characters in production"
+        )
+
+    if len(s.jwt_secret) < _MIN_PROD_SECRET_LEN:
+        problems.append(
+            f"JWT_SECRET must be at least {_MIN_PROD_SECRET_LEN} characters in production"
+        )
+
+    samesite = s.refresh_cookie_samesite.lower()
+    if samesite not in ("lax", "strict"):
+        # SameSite=None requires a documented cross-site need. Frontend and
+        # API are same-origin in prod, so this is almost certainly a misconfig.
+        problems.append(
+            "REFRESH_COOKIE_SAMESITE must be 'lax' or 'strict' in production "
+            f"(got {s.refresh_cookie_samesite!r})"
+        )
+
+    if s.access_token_signing_keys:
+        try:
+            _ = s.signing_keys
+        except ValueError as exc:
+            problems.append(f"ACCESS_TOKEN_SIGNING_KEYS invalid: {exc}")
+
+    if problems:
+        raise RuntimeError(
+            "Invalid production configuration:\n  - " + "\n  - ".join(problems)
+        )
 
 
 settings = Settings()

--- a/apps/api/tests/unit/test_settings.py
+++ b/apps/api/tests/unit/test_settings.py
@@ -1,0 +1,117 @@
+"""Unit tests for validate_settings() — the prod-only fail-fast guard."""
+import pytest
+
+from src.settings import Settings, validate_settings
+
+
+def _prod_settings(**overrides) -> Settings:
+    """Build a Settings instance with valid prod defaults; override per-test."""
+    base: dict[str, object] = {
+        "environment": "production",
+        "database_url": "postgresql://user:pass@host/db",
+        "jwt_secret": "x" * 32,
+        "refresh_pepper": "y" * 32,
+        "refresh_cookie_samesite": "lax",
+    }
+    base.update(overrides)
+    return Settings(**base)
+
+
+class TestValidateSettings:
+    def test_dev_environment_skips_validation(self):
+        """Outside production, validate_settings is a no-op even with bad values."""
+        s = Settings(
+            environment="development",
+            database_url="postgresql://x/y",
+            jwt_secret="short",
+            refresh_pepper=None,
+            refresh_cookie_samesite="none",
+        )
+        validate_settings(s)  # must not raise
+
+    def test_valid_prod_config_passes(self):
+        validate_settings(_prod_settings())
+
+    def test_strict_samesite_is_accepted_in_prod(self):
+        validate_settings(_prod_settings(refresh_cookie_samesite="strict"))
+
+    def test_missing_refresh_pepper_fails_in_prod(self):
+        s = _prod_settings(refresh_pepper=None)
+        with pytest.raises(RuntimeError, match="REFRESH_PEPPER must be set"):
+            validate_settings(s)
+
+    def test_short_refresh_pepper_fails_in_prod(self):
+        s = _prod_settings(refresh_pepper="short")
+        with pytest.raises(RuntimeError, match="REFRESH_PEPPER must be at least 32"):
+            validate_settings(s)
+
+    def test_short_jwt_secret_fails_in_prod(self):
+        s = _prod_settings(jwt_secret="short")
+        with pytest.raises(RuntimeError, match="JWT_SECRET must be at least 32"):
+            validate_settings(s)
+
+    def test_samesite_none_rejected_in_prod(self):
+        s = _prod_settings(refresh_cookie_samesite="none")
+        with pytest.raises(RuntimeError, match="REFRESH_COOKIE_SAMESITE"):
+            validate_settings(s)
+
+    def test_invalid_samesite_value_rejected_in_prod(self):
+        s = _prod_settings(refresh_cookie_samesite="bogus")
+        with pytest.raises(RuntimeError, match="REFRESH_COOKIE_SAMESITE"):
+            validate_settings(s)
+
+    def test_invalid_signing_keys_json_rejected_in_prod(self):
+        s = _prod_settings(access_token_signing_keys="{not valid json")
+        with pytest.raises(RuntimeError, match="ACCESS_TOKEN_SIGNING_KEYS"):
+            validate_settings(s)
+
+    def test_signing_keys_missing_active_kid_rejected_in_prod(self):
+        s = _prod_settings(
+            access_token_signing_keys='{"v2": "secret-value"}',
+            access_token_active_kid="v1",
+        )
+        with pytest.raises(RuntimeError, match="ACCESS_TOKEN_SIGNING_KEYS"):
+            validate_settings(s)
+
+    def test_valid_signing_keys_with_active_kid_passes(self):
+        validate_settings(
+            _prod_settings(
+                access_token_signing_keys='{"v1": "active-key", "v2": "rotation"}',
+                access_token_active_kid="v1",
+            )
+        )
+
+    def test_all_problems_reported_together(self):
+        """A misconfig with multiple issues surfaces them all in one error."""
+        s = _prod_settings(
+            refresh_pepper=None,
+            jwt_secret="short",
+            refresh_cookie_samesite="none",
+        )
+        with pytest.raises(RuntimeError) as exc_info:
+            validate_settings(s)
+        msg = str(exc_info.value)
+        assert "REFRESH_PEPPER" in msg
+        assert "JWT_SECRET" in msg
+        assert "REFRESH_COOKIE_SAMESITE" in msg
+
+
+class TestEffectiveRefreshPepper:
+    def test_uses_pepper_when_set(self):
+        s = Settings(
+            environment="production",
+            database_url="postgresql://x/y",
+            jwt_secret="x" * 32,
+            refresh_pepper="explicit-pepper-value",
+        )
+        assert s.effective_refresh_pepper == "explicit-pepper-value"
+
+    def test_falls_back_to_jwt_secret_in_dev(self):
+        """In dev, missing pepper silently falls back to jwt_secret (no ceremony)."""
+        s = Settings(
+            environment="development",
+            database_url="postgresql://x/y",
+            jwt_secret="dev-secret",
+            refresh_pepper=None,
+        )
+        assert s.effective_refresh_pepper == "dev-secret"

--- a/apps/api/tests/unit/test_settings.py
+++ b/apps/api/tests/unit/test_settings.py
@@ -115,3 +115,14 @@ class TestEffectiveRefreshPepper:
             refresh_pepper=None,
         )
         assert s.effective_refresh_pepper == "dev-secret"
+
+    def test_raises_in_prod_when_pepper_missing(self):
+        """Defense-in-depth: even if validate_settings() is bypassed, prod fails loud."""
+        s = Settings(
+            environment="production",
+            database_url="postgresql://x/y",
+            jwt_secret="x" * 32,
+            refresh_pepper=None,
+        )
+        with pytest.raises(RuntimeError, match="REFRESH_PEPPER must be set"):
+            _ = s.effective_refresh_pepper


### PR DESCRIPTION
Closes #170.

## Summary

- New `validate_settings()` runs first thing in the FastAPI lifespan (`main.py`), so a misconfigured prod deploy exits non-zero before `/health` becomes reachable instead of surfacing as silent 500s on the first `/v1/auth/login`. Validator collects every problem and reports them together. No-op outside production.
- Narrowed `except Exception` to `(jwt.PyJWTError, ValueError)` in the four `/v1/auth/*` handlers (signup/login/refresh/session) and the two legacy `/auth/*` handlers (signup/login). Removed the dead try/except in legacy `/auth/logout` (the wrapped `clear_session_cookie` can't raise).

## Production checks performed at startup

- `REFRESH_PEPPER` set + ≥32 chars (was lazy: only checked on first auth call)
- `JWT_SECRET` ≥32 chars (was non-empty-checked but unbounded length)
- `REFRESH_COOKIE_SAMESITE` ∈ `{lax, strict}` — rejects `none` outright. Frontend and FastAPI are same-origin in prod, so `SameSite=None` would imply a misconfig and would break under the Secure-required browser rules anyway.
- `ACCESS_TOKEN_SIGNING_KEYS` parses if set, with the active kid present (was lazy via the `signing_keys` property)

## Why these specific items

`refresh_cookie_domain` is intentionally **not** prod-required despite being mentioned in the ticket. Leaving it unset scopes cookies to the exact host serving the response — the safer default. Forcing every prod deploy to set a domain creates foot-guns (overly broad cookie scope across subdomains).

The 32-char/256-bit floor matches the standard HMAC-SHA256 minimum (RFC 7518 §3.2). Pre-existing test fixtures in `test_tokens.py` use shorter keys intentionally to exercise rotation logic — those warnings are unchanged by this PR.

## Scope discipline

Only the v1/auth.py + legacy auth.py broad-excepts called out in the ticket are narrowed. There are 16 other `except Exception` sites across other routers (posts, comments, profile, etc.); those are out of scope for this hardening pass.

## Test plan

- [x] `pytest` (full apps/api suite) — 379 passed, 14 new, no regressions
- [x] `ruff check src/ tests/` — clean
- [x] OpenAPI snapshot byte-identical (no router contract drift)
- [x] Boot smoke (negative): `ENVIRONMENT=production` + missing `REFRESH_PEPPER` → `RuntimeError` with a clear named message before traffic
- [x] Boot smoke (positive): `ENVIRONMENT=development` no-op even with weak/missing values
- [x] Unit tests in `tests/unit/test_settings.py` cover: dev no-op, valid prod, each individual prod failure, multi-problem collection, signing-key edge cases

## Verification playbook

Per [docs/verification/fastapi.md](docs/verification/fastapi.md). No router contract changes — touched files are `settings.py`, `main.py`, and exception-handler narrowing in `routers/v1/auth.py` + `routers/auth.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)