### PR TITLE
feat(api): X-Request-Id idempotency helper for FastAPI write endpoints (#180)

### DIFF
--- a/apps/api/src/idempotency.py
+++ b/apps/api/src/idempotency.py
@@ -27,10 +27,37 @@ idempotency is opt-in per request, never enforced when the header is absent.
 When the same `(user_id, request_id)` pair is seen within 24h, the original
 `(body, status_code)` is replayed without re-running the handler.
 
-The replay window is enforced at read time (rows older than 24h are ignored
-and a fresh one is written), so we don't need a background pruner. A periodic
-delete sweep can be added later if the table grows uncomfortably; the
-`(created_at)` index is in place for that.
+## TTL strategy: passive overwrite, not lazy delete
+
+Stale rows are not deleted. The replay window is enforced at *read* time:
+when a row older than 24h is found, the helper ignores it and runs the
+handler again, then `upsert`s — overwriting the stale row with the new
+`(status, body, created_at)` under the same `(user_id, request_id)` key.
+
+Net effect on table size is the same as lazy delete (bounded by the
+active key set, not history) but no DELETE is ever issued. A periodic
+sweep can be added later if the active key set itself grows
+uncomfortably; the `(created_at)` index is in place for that.
+
+## Concurrent-handler race (acknowledged limitation)
+
+The helper protects against duplicate `idempotency_keys` rows but does
+NOT serialize concurrent handler executions. If two retries with the
+same `(user_id, request_id)` arrive within milliseconds of each other:
+
+1. Both call `find_unique` and miss (no row yet).
+2. Both call `do()` — the underlying handler runs twice, potentially
+   creating two rows in *its* table (post, comment, etc.).
+3. Both call `upsert` — the second overwrites the first idempotency-key
+   row, which is harmless but means the cached body matches whichever
+   call landed second.
+
+For the Phase 3 family-only scope this is acceptable: the SPA's retry
+policy is sequential (retry on 5xx after timeout), not concurrent. If a
+write endpoint later takes the helper into a high-traffic / financial
+context, swap the find→upsert dance for `INSERT ... ON CONFLICT DO
+NOTHING RETURNING` (Postgres-native row-level lock) before relying on
+it for at-most-once semantics.
 """
 
 from __future__ import annotations
@@ -67,15 +94,20 @@ async def replay_or_record(
 
     if existing is not None:
         # Stale row past the replay window — ignore it. We let the new request
-        # run, then upsert below to overwrite the old capture.
+        # run, then upsert below to overwrite the old capture (passive TTL —
+        # see module docstring; we never DELETE).
         if datetime.now(timezone.utc) - _aware(existing.createdAt) <= REPLAY_WINDOW:
             return existing.responseBody, existing.statusCode
 
     body, status_code = await do()
 
     # Upsert: a parallel duplicate may have raced ahead of us between the
-    # find_unique and the create. Whichever write lands first wins; subsequent
-    # calls hit the find_unique fast-path on the next request.
+    # find_unique and the create — whichever write lands first wins for the
+    # idempotency-key row, and subsequent calls hit the find_unique fast-path.
+    #
+    # NOTE: this protects the key row from duplicate-PK errors but does NOT
+    # protect the handler from running twice in a tight retry race. See the
+    # module docstring (Concurrent-handler race) for the full rationale.
     await prisma.idempotencykey.upsert(
         where={"userId_requestId": {"userId": user_id, "requestId": request_id}},
         data={

--- a/apps/api/src/idempotency.py
+++ b/apps/api/src/idempotency.py
@@ -1,0 +1,102 @@
+"""X-Request-Id idempotency for write endpoints (Phase 3-A2, issue #180).
+
+Migration plan: docs/API_BACKEND_MIGRATION_PLAN.md#idempotency--retries
+
+Usage from a route handler:
+
+    from fastapi import Header
+    from ..idempotency import replay_or_record
+
+    @router.post("/feedback", status_code=201)
+    async def create_feedback(
+        payload: CreateFeedbackRequest,
+        user: UserResponse = Depends(get_current_user),
+        x_request_id: str | None = Header(default=None),
+    ):
+        async def _do():
+            row = await prisma.feedbacksubmission.create(...)
+            return _serialize(row), 201
+
+        body, status_code = await replay_or_record(
+            user_id=user.id, request_id=x_request_id, do=_do
+        )
+        return JSONResponse(content=body, status_code=status_code)
+
+When `request_id` is None we just call `do()` and return its result —
+idempotency is opt-in per request, never enforced when the header is absent.
+When the same `(user_id, request_id)` pair is seen within 24h, the original
+`(body, status_code)` is replayed without re-running the handler.
+
+The replay window is enforced at read time (rows older than 24h are ignored
+and a fresh one is written), so we don't need a background pruner. A periodic
+delete sweep can be added later if the table grows uncomfortably; the
+`(created_at)` index is in place for that.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Awaitable, Callable, Tuple
+
+from .db import prisma
+
+REPLAY_WINDOW = timedelta(hours=24)
+
+
+async def replay_or_record(
+    *,
+    user_id: str,
+    request_id: str | None,
+    do: Callable[[], Awaitable[Tuple[Any, int]]],
+) -> Tuple[Any, int]:
+    """Run `do()` once and replay its result on duplicate request IDs.
+
+    `do` must return `(json_body, status_code)`. The body is stored as JSON, so
+    it should be a plain dict / list / scalar — Pydantic models should be
+    serialised before being returned.
+
+    Returns the original `(body, status_code)` on replay; otherwise the result
+    of the freshly-executed `do()`.
+    """
+    if not request_id:
+        return await do()
+
+    existing = await prisma.idempotencykey.find_unique(
+        where={"userId_requestId": {"userId": user_id, "requestId": request_id}},
+    )
+
+    if existing is not None:
+        # Stale row past the replay window — ignore it. We let the new request
+        # run, then upsert below to overwrite the old capture.
+        if datetime.now(timezone.utc) - _aware(existing.createdAt) <= REPLAY_WINDOW:
+            return existing.responseBody, existing.statusCode
+
+    body, status_code = await do()
+
+    # Upsert: a parallel duplicate may have raced ahead of us between the
+    # find_unique and the create. Whichever write lands first wins; subsequent
+    # calls hit the find_unique fast-path on the next request.
+    await prisma.idempotencykey.upsert(
+        where={"userId_requestId": {"userId": user_id, "requestId": request_id}},
+        data={
+            "create": {
+                "userId": user_id,
+                "requestId": request_id,
+                "statusCode": status_code,
+                "responseBody": body,
+            },
+            "update": {
+                "statusCode": status_code,
+                "responseBody": body,
+                "createdAt": datetime.now(timezone.utc),
+            },
+        },
+    )
+
+    return body, status_code
+
+
+def _aware(dt: datetime) -> datetime:
+    # Postgres returns naive UTC datetimes through the Python Prisma client;
+    # promote to aware so the subtraction against now(tz=UTC) is well-defined.
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -123,24 +123,29 @@ def mock_prisma(mocker):
             # ... test code
     """
     mock = MagicMock()
-    
+
     # Set up common async methods
-    for model in ["user", "post", "comment", "reaction", "favorite", 
-                  "cookedevent", "familyspace", "familymembership", "tag"]:
+    for model in ["user", "post", "comment", "reaction", "favorite",
+                  "cookedevent", "familyspace", "familymembership", "tag",
+                  "idempotencykey"]:
         model_mock = MagicMock()
         model_mock.find_unique = AsyncMock(return_value=None)
         model_mock.find_first = AsyncMock(return_value=None)
         model_mock.find_many = AsyncMock(return_value=[])
         model_mock.create = AsyncMock(return_value=None)
         model_mock.update = AsyncMock(return_value=None)
+        model_mock.upsert = AsyncMock(return_value=None)
         model_mock.delete = AsyncMock(return_value=None)
         model_mock.delete_many = AsyncMock(return_value=None)
         model_mock.count = AsyncMock(return_value=0)
         setattr(mock, model, model_mock)
-    
-    # Patch the prisma instance in the db module
+
+    # Patch the prisma instance in the db module AND any module that
+    # captured a reference at import time (e.g. `from .db import prisma`
+    # in src/idempotency.py rebinds prisma into that module's namespace).
     mocker.patch("src.db.prisma", mock)
-    
+    mocker.patch("src.idempotency.prisma", mock)
+
     return mock
 
 

--- a/apps/api/tests/helpers/mock_prisma.py
+++ b/apps/api/tests/helpers/mock_prisma.py
@@ -15,6 +15,7 @@ MODEL_NAMES = [
     "familymembership",
     "tag",
     "refreshtoken",
+    "idempotencykey",
 ]
 
 
@@ -26,6 +27,7 @@ def _make_model_mock() -> MagicMock:
     model_mock.create = AsyncMock(return_value=None)
     model_mock.update = AsyncMock(return_value=None)
     model_mock.update_many = AsyncMock(return_value=None)
+    model_mock.upsert = AsyncMock(return_value=None)
     model_mock.delete = AsyncMock(return_value=None)
     model_mock.delete_many = AsyncMock(return_value=None)
     model_mock.count = AsyncMock(return_value=0)
@@ -72,6 +74,7 @@ def reset_mock_prisma(mock_prisma: MagicMock) -> None:
             "create",
             "update",
             "update_many",
+            "upsert",
             "delete",
             "delete_many",
             "count",

--- a/apps/api/tests/unit/test_idempotency.py
+++ b/apps/api/tests/unit/test_idempotency.py
@@ -1,9 +1,14 @@
 """Unit tests for src/idempotency.py — X-Request-Id replay (issue #180).
 
-The helper is exercised against a mocked prisma.idempotencykey model. Tests
-cover the four AC checkpoints: missing header is a no-op, same id replays the
-captured (body, status), different ids each run the handler, and the 24-hour
-window expires correctly.
+The helper is exercised against the shared `mock_prisma` fixture from
+tests/conftest.py — same fixture the rest of the suite uses, so future
+model surface changes (added methods, new models) propagate without a
+parallel test-only mock to maintain.
+
+Tests cover the four AC checkpoints: missing header is a no-op, same id
+replays the captured (body, status), different ids each run the handler,
+and the 24-hour window expires correctly. Plus per-user scoping and the
+naive-UTC datetime promotion.
 """
 
 from __future__ import annotations
@@ -15,16 +20,6 @@ from unittest.mock import AsyncMock
 import pytest
 
 from src import idempotency
-
-
-@pytest.fixture
-def mock_idempotency(monkeypatch):
-    fake = SimpleNamespace(
-        find_unique=AsyncMock(return_value=None),
-        upsert=AsyncMock(return_value=None),
-    )
-    monkeypatch.setattr(idempotency.prisma, "idempotencykey", fake, raising=False)
-    return fake
 
 
 async def _do_once_factory():
@@ -39,7 +34,7 @@ async def _do_once_factory():
 
 
 @pytest.mark.asyncio
-async def test_no_request_id_runs_handler_and_skips_store(mock_idempotency):
+async def test_no_request_id_runs_handler_and_skips_store(mock_prisma):
     handler, counter = await _do_once_factory()
 
     body, status = await idempotency.replay_or_record(
@@ -48,12 +43,12 @@ async def test_no_request_id_runs_handler_and_skips_store(mock_idempotency):
 
     assert (body, status) == ({"created": 1}, 201)
     assert counter.calls == 1
-    mock_idempotency.find_unique.assert_not_awaited()
-    mock_idempotency.upsert.assert_not_awaited()
+    mock_prisma.idempotencykey.find_unique.assert_not_awaited()
+    mock_prisma.idempotencykey.upsert.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_first_call_records_then_second_replays_without_running_handler(mock_idempotency):
+async def test_first_call_records_then_second_replays_without_running_handler(mock_prisma):
     handler, counter = await _do_once_factory()
 
     # First call: cache miss → handler runs, result is stored.
@@ -62,7 +57,7 @@ async def test_first_call_records_then_second_replays_without_running_handler(mo
     )
     assert (body1, status1) == ({"created": 1}, 201)
     assert counter.calls == 1
-    assert mock_idempotency.upsert.await_count == 1
+    assert mock_prisma.idempotencykey.upsert.await_count == 1
 
     # Simulate the row landing in the store: subsequent find_unique returns it.
     stored = SimpleNamespace(
@@ -70,7 +65,7 @@ async def test_first_call_records_then_second_replays_without_running_handler(mo
         statusCode=201,
         createdAt=datetime.now(timezone.utc),
     )
-    mock_idempotency.find_unique = AsyncMock(return_value=stored)
+    mock_prisma.idempotencykey.find_unique = AsyncMock(return_value=stored)
 
     # Second call with same id: replayed from cache; handler not invoked.
     body2, status2 = await idempotency.replay_or_record(
@@ -81,7 +76,7 @@ async def test_first_call_records_then_second_replays_without_running_handler(mo
 
 
 @pytest.mark.asyncio
-async def test_different_request_ids_each_run_the_handler(mock_idempotency):
+async def test_different_request_ids_each_run_the_handler(mock_prisma):
     handler, counter = await _do_once_factory()
 
     body1, _ = await idempotency.replay_or_record(
@@ -97,7 +92,7 @@ async def test_different_request_ids_each_run_the_handler(mock_idempotency):
 
 
 @pytest.mark.asyncio
-async def test_idempotency_is_per_user(mock_idempotency):
+async def test_idempotency_is_per_user(mock_prisma):
     """User A's request id must not collide with user B's same id."""
     handler, counter = await _do_once_factory()
 
@@ -109,12 +104,12 @@ async def test_idempotency_is_per_user(mock_idempotency):
     # Second call with the same request id but a different user: the helper
     # must look up via the (user_id, request_id) composite, so the userB
     # find_unique returns None and the handler runs again.
-    mock_idempotency.find_unique = AsyncMock(return_value=None)
+    mock_prisma.idempotencykey.find_unique = AsyncMock(return_value=None)
     await idempotency.replay_or_record(user_id="userB", request_id="shared", do=handler)
     assert counter.calls == 2
 
     # Confirm both lookups went through the composite-key path.
-    calls = mock_idempotency.find_unique.await_args_list
+    calls = mock_prisma.idempotencykey.find_unique.await_args_list
     assert all(
         "userId_requestId" in call.kwargs.get("where", {})
         for call in calls
@@ -122,7 +117,7 @@ async def test_idempotency_is_per_user(mock_idempotency):
 
 
 @pytest.mark.asyncio
-async def test_stored_row_older_than_window_is_treated_as_miss(mock_idempotency):
+async def test_stored_row_older_than_window_is_treated_as_miss(mock_prisma):
     """A row past REPLAY_WINDOW must NOT replay; the handler runs again."""
     handler, counter = await _do_once_factory()
 
@@ -131,7 +126,7 @@ async def test_stored_row_older_than_window_is_treated_as_miss(mock_idempotency)
         statusCode=201,
         createdAt=datetime.now(timezone.utc) - idempotency.REPLAY_WINDOW - timedelta(seconds=1),
     )
-    mock_idempotency.find_unique = AsyncMock(return_value=stale)
+    mock_prisma.idempotencykey.find_unique = AsyncMock(return_value=stale)
 
     body, status = await idempotency.replay_or_record(
         user_id="u1", request_id="req-old", do=handler
@@ -140,11 +135,11 @@ async def test_stored_row_older_than_window_is_treated_as_miss(mock_idempotency)
     assert body == {"created": 1}
     assert status == 201
     assert counter.calls == 1, "stale row must not short-circuit the handler"
-    mock_idempotency.upsert.assert_awaited_once()
+    mock_prisma.idempotencykey.upsert.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_naive_created_at_from_prisma_is_treated_as_utc(mock_idempotency):
+async def test_naive_created_at_from_prisma_is_treated_as_utc(mock_prisma):
     """Python Prisma client returns naive datetimes; the helper must promote to aware UTC."""
     handler, counter = await _do_once_factory()
 
@@ -153,7 +148,7 @@ async def test_naive_created_at_from_prisma_is_treated_as_utc(mock_idempotency):
         statusCode=201,
         createdAt=datetime.now(timezone.utc).replace(tzinfo=None),  # naive — no tzinfo
     )
-    mock_idempotency.find_unique = AsyncMock(return_value=fresh_naive)
+    mock_prisma.idempotencykey.find_unique = AsyncMock(return_value=fresh_naive)
 
     body, status = await idempotency.replay_or_record(
         user_id="u1", request_id="req-naive", do=handler

--- a/apps/api/tests/unit/test_idempotency.py
+++ b/apps/api/tests/unit/test_idempotency.py
@@ -1,0 +1,164 @@
+"""Unit tests for src/idempotency.py — X-Request-Id replay (issue #180).
+
+The helper is exercised against a mocked prisma.idempotencykey model. Tests
+cover the four AC checkpoints: missing header is a no-op, same id replays the
+captured (body, status), different ids each run the handler, and the 24-hour
+window expires correctly.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src import idempotency
+
+
+@pytest.fixture
+def mock_idempotency(monkeypatch):
+    fake = SimpleNamespace(
+        find_unique=AsyncMock(return_value=None),
+        upsert=AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(idempotency.prisma, "idempotencykey", fake, raising=False)
+    return fake
+
+
+async def _do_once_factory():
+    """Return a (handler, counter) pair; counter.calls counts handler runs."""
+    counter = SimpleNamespace(calls=0)
+
+    async def handler():
+        counter.calls += 1
+        return ({"created": counter.calls}, 201)
+
+    return handler, counter
+
+
+@pytest.mark.asyncio
+async def test_no_request_id_runs_handler_and_skips_store(mock_idempotency):
+    handler, counter = await _do_once_factory()
+
+    body, status = await idempotency.replay_or_record(
+        user_id="u1", request_id=None, do=handler
+    )
+
+    assert (body, status) == ({"created": 1}, 201)
+    assert counter.calls == 1
+    mock_idempotency.find_unique.assert_not_awaited()
+    mock_idempotency.upsert.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_first_call_records_then_second_replays_without_running_handler(mock_idempotency):
+    handler, counter = await _do_once_factory()
+
+    # First call: cache miss → handler runs, result is stored.
+    body1, status1 = await idempotency.replay_or_record(
+        user_id="u1", request_id="req-A", do=handler
+    )
+    assert (body1, status1) == ({"created": 1}, 201)
+    assert counter.calls == 1
+    assert mock_idempotency.upsert.await_count == 1
+
+    # Simulate the row landing in the store: subsequent find_unique returns it.
+    stored = SimpleNamespace(
+        responseBody={"created": 1},
+        statusCode=201,
+        createdAt=datetime.now(timezone.utc),
+    )
+    mock_idempotency.find_unique = AsyncMock(return_value=stored)
+
+    # Second call with same id: replayed from cache; handler not invoked.
+    body2, status2 = await idempotency.replay_or_record(
+        user_id="u1", request_id="req-A", do=handler
+    )
+    assert (body2, status2) == ({"created": 1}, 201)
+    assert counter.calls == 1, "handler must not run on replay"
+
+
+@pytest.mark.asyncio
+async def test_different_request_ids_each_run_the_handler(mock_idempotency):
+    handler, counter = await _do_once_factory()
+
+    body1, _ = await idempotency.replay_or_record(
+        user_id="u1", request_id="req-A", do=handler
+    )
+    body2, _ = await idempotency.replay_or_record(
+        user_id="u1", request_id="req-B", do=handler
+    )
+
+    assert body1 == {"created": 1}
+    assert body2 == {"created": 2}
+    assert counter.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_idempotency_is_per_user(mock_idempotency):
+    """User A's request id must not collide with user B's same id."""
+    handler, counter = await _do_once_factory()
+
+    # Even if find_unique is called with a different (user_id, request_id),
+    # the first call has no row → handler runs.
+    await idempotency.replay_or_record(user_id="userA", request_id="shared", do=handler)
+    assert counter.calls == 1
+
+    # Second call with the same request id but a different user: the helper
+    # must look up via the (user_id, request_id) composite, so the userB
+    # find_unique returns None and the handler runs again.
+    mock_idempotency.find_unique = AsyncMock(return_value=None)
+    await idempotency.replay_or_record(user_id="userB", request_id="shared", do=handler)
+    assert counter.calls == 2
+
+    # Confirm both lookups went through the composite-key path.
+    calls = mock_idempotency.find_unique.await_args_list
+    assert all(
+        "userId_requestId" in call.kwargs.get("where", {})
+        for call in calls
+    )
+
+
+@pytest.mark.asyncio
+async def test_stored_row_older_than_window_is_treated_as_miss(mock_idempotency):
+    """A row past REPLAY_WINDOW must NOT replay; the handler runs again."""
+    handler, counter = await _do_once_factory()
+
+    stale = SimpleNamespace(
+        responseBody={"created": "stale"},
+        statusCode=201,
+        createdAt=datetime.now(timezone.utc) - idempotency.REPLAY_WINDOW - timedelta(seconds=1),
+    )
+    mock_idempotency.find_unique = AsyncMock(return_value=stale)
+
+    body, status = await idempotency.replay_or_record(
+        user_id="u1", request_id="req-old", do=handler
+    )
+
+    assert body == {"created": 1}
+    assert status == 201
+    assert counter.calls == 1, "stale row must not short-circuit the handler"
+    mock_idempotency.upsert.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_naive_created_at_from_prisma_is_treated_as_utc(mock_idempotency):
+    """Python Prisma client returns naive datetimes; the helper must promote to aware UTC."""
+    handler, counter = await _do_once_factory()
+
+    fresh_naive = SimpleNamespace(
+        responseBody={"created": 99},
+        statusCode=201,
+        createdAt=datetime.now(timezone.utc).replace(tzinfo=None),  # naive — no tzinfo
+    )
+    mock_idempotency.find_unique = AsyncMock(return_value=fresh_naive)
+
+    body, status = await idempotency.replay_or_record(
+        user_id="u1", request_id="req-naive", do=handler
+    )
+
+    assert body == {"created": 99}
+    assert status == 201
+    assert counter.calls == 0, "fresh naive-utc row must replay"

--- a/prisma/migrations/20260429000000_add_idempotency_keys/migration.sql
+++ b/prisma/migrations/20260429000000_add_idempotency_keys/migration.sql
@@ -1,0 +1,18 @@
+-- Idempotency-key store for X-Request-Id replay (FastAPI Phase 3-A2)
+-- Issue: https://github.com/wnorowskie/family-recipe/issues/180
+
+CREATE TABLE "idempotency_keys" (
+  "id" TEXT PRIMARY KEY,
+  "user_id" TEXT NOT NULL,
+  "request_id" TEXT NOT NULL,
+  "status_code" INTEGER NOT NULL,
+  "response_body" JSONB NOT NULL,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+ALTER TABLE "idempotency_keys"
+  ADD CONSTRAINT "idempotency_keys_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+CREATE UNIQUE INDEX "idempotency_keys_user_id_request_id_key" ON "idempotency_keys" ("user_id", "request_id");
+CREATE INDEX "idempotency_keys_created_at_idx" ON "idempotency_keys" ("created_at");

--- a/prisma/schema.postgres.node.prisma
+++ b/prisma/schema.postgres.node.prisma
@@ -32,6 +32,7 @@ model User {
   receivedNotifications Notification[] @relation("NotificationRecipient")
   sentNotifications     Notification[] @relation("NotificationActor")
   refreshTokens         RefreshToken[]
+  idempotencyKeys       IdempotencyKey[]
 
   @@map("users")
 }
@@ -324,4 +325,19 @@ model RefreshToken {
   @@index([familySpaceId])
   @@index([expiresAt])
   @@index([revokedAt])
+}
+
+model IdempotencyKey {
+  id           String   @id @default(cuid())
+  userId       String   @map("user_id")
+  requestId    String   @map("request_id")
+  statusCode   Int      @map("status_code")
+  responseBody Json     @map("response_body")
+  createdAt    DateTime @default(now()) @map("created_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("idempotency_keys")
+  @@unique([userId, requestId])
+  @@index([createdAt])
 }

--- a/prisma/schema.postgres.prisma
+++ b/prisma/schema.postgres.prisma
@@ -36,6 +36,7 @@ model User {
   receivedNotifications Notification[]       @relation("NotificationRecipient")
   sentNotifications     Notification[]       @relation("NotificationActor")
   refreshTokens         RefreshToken[]
+  idempotencyKeys       IdempotencyKey[]
 
   @@map("users")
 }
@@ -328,4 +329,19 @@ model RefreshToken {
   @@index([expiresAt])
   @@index([revokedAt])
   @@map("refresh_tokens")
+}
+
+model IdempotencyKey {
+  id           String   @id @default(cuid())
+  userId       String   @map("user_id")
+  requestId    String   @map("request_id")
+  statusCode   Int      @map("status_code")
+  responseBody Json     @map("response_body")
+  createdAt    DateTime @default(now()) @map("created_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, requestId])
+  @@index([createdAt])
+  @@map("idempotency_keys")
 }


### PR DESCRIPTION
## Summary

Closes #180. Phase 3-A2 of the FastAPI migration tracked in #37.

The [migration plan](docs/API_BACKEND_MIGRATION_PLAN.md#idempotency--retries) calls for idempotent writes on create-post / comment / reaction / favorite / cooked / feedback so that retries from the SPA don't produce duplicate rows. This PR lands the infra; no routes consume it yet — that happens in the Track-B endpoint sub-issues (#182 notifications, #183 feedback, etc).

## What changed

- **`IdempotencyKey` model** added to both Prisma schemas in lockstep, plus the matching migration `prisma/migrations/20260429000000_add_idempotency_keys/`. Composite `(user_id, request_id)` unique index, JSONB body capture, `created_at` index for future passive pruning.
- **[apps/api/src/idempotency.py](apps/api/src/idempotency.py)** — `replay_or_record(user_id, request_id, do)` helper. When `request_id` is `None` the handler runs unchanged (opt-in). When the same `(user_id, request_id)` is seen within 24h the original `(body, status_code)` is replayed without re-running the handler. `upsert` semantics so a parallel duplicate that races between `find_unique` and `create` doesn't 500.
- **6 unit tests** in [apps/api/tests/unit/test_idempotency.py](apps/api/tests/unit/test_idempotency.py) covering each AC checkpoint: missing header is a no-op, replay short-circuits the handler, distinct ids each run, per-user scoping via the composite key, 24h cutoff, naive-UTC datetimes from the Python Prisma client are promoted to aware.

## Approach notes

- **Helper, not middleware**: explicit per-handler invocation keeps idempotency opt-in and visible in the route. A custom `APIRoute` class would have been more invisible but harder to test and harder to skip for non-write endpoints.
- **Storage**: a new table rather than reusing an existing one — keeps the model focused and the cleanup story simple.
- **TTL pruning**: lazy/at-read-time. Rows older than the 24h window are treated as a cache miss and overwritten by the next request with the same id. A periodic delete sweep can be added later if the table grows uncomfortably; the `(created_at)` index is in place for it.

## Test plan

- [x] `pytest tests/` — 386 tests pass (380 → 386 with the 6 new unit tests)
- [x] `ruff check .` clean in `apps/api`
- [x] `npm run type-check` clean (Prisma client regenerated for both Node + Python)
- [x] `npx prisma validate` clean for both schemas
- [x] `npm run db:drift-check` against a throwaway Postgres — applies the new migration, both schemas match

## Risk

- Pure additive: no existing handler is touched. The helper is unused in the codebase as of this PR; the new model has no readers/writers besides the helper itself.
- Schema change: a new table with a single FK to `users(id)` ON DELETE CASCADE. No data migration; no existing rows affected.
- The `auth.router` includes the standard error envelope → no contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)