### PR TITLE
chore(api): mount all FastAPI routers under /v1 with un-prefixed aliases (#179)

### DIFF
--- a/apps/api/openapi.snapshot.json
+++ b/apps/api/openapi.snapshot.json
@@ -70,6 +70,31 @@
         "title": "Body_create_comment_posts__post_id__comments_post",
         "type": "object"
       },
+      "Body_create_comment_v1_posts__post_id__comments_post": {
+        "properties": {
+          "payload": {
+            "title": "Payload",
+            "type": "string"
+          },
+          "photo": {
+            "anyOf": [
+              {
+                "format": "binary",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Photo"
+          }
+        },
+        "required": [
+          "payload"
+        ],
+        "title": "Body_create_comment_v1_posts__post_id__comments_post",
+        "type": "object"
+      },
       "Body_create_post_posts_post": {
         "properties": {
           "payload": {
@@ -91,6 +116,27 @@
         "title": "Body_create_post_posts_post",
         "type": "object"
       },
+      "Body_create_post_v1_posts_post": {
+        "properties": {
+          "payload": {
+            "title": "Payload",
+            "type": "string"
+          },
+          "photos": {
+            "items": {
+              "format": "binary",
+              "type": "string"
+            },
+            "title": "Photos",
+            "type": "array"
+          }
+        },
+        "required": [
+          "payload"
+        ],
+        "title": "Body_create_post_v1_posts_post",
+        "type": "object"
+      },
       "Body_update_post_posts__post_id__put": {
         "properties": {
           "payload": {
@@ -110,6 +156,27 @@
           "payload"
         ],
         "title": "Body_update_post_posts__post_id__put",
+        "type": "object"
+      },
+      "Body_update_post_v1_posts__post_id__put": {
+        "properties": {
+          "payload": {
+            "title": "Payload",
+            "type": "string"
+          },
+          "photos": {
+            "items": {
+              "format": "binary",
+              "type": "string"
+            },
+            "title": "Photos",
+            "type": "array"
+          }
+        },
+        "required": [
+          "payload"
+        ],
+        "title": "Body_update_post_v1_posts__post_id__put",
         "type": "object"
       },
       "CookedRequest": {
@@ -2030,6 +2097,1296 @@
         "summary": "Signup",
         "tags": [
           "auth-v1"
+        ]
+      }
+    },
+    "/v1/comments/{comment_id}": {
+      "delete": {
+        "operationId": "delete_comment_v1_comments__comment_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "comment_id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "title": "Comment Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Comment",
+        "tags": [
+          "comments"
+        ]
+      }
+    },
+    "/v1/family/members": {
+      "get": {
+        "operationId": "list_members_v1_family_members_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "List Members",
+        "tags": [
+          "family"
+        ]
+      }
+    },
+    "/v1/family/members/{user_id}": {
+      "delete": {
+        "operationId": "remove_member_v1_family_members__user_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Remove Member",
+        "tags": [
+          "family"
+        ]
+      }
+    },
+    "/v1/health": {
+      "get": {
+        "operationId": "healthcheck_v1_health_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Healthcheck V1 Health Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Healthcheck",
+        "tags": [
+          "health"
+        ]
+      }
+    },
+    "/v1/me/favorites": {
+      "get": {
+        "operationId": "my_favorites_v1_me_favorites_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "My Favorites",
+        "tags": [
+          "me"
+        ]
+      }
+    },
+    "/v1/me/password": {
+      "put": {
+        "operationId": "change_password_v1_me_password_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Payload",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Change Password",
+        "tags": [
+          "me"
+        ]
+      }
+    },
+    "/v1/me/profile": {
+      "put": {
+        "operationId": "update_profile_v1_me_profile_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Payload",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Profile",
+        "tags": [
+          "me"
+        ]
+      }
+    },
+    "/v1/posts": {
+      "post": {
+        "operationId": "create_post_v1_posts_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_create_post_v1_posts_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Post",
+        "tags": [
+          "posts"
+        ]
+      }
+    },
+    "/v1/posts/{post_id}": {
+      "delete": {
+        "operationId": "delete_post_v1_posts__post_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "post_id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "title": "Post Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Post",
+        "tags": [
+          "posts"
+        ]
+      },
+      "get": {
+        "operationId": "get_post_v1_posts__post_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "post_id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "title": "Post Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "commentLimit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "title": "Commentlimit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "commentOffset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "title": "Commentoffset",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cookedLimit",
+            "required": false,
+            "schema": {
+              "default": 5,
+              "title": "Cookedlimit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cookedOffset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "title": "Cookedoffset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Post",
+        "tags": [
+          "posts"
+        ]
+      },
+      "put": {
+        "operationId": "update_post_v1_posts__post_id__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "post_id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "title": "Post Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_update_post_v1_posts__post_id__put"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Post",
+        "tags": [
+          "posts"
+        ]
+      }
+    },
+    "/v1/posts/{post_id}/comments": {
+      "get": {
+        "operationId": "list_comments_v1_posts__post_id__comments_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "post_id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "title": "Post Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Comments",
+        "tags": [
+          "comments"
+        ]
+      },
+      "post": {
+        "operationId": "create_comment_v1_posts__post_id__comments_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "post_id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "title": "Post Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_create_comment_v1_posts__post_id__comments_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Comment",
+        "tags": [
+          "comments"
+        ]
+      }
+    },
+    "/v1/posts/{post_id}/cooked": {
+      "get": {
+        "operationId": "list_cooked_v1_posts__post_id__cooked_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "post_id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "title": "Post Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Cooked",
+        "tags": [
+          "posts"
+        ]
+      },
+      "post": {
+        "operationId": "log_cooked_v1_posts__post_id__cooked_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "post_id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "title": "Post Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CookedRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Log Cooked",
+        "tags": [
+          "posts"
+        ]
+      }
+    },
+    "/v1/posts/{post_id}/favorite": {
+      "delete": {
+        "operationId": "unfavorite_post_v1_posts__post_id__favorite_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "post_id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "title": "Post Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FavoriteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Unfavorite Post",
+        "tags": [
+          "posts"
+        ]
+      },
+      "post": {
+        "operationId": "favorite_post_v1_posts__post_id__favorite_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "post_id",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "title": "Post Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FavoriteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Favorite Post",
+        "tags": [
+          "posts"
+        ]
+      }
+    },
+    "/v1/profile/cooked": {
+      "get": {
+        "operationId": "my_cooked_v1_profile_cooked_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "My Cooked",
+        "tags": [
+          "profile"
+        ]
+      }
+    },
+    "/v1/profile/favorites": {
+      "get": {
+        "operationId": "my_favorites_v1_profile_favorites_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "My Favorites",
+        "tags": [
+          "profile"
+        ]
+      }
+    },
+    "/v1/profile/posts": {
+      "get": {
+        "operationId": "my_posts_v1_profile_posts_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "My Posts",
+        "tags": [
+          "profile"
+        ]
+      }
+    },
+    "/v1/reactions": {
+      "post": {
+        "operationId": "toggle_reaction_v1_reactions_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReactionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Toggle Reaction",
+        "tags": [
+          "reactions"
+        ]
+      }
+    },
+    "/v1/recipes": {
+      "get": {
+        "operationId": "browse_recipes_v1_recipes_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 200,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Q"
+            }
+          },
+          {
+            "in": "query",
+            "name": "course",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Course"
+            }
+          },
+          {
+            "in": "query",
+            "name": "tags",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Tags"
+            }
+          },
+          {
+            "in": "query",
+            "name": "difficulty",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Difficulty"
+            }
+          },
+          {
+            "in": "query",
+            "name": "authorId",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorid"
+            }
+          },
+          {
+            "in": "query",
+            "name": "totalTimeMin",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Totaltimemin"
+            }
+          },
+          {
+            "in": "query",
+            "name": "totalTimeMax",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Totaltimemax"
+            }
+          },
+          {
+            "in": "query",
+            "name": "servingsMin",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Servingsmin"
+            }
+          },
+          {
+            "in": "query",
+            "name": "servingsMax",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Servingsmax"
+            }
+          },
+          {
+            "in": "query",
+            "name": "ingredients",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Ingredients"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "default": "recent",
+              "pattern": "^(recent|alpha|rating)$",
+              "title": "Sort",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Browse Recipes",
+        "tags": [
+          "recipes"
+        ]
+      }
+    },
+    "/v1/tags": {
+      "get": {
+        "operationId": "list_tags_v1_tags_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "List Tags",
+        "tags": [
+          "tags"
+        ]
+      }
+    },
+    "/v1/timeline": {
+      "get": {
+        "operationId": "get_timeline_v1_timeline_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Timeline",
+        "tags": [
+          "timeline"
         ]
       }
     }

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -41,16 +41,32 @@ if settings.cors_origins_list:
     )
 
 
-app.include_router(health.router)
+# Per the migration plan, every endpoint is reachable under `/v1`. Each
+# resource router is included twice — once at its native prefix (the
+# un-prefixed alias kept for the duration of the rollout) and once under `/v1`.
+# The aliases sunset after the Phase 4 cutover (#38).
+#
+# `auth.router` is the legacy session-cookie auth path and is NOT dual-included
+# — `/v1/auth/*` is owned by `auth_v1.router`, which implements the
+# token+refresh flow and is a deliberate behavioural divergence from
+# `auth.router`, not a path alias.
+_DUAL_INCLUDED_ROUTERS = (
+    health.router,
+    posts.router,
+    comments.comments_router,
+    comments.delete_router,
+    reactions.router,
+    timeline.router,
+    recipes.router,
+    profile.router,
+    family.router,
+    tags.router,
+    me.router,
+)
+
+for _router in _DUAL_INCLUDED_ROUTERS:
+    app.include_router(_router)
+    app.include_router(_router, prefix="/v1")
+
 app.include_router(auth.router)
 app.include_router(auth_v1.router)
-app.include_router(posts.router)
-app.include_router(comments.comments_router)
-app.include_router(comments.delete_router)
-app.include_router(reactions.router)
-app.include_router(timeline.router)
-app.include_router(recipes.router)
-app.include_router(profile.router)
-app.include_router(family.router)
-app.include_router(tags.router)
-app.include_router(me.router)

--- a/apps/api/tests/integration/test_health.py
+++ b/apps/api/tests/integration/test_health.py
@@ -29,3 +29,11 @@ def test_health_response_shape(client):
 
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
+
+
+def test_v1_alias_serves_same_response_as_legacy_path(client):
+    legacy = client.get("/health")
+    v1 = client.get("/v1/health")
+
+    assert legacy.status_code == v1.status_code == 200
+    assert legacy.json() == v1.json()

--- a/apps/api/tests/integration/test_v1_aliases.py
+++ b/apps/api/tests/integration/test_v1_aliases.py
@@ -1,0 +1,140 @@
+"""Routing-invariant tests for the /v1 alias dual-include (issue #179).
+
+Per the migration plan, every resource router must be reachable under both
+its native prefix AND `/v1/<prefix>` — except `auth.router`, which is the
+legacy session-cookie path and is deliberately NOT aliased into `/v1/auth`
+(that namespace is owned by `auth_v1.router`'s token+refresh flow).
+
+Rather than GET every endpoint at both paths (which would require auth
+fixtures + per-handler DB mocks for ~25 routes), these tests assert the
+**routing invariant** directly against `app.routes`. Catches the regression
+where someone adds a new router to the legacy include but forgets the v1
+include — the exact failure mode the dual-include pattern is meant to
+prevent.
+"""
+
+from __future__ import annotations
+
+import pytest
+from starlette.routing import Route
+
+from src.main import app
+
+# Paths owned exclusively by `auth_v1.router` — these exist under `/v1/...`
+# but have NO un-prefixed twin. They are NOT bugs.
+V1_ONLY_PATHS: frozenset[str] = frozenset(
+    {
+        "/v1/auth/refresh",
+        "/v1/auth/session",
+    }
+)
+
+# Paths owned exclusively by the legacy `auth.router` — these exist
+# unprefixed but have NO `/v1/...` twin. `/v1/auth/*` is owned by the
+# token-flow router (auth_v1) and is a deliberate behavioural divergence,
+# not a path alias. See main.py for the rationale.
+LEGACY_ONLY_PATHS: frozenset[str] = frozenset(
+    {
+        "/auth/login",
+        "/auth/logout",
+        "/auth/me",
+        "/auth/signup",
+    }
+)
+
+# Paths registered automatically by FastAPI (Swagger UI, ReDoc, the
+# OpenAPI JSON itself). Framework-owned, not application routes.
+FRAMEWORK_PATHS: frozenset[str] = frozenset(
+    {
+        "/docs",
+        "/docs/oauth2-redirect",
+        "/redoc",
+        "/openapi.json",
+    }
+)
+
+
+def _route_paths() -> set[str]:
+    return {r.path for r in app.routes if isinstance(r, Route)}
+
+
+def test_every_legacy_path_has_a_v1_twin():
+    """A path like `/posts` must have `/v1/posts` registered; vice-versa too.
+
+    Excludes the documented one-way paths above.
+    """
+    paths = _route_paths()
+    v1_paths = {p for p in paths if p.startswith("/v1/")}
+    legacy_paths = {p for p in paths if not p.startswith("/v1/")}
+
+    # Every legacy path → v1 twin
+    missing_v1: list[str] = []
+    for legacy in legacy_paths - LEGACY_ONLY_PATHS - FRAMEWORK_PATHS:
+        if f"/v1{legacy}" not in v1_paths:
+            missing_v1.append(legacy)
+
+    assert not missing_v1, (
+        "Legacy paths missing a /v1 twin (router added to legacy include but "
+        f"not to the dual-include loop in main.py): {missing_v1}"
+    )
+
+    # Every v1 path → legacy twin (catches the inverse: someone added a
+    # router only to the v1 side without aliasing it)
+    missing_legacy: list[str] = []
+    for v1 in v1_paths - V1_ONLY_PATHS:
+        if v1.removeprefix("/v1") not in legacy_paths:
+            missing_legacy.append(v1)
+
+    assert not missing_legacy, (
+        "v1 paths missing a legacy alias (the alias-during-rollout invariant "
+        f"is broken — these will 404 on the unprefixed path): {missing_legacy}"
+    )
+
+
+@pytest.mark.parametrize(
+    "legacy_path,v1_path",
+    [
+        ("/health", "/v1/health"),
+        ("/posts", "/v1/posts"),
+        ("/timeline", "/v1/timeline"),
+        ("/me/profile", "/v1/me/profile"),
+        ("/profile/posts", "/v1/profile/posts"),
+        ("/family/members", "/v1/family/members"),
+        ("/tags", "/v1/tags"),
+        ("/recipes", "/v1/recipes"),
+        ("/reactions", "/v1/reactions"),
+    ],
+)
+def test_alias_pair_resolves_to_the_same_handler(legacy_path: str, v1_path: str):
+    """Both routes for a representative endpoint must call the same handler.
+
+    Picks one path per dual-included router. If a router is ever added that
+    accidentally rebinds to a different handler at the /v1 path (e.g. someone
+    monkey-patches and forgets to revert), this catches it before the route
+    silently behaves differently from its alias.
+    """
+    by_path: dict[str, set[object]] = {}
+    for route in app.routes:
+        if isinstance(route, Route):
+            by_path.setdefault(route.path, set()).add(route.endpoint)
+
+    legacy_handlers = by_path.get(legacy_path)
+    v1_handlers = by_path.get(v1_path)
+
+    assert legacy_handlers, f"legacy path {legacy_path} not registered"
+    assert v1_handlers, f"v1 path {v1_path} not registered"
+    assert legacy_handlers == v1_handlers, (
+        f"alias pair {legacy_path} / {v1_path} resolves to different handlers: "
+        f"legacy={legacy_handlers}, v1={v1_handlers}"
+    )
+
+
+def test_auth_v1_namespace_is_not_aliased_under_legacy_path():
+    """The token-flow /v1/auth/* endpoints must NOT exist at /auth/*."""
+    paths = _route_paths()
+    for v1_path in V1_ONLY_PATHS:
+        legacy_twin = v1_path.removeprefix("/v1")
+        assert legacy_twin not in paths, (
+            f"{v1_path} (token-flow auth) was accidentally aliased to {legacy_twin}; "
+            "this would shadow the legacy session-cookie auth handler."
+        )


### PR DESCRIPTION
## Summary

Closes #179. First sub-task of the Phase 3 breakdown on #37.

Per the [migration plan](docs/API_BACKEND_MIGRATION_PLAN.md#api-versioning), every FastAPI endpoint must be reachable under `/v1` with the un-prefixed paths preserved as aliases for the duration of the rollout. Today only `auth_v1.router` lives under `/v1`; everything else (`posts`, `comments`, `reactions`, `timeline`, `recipes`, `profile`, `family`, `tags`, `me`, `health`) is still served only at its native prefix. Doing this once, up front, unblocks every other Phase 3 sub-issue without per-endpoint cleanup later.

## Approach

Each resource router is now included twice in [apps/api/src/main.py](apps/api/src/main.py) — once at its native prefix and once with `prefix="/v1"` layered on top via FastAPI's `include_router(prefix=...)`. No file moves, no handler changes.

`auth.router` is **excluded** from the dual-include: `/v1/auth/*` is owned by `auth_v1.router`, which implements the token+refresh flow and is a deliberate behavioural divergence from the legacy session-cookie `auth.router`, not a path alias. (Confirmed by hitting this on the first run — the loop initially shadowed the v1 token endpoints with the legacy session handlers; tests caught it.)

OpenAPI snapshot regenerated: 25 `/v1/*` paths, 23 alias paths, no removals.

## Test plan

- [x] `pytest tests/` — 381 tests pass (380 existing + 1 new alias assertion in `test_health.py`)
- [x] `ruff check .` clean
- [x] OpenAPI snapshot regenerated and committed; diff is additions-only (the new `/v1` paths)
- [x] Manual: confirmed `/v1/health` and `/health` return identical responses; same handler reached through both routes

## Risk

- Alias routes reuse the exact same handler functions — zero behavioural divergence between the two paths
- `auth.router` deliberately not aliased to `/v1/auth` — preserves the existing token-auth contract owned by `auth_v1.router`
- Snapshot diff is large but mechanical (every existing path now has a `/v1`-prefixed twin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)