### PR TITLE
chore(api): narrow except Exception in non-auth FastAPI routers (#177)

### DIFF
--- a/apps/api/src/routers/comments.py
+++ b/apps/api/src/routers/comments.py
@@ -41,7 +41,7 @@ def _clamp_limit(value: Optional[int], default: int, max_value: int) -> int:
         return default
     try:
         v = int(value)
-    except Exception:
+    except (ValueError, TypeError):
         return default
     v = max(1, v)
     return min(v, max_value)

--- a/apps/api/src/routers/me.py
+++ b/apps/api/src/routers/me.py
@@ -44,7 +44,7 @@ async def my_favorites(limit: int = 20, offset: int = 0, user: UserResponse = De
     except PrismaError as e:
         logger.exception("me.favorites.prisma_error: %s", e)
         return internal_error("Failed to load favorites")
-    except Exception as e:
+    except (ValueError, TypeError, AttributeError, KeyError) as e:
         logger.exception("me.favorites.error: %s", e)
         return internal_error("Failed to load favorites")
 
@@ -84,7 +84,7 @@ async def update_profile(
         }
     except PrismaError:
         return internal_error("Failed to update profile")
-    except Exception:
+    except (ValueError, TypeError, AttributeError, KeyError):
         return internal_error("Failed to update profile")
 
 
@@ -109,5 +109,5 @@ async def change_password(payload: dict, user: UserResponse = Depends(get_curren
         return {"message": "Password updated"}
     except PrismaError:
         return internal_error("Failed to update password")
-    except Exception:
+    except (ValueError, TypeError, AttributeError, KeyError):
         return internal_error("Failed to update password")

--- a/apps/api/src/routers/posts.py
+++ b/apps/api/src/routers/posts.py
@@ -36,7 +36,7 @@ def _parse_courses_from_recipe_details(details: Any) -> List[str]:
                 values = [c for c in parsed if isinstance(c, str) and c in COURSE_VALUES]
         elif isinstance(courses_raw, list):
             values = [c for c in courses_raw if isinstance(c, str) and c in COURSE_VALUES]
-    except Exception:
+    except (json.JSONDecodeError, TypeError):
         values = []
     if not values and getattr(details, "course", None) in COURSE_VALUES:
         values = [getattr(details, "course")]
@@ -48,7 +48,7 @@ def _clamp_limit(value: Optional[int], default: int, max_value: int) -> int:
         return default
     try:
         v = int(value)
-    except Exception:
+    except (ValueError, TypeError):
         return default
     v = max(1, v)
     return min(v, max_value)
@@ -164,7 +164,7 @@ async def create_post(
         return internal_error("Failed to create post")
     except PrismaError:
         return internal_error("Failed to create post")
-    except Exception:
+    except (TypeError, AttributeError, KeyError):
         return internal_error("Failed to create post")
 
 
@@ -435,7 +435,7 @@ async def update_post(
                     continue
                 try:
                     file_index = int(file_index_raw)
-                except Exception:
+                except (ValueError, TypeError):
                     continue
                 if 0 <= file_index < len(saved_photos):
                     resolved_photos.append((saved_photos[file_index]["url"], f"new-{file_index}"))
@@ -527,7 +527,7 @@ async def update_post(
         return internal_error("Failed to update post")
     except PrismaError:
         return internal_error("Failed to update post")
-    except Exception:
+    except (TypeError, AttributeError, KeyError):
         return internal_error("Failed to update post")
 
 
@@ -552,7 +552,7 @@ async def delete_post(
         return {"message": "Post deleted"}
     except PrismaError:
         return internal_error("Failed to delete post")
-    except Exception:
+    except (ValueError, TypeError, AttributeError, KeyError):
         return internal_error("Failed to delete post")
 
 

--- a/apps/api/src/routers/profile.py
+++ b/apps/api/src/routers/profile.py
@@ -94,7 +94,7 @@ async def my_cooked(
     except PrismaError as e:
         logger.exception("profile.cooked.prisma_error: %s", e)
         return internal_error("Failed to load cooked events")
-    except Exception as e:
+    except (ValueError, TypeError, AttributeError, KeyError) as e:
         logger.exception("profile.cooked.error: %s", e)
         return internal_error("Failed to load cooked events")
 
@@ -132,6 +132,6 @@ async def my_favorites(
     except PrismaError as e:
         logger.exception("profile.favorites.prisma_error: %s", e)
         return internal_error("Failed to load favorites")
-    except Exception as e:
+    except (ValueError, TypeError, AttributeError, KeyError) as e:
         logger.exception("profile.favorites.error: %s", e)
         return internal_error("Failed to load favorites")

--- a/apps/api/src/routers/reactions.py
+++ b/apps/api/src/routers/reactions.py
@@ -58,5 +58,5 @@ async def toggle_reaction(payload: ReactionRequest, user: UserResponse = Depends
         return {"reacted": True}
     except PrismaError:
         return internal_error("Failed to toggle reaction")
-    except Exception:
+    except (ValueError, TypeError, AttributeError, KeyError):
         return bad_request("Invalid reaction payload")

--- a/apps/api/src/routers/recipes.py
+++ b/apps/api/src/routers/recipes.py
@@ -1,3 +1,4 @@
+import json
 from typing import List, Optional, cast
 
 from fastapi import APIRouter, Depends, Query
@@ -44,14 +45,12 @@ def _parse_courses_from_recipe_details(recipe_details: Optional[object]) -> List
     try:
         courses_raw = recipe_details.courses  # type: ignore[attr-defined]
         if isinstance(courses_raw, str):
-            import json as _json
-
-            parsed = _json.loads(courses_raw)
+            parsed = json.loads(courses_raw)
             if isinstance(parsed, list):
                 return [c for c in parsed if isinstance(c, str) and c in COURSE_VALUES]
         if isinstance(courses_raw, list):
             return [c for c in courses_raw if isinstance(c, str) and c in COURSE_VALUES]
-    except Exception:
+    except (json.JSONDecodeError, TypeError):
         return []
     return []
 

--- a/apps/api/src/routers/timeline.py
+++ b/apps/api/src/routers/timeline.py
@@ -140,6 +140,6 @@ async def get_timeline(
     except PrismaError as e:
         logger.exception("timeline.prisma_error: %s", e)
         return internal_error("Failed to load timeline")
-    except Exception as e:
+    except (ValueError, TypeError, AttributeError, KeyError) as e:
         logger.exception("timeline.error: %s", e)
         return internal_error("Failed to load timeline")


### PR DESCRIPTION
Closes #177. Follow-up to PR #176 (which closed #170).

## Summary

- Narrow 10 handler-level `except Exception` catches across `timeline`, `me`, `reactions`, `profile`, and `posts` to `(ValueError, TypeError, AttributeError, KeyError)` so genuinely unexpected errors propagate as real stack traces instead of sanitized `INTERNAL_ERROR` 500s.
- Narrow 5 local `try/except` blocks in `recipes`, `posts`, and `comments` to the realistic class — `(json.JSONDecodeError, TypeError)` for JSON parsing, `(ValueError, TypeError)` for `int()` coercion. Hoisted `import json` in `recipes.py` to module level.
- The auth pattern `(jwt.PyJWTError, ValueError)` from #170 does NOT apply here — JWT verification happens upstream in the `get_current_user` dependency, so these routers never see `jwt.PyJWTError`. Adding `import jwt` to seven non-auth files would be cargo-culting.
- `posts.create_post` and `posts.update_post` keep the existing `except ValueError` for the `INVALID_TAG` sentinel above the catch-all and use `(TypeError, AttributeError, KeyError)` to avoid shadowing it.
- `reactions.toggle_reaction` keeps its `bad_request("Invalid reaction payload")` 400 mapping under the narrowed catch, as the ticket called out.
- No `# noqa: BLE001` comments existed in the codebase to remove (verified via `grep -r 'noqa: BLE001' apps/api/src` — empty).

## Behavioral notes

- Documented happy paths and `PrismaError` 500 paths are unchanged.
- A previously-masked `pydantic.ValidationError` from `CreatePostRequest.model_validate(...)` in `create_post` will now propagate to FastAPI's default exception handler (still 500, but with a real stack trace) instead of being flattened into `internal_error("Failed to create post")`. This is the bug-revealing intent the ticket explicitly calls out.

## Test plan

- [x] `pytest apps/api/` — 380 passed, 0 failed
- [x] `ruff check apps/api/src apps/api/tests` — clean
- [x] OpenAPI snapshot byte-identical (regenerated via `python scripts/dump_openapi.py` and diffed against `openapi.snapshot.json`)
- [x] Pre-commit hook (`type-check` + `lint-staged`) passed
- [ ] CI: api-ci.yml mypy job (skipped locally per project memory; relying on CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)