### PR TITLE
feat(api): Phase 3-B1 — notifications endpoints on FastAPI (#182)

### DIFF
--- a/apps/api/openapi.snapshot.json
+++ b/apps/api/openapi.snapshot.json
@@ -262,6 +262,46 @@
         "title": "LoginRequest",
         "type": "object"
       },
+      "MarkNotificationsReadRequest": {
+        "properties": {
+          "ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "maxItems": 50,
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ids"
+          }
+        },
+        "title": "MarkNotificationsReadRequest",
+        "type": "object"
+      },
+      "MarkNotificationsReadResponse": {
+        "properties": {
+          "status": {
+            "const": "ok",
+            "title": "Status",
+            "type": "string"
+          },
+          "unreadCount": {
+            "title": "Unreadcount",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "status",
+          "unreadCount"
+        ],
+        "title": "MarkNotificationsReadResponse",
+        "type": "object"
+      },
       "MeResponse": {
         "properties": {
           "user": {
@@ -272,6 +312,208 @@
           "user"
         ],
         "title": "MeResponse",
+        "type": "object"
+      },
+      "NotificationActor": {
+        "properties": {
+          "avatarUrl": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avatarurl"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "NotificationActor",
+        "type": "object"
+      },
+      "NotificationItem": {
+        "properties": {
+          "actor": {
+            "$ref": "#/components/schemas/NotificationActor"
+          },
+          "commentText": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Commenttext"
+          },
+          "cookedNote": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cookednote"
+          },
+          "cookedRating": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cookedrating"
+          },
+          "createdAt": {
+            "title": "Createdat",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "post": {
+            "$ref": "#/components/schemas/NotificationPost"
+          },
+          "reactionSummary": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ReactionSummary"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "readAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Readat"
+          },
+          "type": {
+            "enum": [
+              "comment",
+              "reaction_batch",
+              "cooked"
+            ],
+            "title": "Type",
+            "type": "string"
+          },
+          "updatedAt": {
+            "title": "Updatedat",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "createdAt",
+          "updatedAt",
+          "actor",
+          "post"
+        ],
+        "title": "NotificationItem",
+        "type": "object"
+      },
+      "NotificationPost": {
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "mainPhotoUrl": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mainphotourl"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title"
+        ],
+        "title": "NotificationPost",
+        "type": "object"
+      },
+      "NotificationsListResponse": {
+        "properties": {
+          "hasMore": {
+            "title": "Hasmore",
+            "type": "boolean"
+          },
+          "nextOffset": {
+            "title": "Nextoffset",
+            "type": "integer"
+          },
+          "notifications": {
+            "items": {
+              "$ref": "#/components/schemas/NotificationItem"
+            },
+            "title": "Notifications",
+            "type": "array"
+          },
+          "unreadCount": {
+            "title": "Unreadcount",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "notifications",
+          "unreadCount",
+          "hasMore",
+          "nextOffset"
+        ],
+        "title": "NotificationsListResponse",
+        "type": "object"
+      },
+      "ReactionEmojiCount": {
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "emoji": {
+            "title": "Emoji",
+            "type": "string"
+          }
+        },
+        "required": [
+          "emoji",
+          "count"
+        ],
+        "title": "ReactionEmojiCount",
         "type": "object"
       },
       "ReactionRequest": {
@@ -299,6 +541,38 @@
           "emoji"
         ],
         "title": "ReactionRequest",
+        "type": "object"
+      },
+      "ReactionSummary": {
+        "properties": {
+          "emojiCounts": {
+            "items": {
+              "$ref": "#/components/schemas/ReactionEmojiCount"
+            },
+            "title": "Emojicounts",
+            "type": "array"
+          },
+          "lastEmoji": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lastemoji"
+          },
+          "totalCount": {
+            "title": "Totalcount",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "totalCount",
+          "emojiCounts"
+        ],
+        "title": "ReactionSummary",
         "type": "object"
       },
       "SignupRequest": {
@@ -348,6 +622,19 @@
           "familyMasterKey"
         ],
         "title": "SignupRequest",
+        "type": "object"
+      },
+      "UnreadCountResponse": {
+        "properties": {
+          "unreadCount": {
+            "title": "Unreadcount",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "unreadCount"
+        ],
+        "title": "UnreadCountResponse",
         "type": "object"
       },
       "UserResponse": {
@@ -2356,6 +2643,149 @@
         "summary": "Update Profile",
         "tags": [
           "me"
+        ]
+      }
+    },
+    "/v1/notifications": {
+      "get": {
+        "operationId": "list_notifications_v1_notifications_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "unreadOnly",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Unreadonly",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationsListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List Notifications",
+        "tags": [
+          "notifications"
+        ]
+      }
+    },
+    "/v1/notifications/mark-read": {
+      "post": {
+        "operationId": "mark_read_v1_notifications_mark_read_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MarkNotificationsReadRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MarkNotificationsReadResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Mark Read",
+        "tags": [
+          "notifications"
+        ]
+      }
+    },
+    "/v1/notifications/unread-count": {
+      "get": {
+        "operationId": "unread_count_v1_notifications_unread_count_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnreadCountResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Unread Count",
+        "tags": [
+          "notifications"
         ]
       }
     },

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -7,6 +7,7 @@ from .db import connect_db, disconnect_db
 from .errors import ApiError, error_response
 from .routers import auth, comments, family, health, me, posts, profile, reactions, recipes, tags, timeline
 from .routers.v1 import auth as auth_v1
+from .routers.v1 import notifications as notifications_v1
 from .settings import settings, validate_settings
 
 
@@ -70,3 +71,8 @@ for _router in _DUAL_INCLUDED_ROUTERS:
 
 app.include_router(auth.router)
 app.include_router(auth_v1.router)
+# `/v1/notifications/*` is owned exclusively by the v1 namespace — Bearer
+# auth, no cookie-auth twin. The Phase 2 frontend only hits these endpoints
+# when `USE_FASTAPI_AUTH` is on (and is therefore already sending access
+# tokens); a dual-mounted unprefixed cookie-auth alias would have no caller.
+app.include_router(notifications_v1.router)

--- a/apps/api/src/routers/v1/notifications.py
+++ b/apps/api/src/routers/v1/notifications.py
@@ -1,0 +1,208 @@
+"""/v1/notifications/* — list, mark-read, unread-count.
+
+Mirrors the Next.js handlers at src/app/api/notifications/* (issue #182,
+sub-task of #37). Bearer-token auth via get_current_user_v1; never mounted
+unprefixed — there is no cookie-auth twin because the Phase 2 frontend only
+hits this surface when USE_FASTAPI_AUTH is on (which means it's already
+sending access tokens).
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, Depends, Query
+from prisma.errors import PrismaError
+
+from ...db import prisma
+from ...dependencies_v1 import get_current_user_v1
+from ...errors import internal_error, validation_error
+from ...schemas.auth import UserResponse
+from ...schemas.notifications import (
+    MarkNotificationsReadRequest,
+    MarkNotificationsReadResponse,
+    NotificationsListResponse,
+    UnreadCountResponse,
+)
+from ...uploads import create_signed_url_resolver
+from ...utils import iso
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/v1/notifications", tags=["notifications"])
+
+
+def _emoji_counts_total(emoji_counts: list[Any] | None) -> int:
+    if not emoji_counts:
+        return 0
+    total = 0
+    for entry in emoji_counts:
+        # Stored as JSON; can come back as either dicts or model objects.
+        if isinstance(entry, dict):
+            total += int(entry.get("count", 0) or 0)
+        else:
+            total += int(getattr(entry, "count", 0) or 0)
+    return total
+
+
+def _emoji_counts_to_list(emoji_counts: list[Any] | None) -> list[dict]:
+    if not emoji_counts:
+        return []
+    out: list[dict] = []
+    for entry in emoji_counts:
+        if isinstance(entry, dict):
+            out.append({"emoji": entry.get("emoji", ""), "count": int(entry.get("count", 0) or 0)})
+        else:
+            out.append({"emoji": getattr(entry, "emoji", ""), "count": int(getattr(entry, "count", 0) or 0)})
+    return out
+
+
+def _metadata_get(metadata: Any, key: str) -> Any:
+    if metadata is None:
+        return None
+    if isinstance(metadata, dict):
+        return metadata.get(key)
+    return getattr(metadata, key, None)
+
+
+@router.get("", response_model=NotificationsListResponse)
+async def list_notifications(
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+    unreadOnly: bool = Query(default=False),
+    user: UserResponse = Depends(get_current_user_v1),
+):
+    try:
+        # Two reads, one count — mirrors fetchNotifications() in
+        # src/lib/notifications.ts. The limit+1 take is the standard
+        # has-more probe used by the rest of this codebase.
+        where: dict = {"recipientId": user.id, "familySpaceId": user.familySpaceId}
+        if unreadOnly:
+            where["readAt"] = None
+        rows = await prisma.notification.find_many(
+            where=where,
+            order=[{"updatedAt": "desc"}, {"createdAt": "desc"}],
+            take=limit + 1,
+            skip=offset,
+            include={
+                "actor": True,
+                "post": True,
+            },
+        )
+        # The Next handler counts unread for the recipient regardless of
+        # family scope (recipient implicitly belongs to one family). Match
+        # that for parity.
+        unread_count = await prisma.notification.count(
+            where={"recipientId": user.id, "readAt": None},
+        )
+
+        has_more = len(rows) > limit
+        slice_rows = rows[:limit]
+
+        resolve_url = create_signed_url_resolver()
+        items: list[dict] = []
+        for row in slice_rows:
+            actor = row.actor
+            post = row.post
+            metadata = getattr(row, "metadata", None)
+            row_type = row.type
+            entry: dict = {
+                "id": row.id,
+                "type": row_type,
+                "createdAt": iso(row.createdAt),
+                "updatedAt": iso(row.updatedAt),
+                "readAt": iso(row.readAt) if row.readAt else None,
+                "actor": {
+                    "id": actor.id,
+                    "name": actor.name,
+                    "avatarUrl": await resolve_url(getattr(actor, "avatarStorageKey", None)),
+                },
+                "post": {
+                    "id": post.id,
+                    "title": post.title,
+                    "mainPhotoUrl": await resolve_url(getattr(post, "mainPhotoStorageKey", None)),
+                },
+                "commentText": _metadata_get(metadata, "commentText"),
+                "cookedNote": _metadata_get(metadata, "note"),
+                "cookedRating": _metadata_get(metadata, "rating") if isinstance(_metadata_get(metadata, "rating"), int) else None,
+            }
+            if row_type == "reaction_batch":
+                emoji_counts = _emoji_counts_to_list(getattr(row, "emojiCounts", None))
+                total = getattr(row, "totalCount", None)
+                if total is None:
+                    total = _emoji_counts_total(emoji_counts)
+                entry["reactionSummary"] = {
+                    "totalCount": total,
+                    "emojiCounts": emoji_counts,
+                    "lastEmoji": _metadata_get(metadata, "lastEmoji"),
+                }
+            items.append(entry)
+
+        return {
+            "notifications": items,
+            "unreadCount": unread_count,
+            "hasMore": has_more,
+            "nextOffset": offset + len(items),
+        }
+    except PrismaError as e:
+        logger.exception("notifications.list.prisma_error: %s", e)
+        return internal_error("Failed to load notifications")
+    except (ValueError, TypeError, AttributeError, KeyError) as e:
+        logger.exception("notifications.list.error: %s", e)
+        return internal_error("Failed to load notifications")
+
+
+@router.post("/mark-read", response_model=MarkNotificationsReadResponse)
+async def mark_read(
+    payload: MarkNotificationsReadRequest,
+    user: UserResponse = Depends(get_current_user_v1),
+):
+    ids = payload.ids
+    if ids is not None and any(not isinstance(i, str) or not i for i in ids):
+        return validation_error("Invalid notification ID")
+
+    try:
+        # Family scoping: even though `recipientId == user.id` is enough to
+        # prevent cross-user writes, we add familySpaceId so a stale ID from
+        # a different space (post-membership-change) cannot be marked. Mirrors
+        # the implicit invariant in the Next handler, where recipient implies
+        # family.
+        where: dict = {
+            "recipientId": user.id,
+            "familySpaceId": user.familySpaceId,
+            "readAt": None,
+        }
+        if ids:
+            where["id"] = {"in": ids}
+
+        await prisma.notification.update_many(
+            where=where,
+            data={"readAt": datetime.now(timezone.utc)},
+        )
+
+        unread_count = await prisma.notification.count(
+            where={"recipientId": user.id, "readAt": None},
+        )
+        return {"status": "ok", "unreadCount": unread_count}
+    except PrismaError as e:
+        logger.exception("notifications.mark_read.prisma_error: %s", e)
+        return internal_error("Failed to mark notifications as read")
+    except (ValueError, TypeError, AttributeError, KeyError) as e:
+        logger.exception("notifications.mark_read.error: %s", e)
+        return internal_error("Failed to mark notifications as read")
+
+
+@router.get("/unread-count", response_model=UnreadCountResponse)
+async def unread_count(user: UserResponse = Depends(get_current_user_v1)):
+    try:
+        count = await prisma.notification.count(
+            where={"recipientId": user.id, "readAt": None},
+        )
+        return {"unreadCount": count}
+    except PrismaError as e:
+        logger.exception("notifications.unread_count.prisma_error: %s", e)
+        return internal_error("Failed to fetch unread notifications")
+    except (ValueError, TypeError, AttributeError) as e:
+        logger.exception("notifications.unread_count.error: %s", e)
+        return internal_error("Failed to fetch unread notifications")

--- a/apps/api/src/schemas/notifications.py
+++ b/apps/api/src/schemas/notifications.py
@@ -1,0 +1,72 @@
+"""Request/response shapes for /v1/notifications/*.
+
+Mirrors the JSON the Next.js handlers at src/app/api/notifications/* return,
+so the frontend can swap base URLs without other changes during dual-mode.
+"""
+from __future__ import annotations
+
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+NotificationType = Literal["comment", "reaction_batch", "cooked"]
+
+
+class NotificationActor(BaseModel):
+    id: str
+    name: str
+    avatarUrl: Optional[str] = None
+
+
+class NotificationPost(BaseModel):
+    id: str
+    title: str
+    mainPhotoUrl: Optional[str] = None
+
+
+class ReactionEmojiCount(BaseModel):
+    emoji: str
+    count: int
+
+
+class ReactionSummary(BaseModel):
+    totalCount: int
+    emojiCounts: List[ReactionEmojiCount]
+    lastEmoji: Optional[str] = None
+
+
+class NotificationItem(BaseModel):
+    id: str
+    type: NotificationType
+    createdAt: str
+    updatedAt: str
+    readAt: Optional[str] = None
+    actor: NotificationActor
+    post: NotificationPost
+    commentText: Optional[str] = None
+    cookedNote: Optional[str] = None
+    cookedRating: Optional[int] = None
+    reactionSummary: Optional[ReactionSummary] = None
+
+
+class NotificationsListResponse(BaseModel):
+    notifications: List[NotificationItem]
+    unreadCount: int
+    hasMore: bool
+    nextOffset: int
+
+
+class MarkNotificationsReadRequest(BaseModel):
+    # Optional list of IDs to mark; omitted/empty = mark all unread for caller.
+    # Capped to mirror the Next.js Zod schema in src/lib/validation.ts.
+    ids: Optional[List[str]] = Field(default=None, max_length=50)
+
+
+class MarkNotificationsReadResponse(BaseModel):
+    status: Literal["ok"]
+    unreadCount: int
+
+
+class UnreadCountResponse(BaseModel):
+    unreadCount: int

--- a/apps/api/tests/helpers/mock_prisma.py
+++ b/apps/api/tests/helpers/mock_prisma.py
@@ -16,6 +16,7 @@ MODEL_NAMES = [
     "tag",
     "refreshtoken",
     "idempotencykey",
+    "notification",
 ]
 
 

--- a/apps/api/tests/integration/conftest.py
+++ b/apps/api/tests/integration/conftest.py
@@ -37,6 +37,7 @@ def mock_prisma(monkeypatch):
     monkeypatch.setattr("src.routers.family.prisma", mock)
     monkeypatch.setattr("src.routers.recipes.prisma", mock)
     monkeypatch.setattr("src.routers.v1.auth.prisma", mock)
+    monkeypatch.setattr("src.routers.v1.notifications.prisma", mock)
     monkeypatch.setattr("src.dependencies.prisma", mock)
     monkeypatch.setattr("src.dependencies_v1.prisma", mock)
     yield mock

--- a/apps/api/tests/integration/test_notifications.py
+++ b/apps/api/tests/integration/test_notifications.py
@@ -1,0 +1,334 @@
+"""Integration tests for /v1/notifications/* — issue #182.
+
+Bearer-token (access-token) auth via dependencies_v1. Mocks Prisma so tests
+exercise the full FastAPI dependency chain without a real DB. Covers the
+acceptance criteria from the ticket: happy path, 401 unauth, family scoping,
+unreadOnly filter, mark-read selective vs. all.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from src import tokens
+from tests.helpers.test_data import make_mock_membership, make_mock_user
+
+
+def _bearer_headers(user_id: str, family_space_id: str, role: str = "member") -> dict:
+    token = tokens.mint_access_token(
+        user_id=user_id, family_space_id=family_space_id, role=role
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _seed_user_lookup(mock_prisma, user, family_space):
+    """Wire the /v1 dependency's `user.find_unique` so the bearer dep
+    resolves to the test user with a membership in the test family."""
+    membership = make_mock_membership(
+        userId=user.id,
+        familySpaceId=family_space.id,
+        familySpace=family_space,
+    )
+    user_with_membership = make_mock_user(memberships=[membership], id=user.id)
+    mock_prisma.user.find_unique = AsyncMock(return_value=user_with_membership)
+    return user_with_membership
+
+
+def _make_notification_row(
+    *,
+    id: str = "notif_1",
+    notif_type: str = "comment",
+    recipient_id: str = "user_test_123",
+    family_space_id: str = "family_test_123",
+    actor_id: str = "actor_1",
+    post_id: str = "post_1",
+    read_at: datetime | None = None,
+    metadata: dict | None = None,
+    emoji_counts: list | None = None,
+    total_count: int | None = None,
+) -> SimpleNamespace:
+    now = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    return SimpleNamespace(
+        id=id,
+        type=notif_type,
+        recipientId=recipient_id,
+        familySpaceId=family_space_id,
+        actorId=actor_id,
+        postId=post_id,
+        commentId=None,
+        cookedEventId=None,
+        emojiCounts=emoji_counts,
+        totalCount=total_count,
+        metadata=metadata or {},
+        createdAt=now,
+        updatedAt=now,
+        readAt=read_at,
+        actor=SimpleNamespace(
+            id=actor_id, name="Actor Name", avatarStorageKey=None
+        ),
+        post=SimpleNamespace(
+            id=post_id, title="Post Title", mainPhotoStorageKey=None
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/notifications
+# ---------------------------------------------------------------------------
+
+
+class TestListNotifications:
+    def test_unauthenticated_returns_envelope_401(self, client):
+        response = client.get("/v1/notifications")
+        assert response.status_code == 401
+        assert response.json() == {
+            "error": {"code": "UNAUTHORIZED", "message": "Unauthorized"}
+        }
+
+    def test_invalid_bearer_returns_envelope_401(self, client):
+        response = client.get(
+            "/v1/notifications", headers={"Authorization": "Bearer not-a-jwt"}
+        )
+        assert response.status_code == 401
+        assert response.json()["error"]["code"] == "UNAUTHORIZED"
+
+    def test_happy_path_returns_items_and_unread_count(
+        self, client, mock_prisma, mock_user, mock_family_space
+    ):
+        _seed_user_lookup(mock_prisma, mock_user, mock_family_space)
+        rows = [
+            _make_notification_row(
+                id="n1",
+                recipient_id=mock_user.id,
+                family_space_id=mock_family_space.id,
+                metadata={"commentText": "Looks great!"},
+            ),
+            _make_notification_row(
+                id="n2",
+                notif_type="reaction_batch",
+                recipient_id=mock_user.id,
+                family_space_id=mock_family_space.id,
+                emoji_counts=[{"emoji": "❤️", "count": 2}, {"emoji": "🔥", "count": 1}],
+                total_count=3,
+                metadata={"lastEmoji": "🔥"},
+            ),
+        ]
+        mock_prisma.notification.find_many = AsyncMock(return_value=rows)
+        mock_prisma.notification.count = AsyncMock(return_value=1)
+
+        response = client.get(
+            "/v1/notifications",
+            headers=_bearer_headers(mock_user.id, mock_family_space.id),
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["unreadCount"] == 1
+        assert body["hasMore"] is False
+        assert body["nextOffset"] == 2
+        assert len(body["notifications"]) == 2
+        assert body["notifications"][0]["id"] == "n1"
+        assert body["notifications"][0]["commentText"] == "Looks great!"
+        assert body["notifications"][1]["reactionSummary"]["totalCount"] == 3
+        assert body["notifications"][1]["reactionSummary"]["lastEmoji"] == "🔥"
+
+    def test_has_more_when_take_returns_extra_row(
+        self, client, mock_prisma, mock_user, mock_family_space
+    ):
+        _seed_user_lookup(mock_prisma, mock_user, mock_family_space)
+        # Request limit=2 → router asks for 3; returning 3 means hasMore=True.
+        rows = [
+            _make_notification_row(
+                id=f"n{i}",
+                recipient_id=mock_user.id,
+                family_space_id=mock_family_space.id,
+            )
+            for i in range(3)
+        ]
+        mock_prisma.notification.find_many = AsyncMock(return_value=rows)
+        mock_prisma.notification.count = AsyncMock(return_value=0)
+
+        response = client.get(
+            "/v1/notifications?limit=2",
+            headers=_bearer_headers(mock_user.id, mock_family_space.id),
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["hasMore"] is True
+        assert len(body["notifications"]) == 2
+
+    def test_query_is_family_scoped(
+        self, client, mock_prisma, mock_user, mock_family_space
+    ):
+        """Family scoping is implicit but load-bearing — the where clause
+        must include familySpaceId so a user moving families can't see
+        old-family notifications."""
+        _seed_user_lookup(mock_prisma, mock_user, mock_family_space)
+        mock_prisma.notification.find_many = AsyncMock(return_value=[])
+        mock_prisma.notification.count = AsyncMock(return_value=0)
+
+        response = client.get(
+            "/v1/notifications",
+            headers=_bearer_headers(mock_user.id, mock_family_space.id),
+        )
+        assert response.status_code == 200
+        call_kwargs = mock_prisma.notification.find_many.await_args.kwargs
+        assert call_kwargs["where"]["recipientId"] == mock_user.id
+        assert call_kwargs["where"]["familySpaceId"] == mock_family_space.id
+
+    def test_unread_only_filter_adds_read_at_null(
+        self, client, mock_prisma, mock_user, mock_family_space
+    ):
+        _seed_user_lookup(mock_prisma, mock_user, mock_family_space)
+        mock_prisma.notification.find_many = AsyncMock(return_value=[])
+        mock_prisma.notification.count = AsyncMock(return_value=0)
+
+        response = client.get(
+            "/v1/notifications?unreadOnly=true",
+            headers=_bearer_headers(mock_user.id, mock_family_space.id),
+        )
+        assert response.status_code == 200
+        call_kwargs = mock_prisma.notification.find_many.await_args.kwargs
+        assert call_kwargs["where"]["readAt"] is None
+
+    def test_default_does_not_filter_by_read_at(
+        self, client, mock_prisma, mock_user, mock_family_space
+    ):
+        _seed_user_lookup(mock_prisma, mock_user, mock_family_space)
+        mock_prisma.notification.find_many = AsyncMock(return_value=[])
+        mock_prisma.notification.count = AsyncMock(return_value=0)
+
+        response = client.get(
+            "/v1/notifications",
+            headers=_bearer_headers(mock_user.id, mock_family_space.id),
+        )
+        assert response.status_code == 200
+        call_kwargs = mock_prisma.notification.find_many.await_args.kwargs
+        assert "readAt" not in call_kwargs["where"]
+
+    def test_invalid_limit_returns_422_envelope_or_envelope(
+        self, client, mock_user, mock_family_space, mock_prisma
+    ):
+        # Pydantic validation on Query params returns FastAPI's default 422
+        # shape. The error-shape audit (#190) is the ticket that converts
+        # this to the standard envelope; for now we just assert the request
+        # is rejected.
+        _seed_user_lookup(mock_prisma, mock_user, mock_family_space)
+        response = client.get(
+            "/v1/notifications?limit=999",
+            headers=_bearer_headers(mock_user.id, mock_family_space.id),
+        )
+        assert response.status_code in (400, 422)
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/notifications/mark-read
+# ---------------------------------------------------------------------------
+
+
+class TestMarkRead:
+    def test_unauthenticated_returns_envelope_401(self, client):
+        response = client.post("/v1/notifications/mark-read", json={})
+        assert response.status_code == 401
+        assert response.json()["error"]["code"] == "UNAUTHORIZED"
+
+    def test_mark_all_when_ids_omitted(
+        self, client, mock_prisma, mock_user, mock_family_space
+    ):
+        _seed_user_lookup(mock_prisma, mock_user, mock_family_space)
+        mock_prisma.notification.update_many = AsyncMock(return_value=None)
+        mock_prisma.notification.count = AsyncMock(return_value=0)
+
+        response = client.post(
+            "/v1/notifications/mark-read",
+            json={},
+            headers=_bearer_headers(mock_user.id, mock_family_space.id),
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body == {"status": "ok", "unreadCount": 0}
+        call_kwargs = mock_prisma.notification.update_many.await_args.kwargs
+        # When `ids` is omitted, the where clause must NOT contain `id` —
+        # otherwise we'd silently mark zero rows.
+        assert "id" not in call_kwargs["where"]
+        assert call_kwargs["where"]["recipientId"] == mock_user.id
+        assert call_kwargs["where"]["familySpaceId"] == mock_family_space.id
+        assert call_kwargs["where"]["readAt"] is None
+
+    def test_mark_specific_ids_passes_in_filter(
+        self, client, mock_prisma, mock_user, mock_family_space
+    ):
+        _seed_user_lookup(mock_prisma, mock_user, mock_family_space)
+        mock_prisma.notification.update_many = AsyncMock(return_value=None)
+        mock_prisma.notification.count = AsyncMock(return_value=2)
+
+        response = client.post(
+            "/v1/notifications/mark-read",
+            json={"ids": ["n1", "n2"]},
+            headers=_bearer_headers(mock_user.id, mock_family_space.id),
+        )
+        assert response.status_code == 200
+        assert response.json()["unreadCount"] == 2
+        call_kwargs = mock_prisma.notification.update_many.await_args.kwargs
+        assert call_kwargs["where"]["id"] == {"in": ["n1", "n2"]}
+        assert call_kwargs["where"]["recipientId"] == mock_user.id
+
+    def test_cannot_mark_other_users_notifications(
+        self, client, mock_prisma, mock_user, mock_family_space
+    ):
+        """Even when the caller passes IDs they don't own, the where clause
+        scopes to recipientId=user.id so the update_many silently affects
+        zero rows — confirmed by inspecting the actual DB query, since the
+        mock can't simulate row-level filtering."""
+        _seed_user_lookup(mock_prisma, mock_user, mock_family_space)
+        mock_prisma.notification.update_many = AsyncMock(return_value=None)
+        mock_prisma.notification.count = AsyncMock(return_value=0)
+
+        response = client.post(
+            "/v1/notifications/mark-read",
+            json={"ids": ["someone_elses_id"]},
+            headers=_bearer_headers(mock_user.id, mock_family_space.id),
+        )
+        assert response.status_code == 200
+        call_kwargs = mock_prisma.notification.update_many.await_args.kwargs
+        # The recipientId predicate is what enforces cross-user safety.
+        assert call_kwargs["where"]["recipientId"] == mock_user.id
+
+    def test_too_many_ids_rejected_by_schema(
+        self, client, mock_prisma, mock_user, mock_family_space
+    ):
+        _seed_user_lookup(mock_prisma, mock_user, mock_family_space)
+        response = client.post(
+            "/v1/notifications/mark-read",
+            json={"ids": [f"id_{i}" for i in range(51)]},
+            headers=_bearer_headers(mock_user.id, mock_family_space.id),
+        )
+        assert response.status_code in (400, 422)
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/notifications/unread-count
+# ---------------------------------------------------------------------------
+
+
+class TestUnreadCount:
+    def test_unauthenticated_returns_envelope_401(self, client):
+        response = client.get("/v1/notifications/unread-count")
+        assert response.status_code == 401
+        assert response.json()["error"]["code"] == "UNAUTHORIZED"
+
+    def test_returns_count_for_caller(
+        self, client, mock_prisma, mock_user, mock_family_space
+    ):
+        _seed_user_lookup(mock_prisma, mock_user, mock_family_space)
+        mock_prisma.notification.count = AsyncMock(return_value=7)
+
+        response = client.get(
+            "/v1/notifications/unread-count",
+            headers=_bearer_headers(mock_user.id, mock_family_space.id),
+        )
+        assert response.status_code == 200
+        assert response.json() == {"unreadCount": 7}
+        call_kwargs = mock_prisma.notification.count.await_args.kwargs
+        assert call_kwargs["where"]["recipientId"] == mock_user.id
+        assert call_kwargs["where"]["readAt"] is None

--- a/apps/api/tests/integration/test_v1_aliases.py
+++ b/apps/api/tests/integration/test_v1_aliases.py
@@ -26,6 +26,11 @@ V1_ONLY_PATHS: frozenset[str] = frozenset(
     {
         "/v1/auth/refresh",
         "/v1/auth/session",
+        # /v1/notifications/* (issue #182) is Bearer-token only — never had a
+        # cookie-auth Next twin behind FastAPI, so no unprefixed alias.
+        "/v1/notifications",
+        "/v1/notifications/mark-read",
+        "/v1/notifications/unread-count",
     }
 )
 

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -27,11 +27,12 @@ export default async function AppLayout({
       redirect('/login');
     }
 
-    // Notifications still read directly from Prisma in Phase 2 — see issue #171
-    // for the follow-up to move this onto a /v1 FastAPI endpoint.
-    const initialUnreadCount = await prisma.notification.count({
-      where: { recipientId: result.user.id, readAt: null },
-    });
+    // Flag-on path: defer the unread-count fetch to <NotificationBell>'s
+    // client-side effect, which calls /v1/notifications/unread-count via
+    // apiClient with the in-memory access token. The badge briefly shows 0
+    // before the first tick replaces it — acceptable trade-off vs. minting a
+    // server-side access token (which would rotate the refresh chain on
+    // every layout render, defeating the /session split from #173).
 
     return (
       <AuthBootstrap>
@@ -47,7 +48,7 @@ export default async function AppLayout({
                 </p>
               </div>
               <div className="flex items-center gap-3">
-                <NotificationBell initialCount={initialUnreadCount} />
+                <NotificationBell initialCount={0} />
                 <LogoutButton />
               </div>
             </div>

--- a/src/components/navigation/NotificationBell.tsx
+++ b/src/components/navigation/NotificationBell.tsx
@@ -4,8 +4,15 @@ import { Bell } from 'lucide-react';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
+import { apiClient, ApiError } from '@/lib/apiClient';
+import { isFastApiAuthEnabled } from '@/lib/featureFlags';
+
 interface NotificationBellProps {
   initialCount: number;
+}
+
+interface UnreadCountResponse {
+  unreadCount: number;
 }
 
 export default function NotificationBell({
@@ -14,20 +21,42 @@ export default function NotificationBell({
   const [unreadCount, setUnreadCount] = useState<number>(initialCount);
 
   useEffect(() => {
+    const fastApiOn = isFastApiAuthEnabled();
+
     const refresh = async () => {
       try {
+        if (fastApiOn) {
+          const data = await apiClient.get<UnreadCountResponse>(
+            '/v1/notifications/unread-count'
+          );
+          setUnreadCount(
+            typeof data.unreadCount === 'number' ? data.unreadCount : 0
+          );
+          return;
+        }
         const response = await fetch('/api/notifications/unread-count', {
           cache: 'no-store',
         });
         if (!response.ok) return;
-        const data = await response.json();
+        const data = (await response.json()) as UnreadCountResponse;
         setUnreadCount(
           typeof data.unreadCount === 'number' ? data.unreadCount : 0
         );
       } catch (error) {
+        // Ignore 401s: AuthBootstrap may not have minted the access token
+        // yet on first render. The 60s interval below will retry.
+        if (error instanceof ApiError && error.status === 401) return;
         console.error('Failed to fetch unread notifications', error);
       }
     };
+
+    // Flag-on layout intentionally renders with initialCount=0; refresh
+    // immediately so the badge reflects reality post-hydration. Flag-off
+    // layout SSR-prefetches via Prisma, so the immediate call is just an
+    // extra round-trip — the interval below is enough.
+    if (fastApiOn) {
+      refresh();
+    }
     const interval = setInterval(refresh, 60000);
     return () => clearInterval(interval);
   }, []);

--- a/src/components/notifications/NotificationsFeed.tsx
+++ b/src/components/notifications/NotificationsFeed.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useState } from 'react';
 import NotificationCard from './NotificationCard';
+import { apiClient } from '@/lib/apiClient';
+import { isFastApiAuthEnabled } from '@/lib/featureFlags';
 
 export type NotificationResponseItem = {
   id: string;
@@ -59,26 +61,42 @@ export default function NotificationsFeed({
   useEffect(() => {
     // Fire-and-forget: mark notifications read once the feed has been opened.
     // No state is set in this effect body; the bell refreshes via its own poll.
-    fetch('/api/notifications/mark-read', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({}),
-    }).catch((err) => {
-      console.error('Failed to mark notifications as read', err);
-    });
+    const markRead = async () => {
+      try {
+        if (isFastApiAuthEnabled()) {
+          await apiClient.post('/v1/notifications/mark-read', { body: {} });
+          return;
+        }
+        await fetch('/api/notifications/mark-read', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        });
+      } catch (err) {
+        console.error('Failed to mark notifications as read', err);
+      }
+    };
+    markRead();
   }, []);
 
   const handleLoadMore = async () => {
     setIsLoadingMore(true);
     try {
-      const response = await fetch(
-        `/api/notifications?limit=${PAGE_SIZE}&offset=${offset}`,
-        { cache: 'no-store' }
-      );
-      if (!response.ok) {
-        throw new Error('Failed to fetch notifications');
+      let data: ApiResponse;
+      if (isFastApiAuthEnabled()) {
+        data = await apiClient.get<ApiResponse>('/v1/notifications', {
+          query: { limit: PAGE_SIZE, offset },
+        });
+      } else {
+        const response = await fetch(
+          `/api/notifications?limit=${PAGE_SIZE}&offset=${offset}`,
+          { cache: 'no-store' }
+        );
+        if (!response.ok) {
+          throw new Error('Failed to fetch notifications');
+        }
+        data = (await response.json()) as ApiResponse;
       }
-      const data: ApiResponse = await response.json();
       setNotifications((prev) => [...prev, ...data.notifications]);
       setHasMore(data.hasMore);
       setOffset(data.nextOffset);


### PR DESCRIPTION
Closes #182. Sub-task of #37 (Phase 3 endpoint parity).

## Summary

- New v1 router at `apps/api/src/routers/v1/notifications.py` exposing `/v1/notifications`, `/v1/notifications/mark-read`, `/v1/notifications/unread-count`, all behind `get_current_user_v1` (Bearer access token) and family-scoped via `recipientId + familySpaceId`.
- JSON shapes mirror the Next handlers at `src/app/api/notifications/*` so the frontend can swap base URLs without contract changes during dual-mode (`{ notifications, unreadCount, hasMore, nextOffset }` for list; `{ status, unreadCount }` for mark-read; `{ unreadCount }` for unread-count). Plan-spec `unreadOnly?` filter is implemented as a pure addition.
- Mounted at `/v1` only — no unprefixed cookie-auth twin. The Phase 2 frontend only hits this surface when `USE_FASTAPI_AUTH` is on (and is therefore already sending access tokens). Added the three paths to `V1_ONLY_PATHS` in `test_v1_aliases.py` so the dual-include invariant test still passes.
- Frontend: `NotificationBell.tsx` and `NotificationsFeed.tsx` route through `apiClient` when `USE_FASTAPI_AUTH` is on (so the in-memory access token is attached automatically), and fall back to the existing `/api/notifications/*` Next routes when the flag is off. The off-flag SSR Prisma prefetch in `(app)/layout.tsx` is preserved for parity; the on-flag path renders with `initialCount={0}` and lets the bell's effect populate the badge — the alternative (server-side access token) would rotate the refresh-token chain on every layout render and defeat the `/v1/auth/session` split from #173.
- `apps/api/openapi.snapshot.json` regenerated; diff is purely additive (notifications schemas + 3 new operations).

## Test plan

- [x] `apps/api/.venv/bin/pytest tests/ --ignore=tests/unit/test_multipart_uploads.py` — 413 passed (PIL-only suite was already broken on this machine, pre-existing)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 1056 passed across 52 suites
- [x] `apps/api/.venv/bin/ruff check src/ tests/` — all checks passed
- [x] OpenAPI snapshot regenerated; `git diff --stat` shows pure additions
- [ ] Manual smoke against the running dev stack with `USE_FASTAPI_AUTH=true`: notifications page lists, marks-read on open, badge count refreshes — not run from this session (no browser environment)
- [x] Family-scoping covered by integration test asserting `where.familySpaceId == user.familySpaceId` on the find_many call
- [x] `unreadOnly` filter covered by an integration test asserting `where.readAt is None` is added when set
- [x] Mark-read selective vs all covered (with-IDs builds an `id: { in: ... }` filter; without-IDs marks all unread for the recipient/family)

## Out of scope (deferred)

- Pydantic `422` validation responses still use FastAPI's default `{detail: ...}` shape rather than the project envelope; that conversion lives in #190 (Phase 3-D2 error-shape audit).
- Idempotency on `mark-read` writes — the new `X-Request-Id` helper from #180 is not yet wired here; can be a follow-up under #194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)