### PR TITLE
chore(api): Phase 3-D2 — error-shape audit on FastAPI handlers (#190)

### DIFF
--- a/apps/api/src/dependencies.py
+++ b/apps/api/src/dependencies.py
@@ -1,21 +1,26 @@
-from fastapi import HTTPException, Request, status
+from fastapi import Request, status
 
 from .db import prisma
+from .errors import ApiError
 from .schemas.auth import UserResponse
 from .security import verify_token
 from .settings import settings
 from .uploads import get_signed_upload_url
 
 
+def _unauthorized() -> ApiError:
+    return ApiError("UNAUTHORIZED", "Unauthorized", status.HTTP_401_UNAUTHORIZED)
+
+
 async def get_current_user(request: Request) -> UserResponse:
     token = request.cookies.get(settings.cookie_name)
     if not token:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+        raise _unauthorized()
 
     payload = verify_token(token)
 
     if not payload:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+        raise _unauthorized()
 
     user = await prisma.user.find_unique(
         where={"id": payload["userId"]},
@@ -28,7 +33,7 @@ async def get_current_user(request: Request) -> UserResponse:
     )
 
     if not user or not user.memberships:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+        raise _unauthorized()
 
     membership = user.memberships[0]
     avatar_url = await get_signed_upload_url(getattr(user, "avatarStorageKey", None))

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -1,10 +1,11 @@
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 
 from .db import connect_db, disconnect_db
-from .errors import ApiError, error_response
+from .errors import ApiError, error_response, validation_error
 from .routers import auth, comments, family, health, me, posts, profile, reactions, recipes, tags, timeline
 from .routers.v1 import auth as auth_v1
 from .routers.v1 import notifications as notifications_v1
@@ -30,6 +31,15 @@ app = FastAPI(title="Family Recipe API", lifespan=lifespan)
 @app.exception_handler(ApiError)
 async def _api_error_handler(_request: Request, exc: ApiError):
     return error_response(exc.code, exc.message, exc.status_code)
+
+
+@app.exception_handler(RequestValidationError)
+async def _validation_error_handler(_request: Request, _exc: RequestValidationError):
+    # FastAPI's default 422 `{detail: [...]}` shape is not the documented
+    # contract — the migration plan specifies 400 VALIDATION_ERROR for every
+    # endpoint. Per-field detail is intentionally dropped: the envelope is
+    # public surface, the field list is not.
+    return validation_error("Invalid input")
 
 
 if settings.cors_origins_list:

--- a/apps/api/tests/helpers/error_envelope.py
+++ b/apps/api/tests/helpers/error_envelope.py
@@ -1,0 +1,65 @@
+"""Assertion helpers for the standard `{error: {code, message}}` envelope.
+
+Per docs/API_BACKEND_MIGRATION_PLAN.md (Common Conventions), every non-2xx
+response from a `/v1` handler — and every error response from the legacy
+cookie-auth surface kept alive during Phase 3 — must use this envelope.
+Tests should call `assert_error_envelope` rather than poking at
+`response.json()["error"]["code"]` ad-hoc; it keeps the contract assertion
+in one place and produces clearer diffs on regressions.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+VALID_ERROR_CODES = {
+    "VALIDATION_ERROR",
+    "BAD_REQUEST",
+    "UNAUTHORIZED",
+    "INVALID_CREDENTIALS",
+    "INVALID_TOKEN",
+    "TOKEN_EXPIRED",
+    "FORBIDDEN",
+    "NOT_FOUND",
+    "CONFLICT",
+    "RATE_LIMITED",
+    "INTERNAL_ERROR",
+}
+
+
+def assert_error_envelope(
+    response: Any,
+    *,
+    status_code: int,
+    code: str,
+    message_contains: str | None = None,
+) -> None:
+    """Assert that `response` carries the standard error envelope.
+
+    `response` is a `httpx.Response` (or anything with `.status_code` and
+    `.json()`). `code` must be one of `VALID_ERROR_CODES`. `message_contains`
+    is an optional case-insensitive substring match on the message — useful
+    when the exact phrasing is not part of the contract.
+    """
+    assert response.status_code == status_code, (
+        f"expected status {status_code}, got {response.status_code}: {response.text}"
+    )
+    body = response.json()
+    assert "error" in body, f"missing `error` key in body: {body}"
+    err = body["error"]
+    assert isinstance(err, dict), f"`error` must be an object, got {type(err).__name__}: {err}"
+    assert err.get("code") == code, f"expected code {code!r}, got {err.get('code')!r}"
+    assert code in VALID_ERROR_CODES, (
+        f"unknown error code {code!r}; update VALID_ERROR_CODES if this was added intentionally"
+    )
+    assert isinstance(err.get("message"), str) and err["message"], (
+        f"`error.message` must be a non-empty string, got {err.get('message')!r}"
+    )
+    # Public envelope is exactly {code, message} — extra keys would be
+    # contract drift and easy to miss in a snapshot diff.
+    assert set(err.keys()) == {"code", "message"}, (
+        f"`error` must contain exactly {{code, message}}, got keys: {sorted(err.keys())}"
+    )
+    if message_contains is not None:
+        assert message_contains.lower() in err["message"].lower(), (
+            f"expected message to contain {message_contains!r}, got {err['message']!r}"
+        )

--- a/apps/api/tests/integration/test_auth.py
+++ b/apps/api/tests/integration/test_auth.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 from src.security import COOKIE_MAX_AGE_EXTENDED
 from tests.helpers.auth import make_auth_cookie
+from tests.helpers.error_envelope import assert_error_envelope
 from tests.helpers.test_data import make_mock_family_space, make_mock_membership, make_mock_user
 
 
@@ -19,7 +20,7 @@ class TestAuthMe:
     def test_me_unauthenticated(self, client):
         response = client.get("/auth/me")
 
-        assert response.status_code == 401
+        assert_error_envelope(response, status_code=401, code="UNAUTHORIZED")
 
     def test_me_authenticated(self, client, mock_prisma, mock_user, mock_family_space):
         membership = make_mock_membership(
@@ -212,7 +213,7 @@ class TestAuthLogin:
             json={"emailOrUsername": "ab", "password": "123"},
         )
 
-        assert response.status_code == 422
+        assert_error_envelope(response, status_code=400, code="VALIDATION_ERROR")
 
     def test_login_user_not_found(self, client, mock_prisma):
         mock_prisma.user.find_first.return_value = None

--- a/apps/api/tests/integration/test_error_envelope.py
+++ b/apps/api/tests/integration/test_error_envelope.py
@@ -1,0 +1,58 @@
+"""Contract tests for the global error envelope (issue #190).
+
+These exercise the global exception handlers in src/main.py end-to-end.
+Per-endpoint failing-path tests still assert their specific code/status;
+this file is the focused regression net for the *envelope* itself —
+i.e., that nothing leaks `{"detail": ...}` (FastAPI's default shape) or
+a 422 status code (the migration plan specifies 400 VALIDATION_ERROR for
+every endpoint).
+"""
+from __future__ import annotations
+
+import pytest
+
+from tests.helpers.error_envelope import assert_error_envelope
+
+
+class TestPydanticValidationEnvelope:
+    """RequestValidationError → 400 VALIDATION_ERROR (not FastAPI's default 422)."""
+
+    def test_invalid_json_body_returns_400_envelope(self, client):
+        # Missing required fields trigger Pydantic validation; the global
+        # handler wraps the error rather than letting FastAPI's default
+        # 422 `{detail: [...]}` shape leak.
+        response = client.post("/auth/login", json={})
+
+        assert_error_envelope(response, status_code=400, code="VALIDATION_ERROR")
+
+    @pytest.mark.usefixtures("mock_prisma", "prisma_user_with_membership")
+    def test_invalid_query_param_returns_400_envelope(self, client, member_auth):
+        # Validation runs before the route body, so the prisma stub doesn't
+        # need any specific return value here — the request never reaches
+        # the handler.
+        response = client.get("/recipes?sort=popularity", headers=member_auth)
+
+        assert_error_envelope(response, status_code=400, code="VALIDATION_ERROR")
+
+    def test_validation_error_does_not_leak_detail_key(self, client):
+        response = client.post("/auth/login", json={})
+
+        body = response.json()
+        assert "detail" not in body, (
+            "FastAPI's default `detail` key leaked through — RequestValidationError "
+            "handler is missing or misconfigured"
+        )
+
+
+class TestCookieAuthUnauthorizedEnvelope:
+    """Legacy cookie-auth dependency raises ApiError, not HTTPException."""
+
+    def test_missing_cookie_returns_envelope(self, client):
+        response = client.get("/auth/me")
+
+        assert_error_envelope(response, status_code=401, code="UNAUTHORIZED")
+
+    def test_invalid_cookie_returns_envelope(self, client):
+        response = client.get("/auth/me", headers={"Cookie": "session=not-a-real-jwt"})
+
+        assert_error_envelope(response, status_code=401, code="UNAUTHORIZED")

--- a/apps/api/tests/integration/test_recipes.py
+++ b/apps/api/tests/integration/test_recipes.py
@@ -7,6 +7,8 @@ from unittest.mock import AsyncMock
 import pytest
 from prisma.errors import PrismaError
 
+from tests.helpers.error_envelope import assert_error_envelope
+
 
 pytestmark = pytest.mark.usefixtures("mock_prisma", "prisma_user_with_membership")
 
@@ -453,7 +455,7 @@ def test_browse_recipes_sort_rating_rejects_invalid_pattern(client, mock_prisma,
 
     response = client.get("/recipes?sort=popularity", headers=member_auth)
 
-    assert response.status_code == 422
+    assert_error_envelope(response, status_code=400, code="VALIDATION_ERROR")
 
 
 def test_browse_recipes_sort_rating_caps_candidate_fetch(client, mock_prisma, member_auth):


### PR DESCRIPTION
Closes #190.

## Summary

Two real envelope leaks closed before Phase 4 cuts Next out:

- **`src/dependencies.py`** (legacy cookie-auth) raised plain `HTTPException`, producing FastAPI's default `{"detail": ...}` shape on 401 instead of the documented `{"error": {"code", "message"}}` envelope. Now raises `ApiError("UNAUTHORIZED", ..., 401)` and routes through the global handler in `main.py`. Mirrors `src/dependencies_v1.py`.
- **`RequestValidationError`** had no handler, so Pydantic body/query/path validation failures returned 422 with FastAPI's default per-field `{detail: [...]}` shape. The migration plan specifies 400 VALIDATION_ERROR for every endpoint; added a global handler that remaps 422 → 400 + envelope. Per-field detail intentionally dropped — the envelope is public surface, the field list is not.

Added `tests/helpers/error_envelope.py::assert_error_envelope` so failing-path tests assert the contract in one place (status, code, message presence, no extra keys, code in registry). Used in:

- New `tests/integration/test_error_envelope.py` — focused regression net for the global handlers (locks 422→400, locks `detail` key never leaking, locks cookie-auth 401 envelope).
- Two pre-existing `== 422` assertions in `test_recipes.py` and `test_auth.py` that were status-only (now status + envelope).
- Pre-existing 401 assertion on `/auth/me` in `test_auth.py` (now envelope-shape, locks the dependencies.py fix).

## Audit findings outside #190's scope

The sweep also turned up two parity bugs that I didn't fix here to keep the diff narrow:

1. **`src/routers/posts.py` uses `conflict()` (409) for photo validation errors** — oversized photo, disallowed mime, >10 photos. The Next handler (and migration plan) use 400 with custom codes (`UNSUPPORTED_FILE_TYPE`, `FILE_TOO_LARGE`). This is behavior change on a production endpoint with real users; should be its own ticket (also pairs naturally with #187 multipart work).
2. **JSON parse error in `posts.py` `create_post`** also returns 409 CONFLICT — should be 400 VALIDATION_ERROR.

Happy to open a follow-up ticket for both if it's worth tracking separately.

## OpenAPI snapshot

Regenerated; **no diff**. The new global handlers are runtime behavior; per-endpoint OpenAPI docs already document their own error responses, and the global validation handler doesn't appear in OpenAPI metadata.

## Test plan
- [x] `python -m ruff check src/ tests/` — clean
- [x] `python -m pytest` — 428 passed
- [x] New `test_error_envelope.py` covers: missing JSON body → 400 envelope, invalid query param → 400 envelope, no `detail` key in any 4xx, missing/invalid cookie → 401 envelope
- [x] Pre-existing `test_login_invalid_payload` flipped from `== 422` (status only) to `== 400 + VALIDATION_ERROR` envelope
- [x] Pre-existing `test_browse_recipes_sort_rating_rejects_invalid_pattern` same flip
- [x] Pre-existing `test_me_unauthenticated` upgraded from status-only to envelope assertion (locks dependencies.py fix)

## Unblocks
- #183 (feedback) and #184 (auth reset) inherit the working envelope + test helper
- #189 (frontend OpenAPI contract test) can now baseline against a stable surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)