### PR TITLE
chore(api): reconcile FastAPI/Next bad-input error codes on /api/posts (#202)

### DIFF
--- a/__tests__/integration/api/posts/create-post.test.ts
+++ b/__tests__/integration/api/posts/create-post.test.ts
@@ -175,7 +175,7 @@ describe('POST /api/posts', () => {
       expect(response.status).toBe(400);
 
       const data = await parseResponseJSON(response);
-      expect(data.error.code).toBe('BAD_REQUEST');
+      expect(data.error.code).toBe('VALIDATION_ERROR');
       expect(data.error.message).toContain('valid JSON');
     });
 
@@ -220,7 +220,7 @@ describe('POST /api/posts', () => {
       expect(response.status).toBe(400);
 
       const data = await parseResponseJSON(response);
-      expect(data.error.code).toBe('BAD_REQUEST');
+      expect(data.error.code).toBe('TOO_MANY_PHOTOS');
       expect(data.error.message).toContain('up to 10 photos');
     });
 

--- a/__tests__/integration/api/posts/update-post.test.ts
+++ b/__tests__/integration/api/posts/update-post.test.ts
@@ -323,7 +323,7 @@ describe('PUT /api/posts/[postId]', () => {
       expect(response.status).toBe(400);
 
       const data = await parseResponseJSON(response);
-      expect(data.error.code).toBe('INVALID_JSON');
+      expect(data.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('requires title', async () => {

--- a/__tests__/unit/lib/apiErrors.test.ts
+++ b/__tests__/unit/lib/apiErrors.test.ts
@@ -11,6 +11,7 @@ import { z } from 'zod';
 import {
   validationError,
   badRequestError,
+  tooManyPhotosError,
   unauthorizedError,
   invalidCredentialsError,
   forbiddenError,
@@ -33,7 +34,7 @@ describe('API Error Helpers', () => {
           'Custom not found message',
           404
         );
-        
+
         expect(response.status).toBe(404);
         const data = await response.json();
         expect(data.error.code).toBe(API_ERROR_CODES.NOT_FOUND);
@@ -46,7 +47,7 @@ describe('API Error Helpers', () => {
           'Access denied',
           403
         );
-        
+
         expect(response.status).toBe(403);
         const data = await response.json();
         expect(data.error.code).toBe(API_ERROR_CODES.FORBIDDEN);
@@ -59,7 +60,7 @@ describe('API Error Helpers', () => {
           'Resource conflict',
           409
         );
-        
+
         const data = await response.json();
         expect(data).toHaveProperty('error');
         expect(data.error).toHaveProperty('code');
@@ -72,7 +73,7 @@ describe('API Error Helpers', () => {
       it('should return 400 with VALIDATION_ERROR code', async () => {
         const response = validationError();
         expect(response.status).toBe(400);
-        
+
         const data = await response.json();
         expect(data.error.code).toBe(API_ERROR_CODES.VALIDATION_ERROR);
       });
@@ -80,21 +81,21 @@ describe('API Error Helpers', () => {
       it('should use default message when not provided', async () => {
         const response = validationError();
         const data = await response.json();
-        
+
         expect(data.error.message).toBe('Validation failed');
       });
 
       it('should use custom message when provided', async () => {
         const response = validationError('Custom validation error');
         const data = await response.json();
-        
+
         expect(data.error.message).toBe('Custom validation error');
       });
 
       it('should return correct response structure', async () => {
         const response = validationError('Test message');
         const data = await response.json();
-        
+
         expect(data).toHaveProperty('error');
         expect(data.error).toHaveProperty('code');
         expect(data.error).toHaveProperty('message');
@@ -105,7 +106,7 @@ describe('API Error Helpers', () => {
       it('should return 400 with BAD_REQUEST code', async () => {
         const response = badRequestError();
         expect(response.status).toBe(400);
-        
+
         const data = await response.json();
         expect(data.error.code).toBe(API_ERROR_CODES.BAD_REQUEST);
       });
@@ -113,15 +114,39 @@ describe('API Error Helpers', () => {
       it('should use default message when not provided', async () => {
         const response = badRequestError();
         const data = await response.json();
-        
+
         expect(data.error.message).toBe('Bad request');
       });
 
       it('should use custom message when provided', async () => {
         const response = badRequestError('Invalid input');
         const data = await response.json();
-        
+
         expect(data.error.message).toBe('Invalid input');
+      });
+    });
+
+    describe('tooManyPhotosError()', () => {
+      it('should return 400 with TOO_MANY_PHOTOS code', async () => {
+        const response = tooManyPhotosError();
+        expect(response.status).toBe(400);
+
+        const data = await response.json();
+        expect(data.error.code).toBe(API_ERROR_CODES.TOO_MANY_PHOTOS);
+      });
+
+      it('should use default message when not provided', async () => {
+        const response = tooManyPhotosError();
+        const data = await response.json();
+
+        expect(data.error.message).toBe('Too many photos');
+      });
+
+      it('should use custom message when provided', async () => {
+        const response = tooManyPhotosError('You can upload up to 10 photos');
+        const data = await response.json();
+
+        expect(data.error.message).toBe('You can upload up to 10 photos');
       });
     });
 
@@ -129,7 +154,7 @@ describe('API Error Helpers', () => {
       it('should return 401 with UNAUTHORIZED code', async () => {
         const response = unauthorizedError();
         expect(response.status).toBe(401);
-        
+
         const data = await response.json();
         expect(data.error.code).toBe(API_ERROR_CODES.UNAUTHORIZED);
       });
@@ -137,14 +162,14 @@ describe('API Error Helpers', () => {
       it('should use default message when not provided', async () => {
         const response = unauthorizedError();
         const data = await response.json();
-        
+
         expect(data.error.message).toBe('Not authenticated');
       });
 
       it('should use custom message when provided', async () => {
         const response = unauthorizedError('Please log in');
         const data = await response.json();
-        
+
         expect(data.error.message).toBe('Please log in');
       });
     });
@@ -153,7 +178,7 @@ describe('API Error Helpers', () => {
       it('should return 401 with INVALID_CREDENTIALS code', async () => {
         const response = invalidCredentialsError();
         expect(response.status).toBe(401);
-        
+
         const data = await response.json();
         expect(data.error.code).toBe(API_ERROR_CODES.INVALID_CREDENTIALS);
       });
@@ -161,14 +186,14 @@ describe('API Error Helpers', () => {
       it('should use default message when not provided', async () => {
         const response = invalidCredentialsError();
         const data = await response.json();
-        
+
         expect(data.error.message).toBe('Invalid credentials');
       });
 
       it('should use custom message when provided', async () => {
         const response = invalidCredentialsError('Wrong password');
         const data = await response.json();
-        
+
         expect(data.error.message).toBe('Wrong password');
       });
     });
@@ -177,7 +202,7 @@ describe('API Error Helpers', () => {
       it('should return 403 with FORBIDDEN code', async () => {
         const response = forbiddenError();
         expect(response.status).toBe(403);
-        
+
         const data = await response.json();
         expect(data.error.code).toBe(API_ERROR_CODES.FORBIDDEN);
       });
@@ -185,14 +210,14 @@ describe('API Error Helpers', () => {
       it('should use default message when not provided', async () => {
         const response = forbiddenError();
         const data = await response.json();
-        
+
         expect(data.error.message).toBe('Forbidden');
       });
 
       it('should use custom message when provided', async () => {
         const response = forbiddenError('Access denied');
         const data = await response.json();
-        
+
         expect(data.error.message).toBe('Access denied');
       });
     });
@@ -201,7 +226,7 @@ describe('API Error Helpers', () => {
       it('should return 404 with NOT_FOUND code', async () => {
         const response = notFoundError();
         expect(response.status).toBe(404);
-        
+
         const data = await response.json();
         expect(data.error.code).toBe(API_ERROR_CODES.NOT_FOUND);
       });
@@ -209,14 +234,14 @@ describe('API Error Helpers', () => {
       it('should use default message when not provided', async () => {
         const response = notFoundError();
         const data = await response.json();
-        
+
         expect(data.error.message).toBe('Resource not found');
       });
 
       it('should use custom message when provided', async () => {
         const response = notFoundError('Post not found');
         const data = await response.json();
-        
+
         expect(data.error.message).toBe('Post not found');
       });
     });
@@ -225,7 +250,7 @@ describe('API Error Helpers', () => {
       it('should return 409 with CONFLICT code', async () => {
         const response = conflictError();
         expect(response.status).toBe(409);
-        
+
         const data = await response.json();
         expect(data.error.code).toBe(API_ERROR_CODES.CONFLICT);
       });
@@ -233,14 +258,14 @@ describe('API Error Helpers', () => {
       it('should use default message when not provided', async () => {
         const response = conflictError();
         const data = await response.json();
-        
+
         expect(data.error.message).toBe('Resource conflict');
       });
 
       it('should use custom message when provided', async () => {
         const response = conflictError('Email already exists');
         const data = await response.json();
-        
+
         expect(data.error.message).toBe('Email already exists');
       });
     });
@@ -249,7 +274,7 @@ describe('API Error Helpers', () => {
       it('should return 500 with INTERNAL_ERROR code', async () => {
         const response = internalError();
         expect(response.status).toBe(500);
-        
+
         const data = await response.json();
         expect(data.error.code).toBe(API_ERROR_CODES.INTERNAL_ERROR);
       });
@@ -257,14 +282,14 @@ describe('API Error Helpers', () => {
       it('should use default message when not provided', async () => {
         const response = internalError();
         const data = await response.json();
-        
+
         expect(data.error.message).toBe('An unexpected error occurred');
       });
 
       it('should use custom message when provided', async () => {
         const response = internalError('Database connection failed');
         const data = await response.json();
-        
+
         expect(data.error.message).toBe('Database connection failed');
       });
     });
@@ -603,10 +628,12 @@ describe('API Error Helpers', () => {
       it('should handle nested objects', () => {
         const nestedSchema = z.object({
           title: z.string(),
-          recipe: z.object({
-            ingredients: z.array(z.string()),
-            steps: z.array(z.string()),
-          }).optional(),
+          recipe: z
+            .object({
+              ingredients: z.array(z.string()),
+              steps: z.array(z.string()),
+            })
+            .optional(),
         });
 
         const body = {
@@ -677,6 +704,7 @@ describe('API Error Helpers', () => {
     it('should have all expected error codes', () => {
       expect(API_ERROR_CODES.VALIDATION_ERROR).toBe('VALIDATION_ERROR');
       expect(API_ERROR_CODES.BAD_REQUEST).toBe('BAD_REQUEST');
+      expect(API_ERROR_CODES.TOO_MANY_PHOTOS).toBe('TOO_MANY_PHOTOS');
       expect(API_ERROR_CODES.UNAUTHORIZED).toBe('UNAUTHORIZED');
       expect(API_ERROR_CODES.INVALID_CREDENTIALS).toBe('INVALID_CREDENTIALS');
       expect(API_ERROR_CODES.FORBIDDEN).toBe('FORBIDDEN');
@@ -709,7 +737,7 @@ describe('API Error Helpers', () => {
       if (!result.success) {
         const response = result.error;
         expect(response.status).toBe(400);
-        
+
         const data = await response.json();
         expect(data.error.code).toBe('VALIDATION_ERROR');
         expect(data.error.message).toBeTruthy();
@@ -719,19 +747,23 @@ describe('API Error Helpers', () => {
     it('should handle complete API error flow for not found', async () => {
       const response = notFoundError('Post with ID clh123 not found');
       expect(response.status).toBe(404);
-      
+
       const data = await response.json();
       expect(data.error.code).toBe('NOT_FOUND');
       expect(data.error.message).toBe('Post with ID clh123 not found');
     });
 
     it('should handle complete API error flow for forbidden', async () => {
-      const response = forbiddenError('You do not have permission to delete this post');
+      const response = forbiddenError(
+        'You do not have permission to delete this post'
+      );
       expect(response.status).toBe(403);
-      
+
       const data = await response.json();
       expect(data.error.code).toBe('FORBIDDEN');
-      expect(data.error.message).toBe('You do not have permission to delete this post');
+      expect(data.error.message).toBe(
+        'You do not have permission to delete this post'
+      );
     });
   });
 });

--- a/apps/api/tests/integration/test_posts.py
+++ b/apps/api/tests/integration/test_posts.py
@@ -147,9 +147,9 @@ class TestCreatePost:
         )
 
     def test_create_post_max_photos_exceeded_400(self, client, member_auth):
-        # Matches Next PATCH handler's TOO_MANY_PHOTOS (the Next POST handler
-        # uses BAD_REQUEST, but TOO_MANY_PHOTOS is what the frontend keys off
-        # — see src/app/api/posts/[postId]/route.ts).
+        # Matches Next POST + PATCH handlers' TOO_MANY_PHOTOS canonical code
+        # (see src/app/api/posts/route.ts and src/app/api/posts/[postId]/route.ts;
+        # reconciled in #202).
         files = [("photos", (f"p{i}.jpg", b"data", "image/jpeg")) for i in range(MAX_PHOTO_COUNT + 1)]
         payload = {"title": "Too many"}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "jsonwebtoken": "^9.0.3",
         "lru-cache": "^11.2.4",
         "lucide-react": "^1.11.0",
-        "next": "^16.2.4",
+        "next": "^16.2.6",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "tar": "^7.5.3",
@@ -2414,9 +2414,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
-      "integrity": "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
+      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2460,9 +2460,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz",
-      "integrity": "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
+      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
       "cpu": [
         "arm64"
       ],
@@ -2476,9 +2476,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
-      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
+      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
       "cpu": [
         "x64"
       ],
@@ -2492,9 +2492,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
-      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
+      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
       "cpu": [
         "arm64"
       ],
@@ -2508,9 +2508,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
-      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
+      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
       "cpu": [
         "arm64"
       ],
@@ -2524,9 +2524,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
-      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
+      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
       "cpu": [
         "x64"
       ],
@@ -2540,9 +2540,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
-      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
+      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
       "cpu": [
         "x64"
       ],
@@ -2556,9 +2556,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
-      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
+      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
       "cpu": [
         "arm64"
       ],
@@ -2572,9 +2572,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
-      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
+      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
       "cpu": [
         "x64"
       ],
@@ -9529,12 +9529,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
-      "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
+      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.4",
+        "@next/env": "16.2.6",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -9548,14 +9548,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.4",
-        "@next/swc-darwin-x64": "16.2.4",
-        "@next/swc-linux-arm64-gnu": "16.2.4",
-        "@next/swc-linux-arm64-musl": "16.2.4",
-        "@next/swc-linux-x64-gnu": "16.2.4",
-        "@next/swc-linux-x64-musl": "16.2.4",
-        "@next/swc-win32-arm64-msvc": "16.2.4",
-        "@next/swc-win32-x64-msvc": "16.2.4",
+        "@next/swc-darwin-arm64": "16.2.6",
+        "@next/swc-darwin-x64": "16.2.6",
+        "@next/swc-linux-arm64-gnu": "16.2.6",
+        "@next/swc-linux-arm64-musl": "16.2.6",
+        "@next/swc-linux-x64-gnu": "16.2.6",
+        "@next/swc-linux-x64-musl": "16.2.6",
+        "@next/swc-win32-arm64-msvc": "16.2.6",
+        "@next/swc-win32-x64-msvc": "16.2.6",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "jsonwebtoken": "^9.0.3",
     "lru-cache": "^11.2.4",
     "lucide-react": "^1.11.0",
-    "next": "^16.2.4",
+    "next": "^16.2.6",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "tar": "^7.5.3",

--- a/src/app/api/posts/[postId]/route.ts
+++ b/src/app/api/posts/[postId]/route.ts
@@ -231,7 +231,7 @@ export const PUT = withAuth(
         return NextResponse.json(
           {
             error: {
-              code: 'INVALID_JSON',
+              code: 'VALIDATION_ERROR',
               message: 'Payload must be valid JSON',
             },
           },

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -11,6 +11,7 @@ import { postCreationLimiter, applyRateLimit } from '@/lib/rateLimit';
 import {
   badRequestError,
   validationError,
+  tooManyPhotosError,
   internalError,
 } from '@/lib/apiErrors';
 
@@ -36,7 +37,7 @@ export const POST = withAuth(async (request, user) => {
     try {
       parsedPayload = JSON.parse(rawPayload);
     } catch {
-      return badRequestError('Payload must be valid JSON');
+      return validationError('Payload must be valid JSON');
     }
 
     const normalizedPayload = normalizePostPayload(parsedPayload);
@@ -65,7 +66,9 @@ export const POST = withAuth(async (request, user) => {
       .filter((entry): entry is File => isFormDataFile(entry));
 
     if (files.length > MAX_PHOTO_COUNT) {
-      return badRequestError(`You can upload up to ${MAX_PHOTO_COUNT} photos`);
+      return tooManyPhotosError(
+        `You can upload up to ${MAX_PHOTO_COUNT} photos`
+      );
     }
 
     const savedPhotos = await Promise.all(

--- a/src/lib/apiErrors.ts
+++ b/src/lib/apiErrors.ts
@@ -7,8 +7,9 @@ import { z } from 'zod';
  */
 export const API_ERROR_CODES = {
   // 400 - Bad Request errors
-  VALIDATION_ERROR: 'VALIDATION_ERROR', // Schema validation failures
+  VALIDATION_ERROR: 'VALIDATION_ERROR', // Schema validation failures (also: malformed JSON payloads)
   BAD_REQUEST: 'BAD_REQUEST', // General bad request
+  TOO_MANY_PHOTOS: 'TOO_MANY_PHOTOS', // Per-post photo count cap exceeded (matches FastAPI mirror)
 
   // 401 - Unauthorized errors
   UNAUTHORIZED: 'UNAUTHORIZED', // Not authenticated
@@ -61,17 +62,26 @@ export function createErrorResponse(
 export function validationError(
   message: string = 'Validation failed'
 ): NextResponse<ApiErrorResponse> {
-  return createErrorResponse(
-    API_ERROR_CODES.VALIDATION_ERROR,
-    message,
-    400
-  );
+  return createErrorResponse(API_ERROR_CODES.VALIDATION_ERROR, message, 400);
 }
 
 export function badRequestError(
   message: string = 'Bad request'
 ): NextResponse<ApiErrorResponse> {
   return createErrorResponse(API_ERROR_CODES.BAD_REQUEST, message, 400);
+}
+
+/**
+ * 400 — caller exceeded the per-post photo count cap.
+ *
+ * Dedicated code so the frontend can key off `TOO_MANY_PHOTOS` (and the
+ * FastAPI mirror in apps/api/src/errors.py uses the same code) rather than
+ * the generic `BAD_REQUEST` / `VALIDATION_ERROR` buckets.
+ */
+export function tooManyPhotosError(
+  message: string = 'Too many photos'
+): NextResponse<ApiErrorResponse> {
+  return createErrorResponse(API_ERROR_CODES.TOO_MANY_PHOTOS, message, 400);
 }
 
 export function unauthorizedError(
@@ -83,11 +93,7 @@ export function unauthorizedError(
 export function invalidCredentialsError(
   message: string = 'Invalid credentials'
 ): NextResponse<ApiErrorResponse> {
-  return createErrorResponse(
-    API_ERROR_CODES.INVALID_CREDENTIALS,
-    message,
-    401
-  );
+  return createErrorResponse(API_ERROR_CODES.INVALID_CREDENTIALS, message, 401);
 }
 
 export function forbiddenError(
@@ -125,10 +131,12 @@ export function internalError(
 export function parseQueryParams<T extends z.ZodTypeAny>(
   searchParams: URLSearchParams,
   schema: T
-): { success: true; data: z.infer<T> } | { success: false; error: NextResponse<ApiErrorResponse> } {
+):
+  | { success: true; data: z.infer<T> }
+  | { success: false; error: NextResponse<ApiErrorResponse> } {
   // Build params object from URLSearchParams
   const params: Record<string, string | string[]> = {};
-  
+
   // Track which keys have multiple values
   const multiValueKeys = new Set<string>();
   searchParams.forEach((_, key) => {
@@ -136,7 +144,7 @@ export function parseQueryParams<T extends z.ZodTypeAny>(
       multiValueKeys.add(key);
     }
   });
-  
+
   // Populate params object
   searchParams.forEach((value, key) => {
     if (multiValueKeys.has(key)) {
@@ -145,9 +153,9 @@ export function parseQueryParams<T extends z.ZodTypeAny>(
       params[key] = value;
     }
   });
-  
+
   const result = schema.safeParse(params);
-  
+
   if (!result.success) {
     return {
       success: false,
@@ -156,7 +164,7 @@ export function parseQueryParams<T extends z.ZodTypeAny>(
       ),
     };
   }
-  
+
   return { success: true, data: result.data };
 }
 
@@ -166,9 +174,11 @@ export function parseQueryParams<T extends z.ZodTypeAny>(
 export function parseRouteParams<T>(
   params: unknown,
   schema: z.ZodSchema<T>
-): { success: true; data: T } | { success: false; error: NextResponse<ApiErrorResponse> } {
+):
+  | { success: true; data: T }
+  | { success: false; error: NextResponse<ApiErrorResponse> } {
   const result = schema.safeParse(params);
-  
+
   if (!result.success) {
     return {
       success: false,
@@ -177,7 +187,7 @@ export function parseRouteParams<T>(
       ),
     };
   }
-  
+
   return { success: true, data: result.data };
 }
 
@@ -187,9 +197,11 @@ export function parseRouteParams<T>(
 export function parseRequestBody<T>(
   body: unknown,
   schema: z.ZodSchema<T>
-): { success: true; data: T } | { success: false; error: NextResponse<ApiErrorResponse> } {
+):
+  | { success: true; data: T }
+  | { success: false; error: NextResponse<ApiErrorResponse> } {
   const result = schema.safeParse(body);
-  
+
   if (!result.success) {
     return {
       success: false,
@@ -198,6 +210,6 @@ export function parseRequestBody<T>(
       ),
     };
   }
-  
+
   return { success: true, data: result.data };
 }


### PR DESCRIPTION
Closes #202. Follow-up from PR #201 review.

## What changed

After PR #201 aligned the *status code* (409 → 400) and the *envelope shape* on 8 sites in posts.py, three sites still carried a different `code` string than the Next handler. This PR settles the canonical mapping (FastAPI already had it right):

| Site | Before (Next) | After (Next) | FastAPI (unchanged) |
|---|---|---|---|
| `POST /api/posts` JSON-parse | `BAD_REQUEST` | **`VALIDATION_ERROR`** | `VALIDATION_ERROR` ✓ |
| `POST /api/posts` photo-count | `BAD_REQUEST` | **`TOO_MANY_PHOTOS`** | `TOO_MANY_PHOTOS` ✓ |
| `PUT /api/posts/{id}` JSON-parse | `INVALID_JSON` (inline) | **`VALIDATION_ERROR`** | `VALIDATION_ERROR` ✓ |

**Why `VALIDATION_ERROR` for JSON-parse:** malformed JSON is the most generic form of "input failed validation"; canonical helpers already exist on both sides; `INVALID_JSON` lived as an inline string in exactly one place and was never registered in `API_ERROR_CODES`.

**Why `TOO_MANY_PHOTOS` for POST photo-count:** PATCH (PUT) already used it and the FastAPI mirror is on it. Promoting POST to match means the frontend can key off a single code regardless of HTTP method.

## Code changes

- [src/lib/apiErrors.ts](src/lib/apiErrors.ts): register `TOO_MANY_PHOTOS` in `API_ERROR_CODES`; add `tooManyPhotosError()` helper. Matches the dedicated `too_many_photos()` helper already in [apps/api/src/errors.py](apps/api/src/errors.py).
- [src/app/api/posts/route.ts](src/app/api/posts/route.ts): JSON-parse → `validationError(...)`, photo-count → `tooManyPhotosError(...)`.
- [src/app/api/posts/[postId]/route.ts](src/app/api/posts/[postId]/route.ts): the inline `INVALID_JSON` literal → `VALIDATION_ERROR` literal (still inline because the rest of this handler still uses inline literals — broader cleanup is out of scope here).
- [__tests__/unit/lib/apiErrors.test.ts](__tests__/unit/lib/apiErrors.test.ts): unit coverage for the new helper + constant.
- [__tests__/integration/api/posts/create-post.test.ts](__tests__/integration/api/posts/create-post.test.ts) and [__tests__/integration/api/posts/update-post.test.ts](__tests__/integration/api/posts/update-post.test.ts): 3 assertions flipped to the new canonical codes.
- [apps/api/tests/integration/test_posts.py](apps/api/tests/integration/test_posts.py): updated a now-stale parity comment that said "the Next POST handler uses BAD_REQUEST" — both sides are TOO_MANY_PHOTOS now.

## Why this is safe for the frontend

A grep across `src/{components,hooks,lib,app}` confirms **no consumer branches on `INVALID_JSON`, `TOO_MANY_PHOTOS`, or `BAD_REQUEST` codes specifically**. `apiClient.ts` falls back by HTTP status, not code string. Only `UNAUTHORIZED` and `RATE_LIMIT_EXCEEDED` are matched on. This is contract hygiene before the Phase 4 cutover (#38), not a behavior fix.

## "Missing payload" deliberately untouched

The POST handler still returns `BAD_REQUEST` for a missing `payload` field (vs. malformed JSON). That divergence isn't called out in #202 — FastAPI handles missing `Form(...)` fields via its built-in `RequestValidationError` mapping. Out of scope here; can be a separate ticket if we want to align.

## OpenAPI snapshot

Not regenerated — the snapshot doesn't enumerate 400-response code strings. FastAPI returns identical envelopes already.

## Verification

- `npm run type-check` — clean
- `npm run lint` — clean
- `npm test` — 52 suites, 1059 tests pass

Per [docs/verification/next-api.md](docs/verification/next-api.md): no Prisma schema or auth flow changes, so the targeted Jest integration tests cover the surface this touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update (commit 526de17): security audit bump

The `dependency-scan` CI job (`npm audit --production --audit-level=high`) was failing on this PR because `next@16.2.4` falls inside the vulnerable range `>=16.0.0 <16.2.5` for 13 advisories (8 high). Bumped to `next@16.2.6` (current latest stable) — patch-level bump, no API changes.

Also clears a nested `postcss <8.5.10` finding under `next/node_modules/postcss` because next 16.2.5+ ships a patched bundled postcss.

Local verification after the bump:
- `npm audit --omit=dev --audit-level=high` → exit 0
- `npm run type-check` → clean
- `npm run lint` → clean
- `npm test` → 52 suites, 1059 tests pass
