### PR TITLE
chore(api): Depends-compatible wrapper for X-Request-Id idempotency (#194)

### DIFF
--- a/apps/api/openapi.snapshot.json
+++ b/apps/api/openapi.snapshot.json
@@ -2938,25 +2938,9 @@
         ]
       },
       "post": {
-        "description": "Create a feedback submission.\n\nRate-limited at 20/hour/user (migration plan \u00a7 Rate Limits). Honours\n`X-Request-Id` for at-most-once retry semantics; the 24h idempotency\nwindow is shared with every other write endpoint via replay_or_record.\n\nRate-limit is checked BEFORE the idempotency lookup so a flood of\nreplays from the same client can't bypass the limiter \u2014 the replay\npath re-issues the original 201 only when the original call was\nactually allowed. A 429 on the first attempt is not idempotency-\ncached (we don't call `do`, so no row is recorded); subsequent\nretries hit the limiter again and stay 429 until the window resets.",
+        "description": "Create a feedback submission.\n\nRate-limited at 20/hour/user (migration plan \u00a7 Rate Limits). Honours\n`X-Request-Id` for at-most-once retry semantics via the shared\n`idempotency_key` dependency; the 24h replay window is shared with\nevery other write endpoint that takes the dependency.\n\nRate-limit is checked BEFORE the idempotency lookup so a flood of\nreplays from the same client can't bypass the limiter \u2014 the replay\npath re-issues the original 201 only when the original call was\nactually allowed. A 429 on the first attempt is not idempotency-\ncached (we don't call `do`, so no row is recorded); subsequent\nretries hit the limiter again and stay 429 until the window resets.",
         "operationId": "create_feedback_v1_feedback_post",
         "parameters": [
-          {
-            "in": "header",
-            "name": "X-Request-Id",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Request-Id"
-            }
-          },
           {
             "in": "header",
             "name": "User-Agent",
@@ -2971,6 +2955,22 @@
                 }
               ],
               "title": "User-Agent"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Request-Id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Request-Id"
             }
           }
         ],

--- a/apps/api/src/idempotency.py
+++ b/apps/api/src/idempotency.py
@@ -2,25 +2,34 @@
 
 Migration plan: docs/API_BACKEND_MIGRATION_PLAN.md#idempotency--retries
 
-Usage from a route handler:
+## Recommended usage — `Depends(idempotency_key)` (issue #194)
 
-    from fastapi import Header
-    from ..idempotency import replay_or_record
+Most route handlers should take the dependency, which pulls `X-Request-Id`
+from the request and exposes the same replay-or-record semantics through
+a one-liner:
+
+    from fastapi import Depends
+    from ..idempotency import IdempotencyKey, idempotency_key
 
     @router.post("/feedback", status_code=201)
     async def create_feedback(
         payload: CreateFeedbackRequest,
         user: UserResponse = Depends(get_current_user),
-        x_request_id: str | None = Header(default=None),
+        idem: IdempotencyKey = Depends(idempotency_key),
     ):
         async def _do():
             row = await prisma.feedbacksubmission.create(...)
             return _serialize(row), 201
 
-        body, status_code = await replay_or_record(
-            user_id=user.id, request_id=x_request_id, do=_do
-        )
+        body, status_code = await idem.replay_or_record(user_id=user.id, do=_do)
         return JSONResponse(content=body, status_code=status_code)
+
+## Underlying primitive — `replay_or_record(...)`
+
+The dependency is a thin layer over `replay_or_record`, which stays
+exported for tests and any non-route caller that already holds a parsed
+request id. Both call styles share the same store, replay window, and
+5xx-bypass behaviour.
 
 When `request_id` is None we just call `do()` and return its result —
 idempotency is opt-in per request, never enforced when the header is absent.
@@ -82,8 +91,11 @@ it for at-most-once semantics.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Awaitable, Callable, Tuple
+
+from fastapi import Header
 
 from .db import prisma
 
@@ -159,3 +171,43 @@ def _aware(dt: datetime) -> datetime:
     # Postgres returns naive UTC datetimes through the Python Prisma client;
     # promote to aware so the subtraction against now(tz=UTC) is well-defined.
     return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
+@dataclass(frozen=True)
+class IdempotencyKey:
+    """Per-request handle returned by the `idempotency_key` dependency.
+
+    Holds the parsed `X-Request-Id` (or `None` when the header is absent)
+    and exposes `replay_or_record` so route handlers don't need to thread
+    the raw header value through the call. The underlying behaviour is
+    identical to calling `replay_or_record` directly — see module docstring.
+    """
+
+    request_id: str | None
+
+    async def replay_or_record(
+        self,
+        *,
+        user_id: str,
+        do: Callable[[], Awaitable[Tuple[Any, int]]],
+    ) -> Tuple[Any, int]:
+        return await replay_or_record(
+            user_id=user_id, request_id=self.request_id, do=do
+        )
+
+
+async def idempotency_key(
+    x_request_id: str | None = Header(default=None, alias="X-Request-Id"),
+) -> IdempotencyKey:
+    """FastAPI dependency that pulls `X-Request-Id` and returns an `IdempotencyKey`.
+
+    Route usage:
+
+        idem: IdempotencyKey = Depends(idempotency_key)
+        body, status = await idem.replay_or_record(user_id=user.id, do=_do)
+
+    See the module docstring for full semantics. The dependency stays
+    opt-in: a missing header yields `IdempotencyKey(request_id=None)`,
+    which short-circuits to calling `do()` once and skipping the store.
+    """
+    return IdempotencyKey(request_id=x_request_id)

--- a/apps/api/src/routers/v1/feedback.py
+++ b/apps/api/src/routers/v1/feedback.py
@@ -33,7 +33,7 @@ from prisma.errors import PrismaError
 from ...db import prisma
 from ...dependencies_v1 import get_current_user_v1
 from ...errors import forbidden, internal_error, rate_limited, validation_error
-from ...idempotency import replay_or_record
+from ...idempotency import IdempotencyKey, idempotency_key
 from ...permissions import is_owner_or_admin
 from ...rate_limit import feedback_limiter
 from ...schemas.auth import UserResponse
@@ -86,14 +86,15 @@ def _serialize_list_row(row: Any) -> dict:
 async def create_feedback(
     payload: CreateFeedbackRequest,
     user: UserResponse = Depends(get_current_user_v1),
-    x_request_id: Optional[str] = Header(default=None, alias="X-Request-Id"),
+    idem: IdempotencyKey = Depends(idempotency_key),
     user_agent: Optional[str] = Header(default=None, alias="User-Agent"),
 ):
     """Create a feedback submission.
 
     Rate-limited at 20/hour/user (migration plan § Rate Limits). Honours
-    `X-Request-Id` for at-most-once retry semantics; the 24h idempotency
-    window is shared with every other write endpoint via replay_or_record.
+    `X-Request-Id` for at-most-once retry semantics via the shared
+    `idempotency_key` dependency; the 24h replay window is shared with
+    every other write endpoint that takes the dependency.
 
     Rate-limit is checked BEFORE the idempotency lookup so a flood of
     replays from the same client can't bypass the limiter — the replay
@@ -123,7 +124,7 @@ async def create_feedback(
             logger.exception("feedback.create.prisma_error: %s", e)
             # Return a 500 tuple instead of re-raising so we keep the
             # structured log line that ties the failure to this handler.
-            # replay_or_record will NOT cache this (status_code >= 500
+            # idem.replay_or_record will NOT cache this (status_code >= 500
             # short-circuits the upsert — see src/idempotency.py docstring
             # "Server errors (5xx) are NOT cached"), so a subsequent retry
             # under the same X-Request-Id runs the handler fresh against a
@@ -136,9 +137,7 @@ async def create_feedback(
         )
         return {"feedback": _serialize_row(row)}, 201
 
-    body, status_code = await replay_or_record(
-        user_id=user.id, request_id=x_request_id, do=_do
-    )
+    body, status_code = await idem.replay_or_record(user_id=user.id, do=_do)
     return JSONResponse(content=body, status_code=status_code)
 
 

--- a/apps/api/tests/unit/test_idempotency.py
+++ b/apps/api/tests/unit/test_idempotency.py
@@ -220,3 +220,132 @@ async def test_naive_created_at_from_prisma_is_treated_as_utc(mock_prisma):
     assert body == {"created": 99}
     assert status == 201
     assert counter.calls == 0, "fresh naive-utc row must replay"
+
+
+# ---------------------------------------------------------------------------
+# Depends(idempotency_key) wrapper — issue #194
+#
+# The dependency is a thin layer over replay_or_record. We test the
+# routing/binding seam end-to-end via TestClient (one route registered with
+# Depends(idempotency_key) replays correctly; missing header runs once)
+# rather than re-asserting the underlying semantics — those are covered by
+# the existing tests above against `replay_or_record` directly.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_idempotency_key_dependency_returns_request_id_from_header():
+    """Direct call to the dependency function: header maps onto the dataclass."""
+    key = await idempotency.idempotency_key(x_request_id="req-XYZ")
+    assert isinstance(key, idempotency.IdempotencyKey)
+    assert key.request_id == "req-XYZ"
+
+
+@pytest.mark.asyncio
+async def test_idempotency_key_dependency_missing_header_yields_none():
+    key = await idempotency.idempotency_key(x_request_id=None)
+    assert key.request_id is None
+
+
+@pytest.mark.asyncio
+async def test_idempotency_key_method_delegates_to_replay_or_record(mock_prisma):
+    """`IdempotencyKey.replay_or_record` must share the store with the module
+    function — calling either should hit the same find_unique / upsert calls
+    against the same (user_id, request_id) composite key."""
+    handler, counter = await _do_once_factory()
+    key = idempotency.IdempotencyKey(request_id="req-via-dep")
+
+    body, status = await key.replay_or_record(user_id="u1", do=handler)
+
+    assert (body, status) == ({"created": 1}, 201)
+    assert counter.calls == 1
+    # Confirms the dependency went through the same composite-key path.
+    mock_prisma.idempotencykey.upsert.assert_awaited_once()
+    upsert_where = mock_prisma.idempotencykey.upsert.await_args.kwargs["where"]
+    assert upsert_where == {"userId_requestId": {"userId": "u1", "requestId": "req-via-dep"}}
+
+
+@pytest.mark.asyncio
+async def test_idempotency_key_method_no_request_id_skips_store(mock_prisma):
+    """Missing header → dependency yields request_id=None → handler runs,
+    store is untouched. Mirrors test_no_request_id_runs_handler_and_skips_store
+    against the dependency call style."""
+    handler, counter = await _do_once_factory()
+    key = idempotency.IdempotencyKey(request_id=None)
+
+    body, status = await key.replay_or_record(user_id="u1", do=handler)
+
+    assert (body, status) == ({"created": 1}, 201)
+    assert counter.calls == 1
+    mock_prisma.idempotencykey.find_unique.assert_not_awaited()
+    mock_prisma.idempotencykey.upsert.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_idempotency_key_dependency_replays_under_fastapi_routing(mock_prisma):
+    """End-to-end: register a route with Depends(idempotency_key), hit it twice
+    with the same X-Request-Id, second call replays without re-running the
+    handler. This is the actual route-handler integration shape that #194
+    introduces and that real consumers (feedback.py et al) take."""
+    from fastapi import Depends, FastAPI
+    from fastapi.testclient import TestClient
+
+    app = FastAPI()
+    counter = SimpleNamespace(calls=0)
+
+    @app.post("/probe")
+    async def probe(idem: idempotency.IdempotencyKey = Depends(idempotency.idempotency_key)):
+        async def _do():
+            counter.calls += 1
+            return ({"n": counter.calls}, 201)
+        body, status = await idem.replay_or_record(user_id="u1", do=_do)
+        return {"body": body, "status": status}
+
+    client = TestClient(app)
+
+    # First call: cache miss, handler runs, store gets upserted.
+    resp1 = client.post("/probe", headers={"X-Request-Id": "rid-1"})
+    assert resp1.status_code == 200
+    assert resp1.json() == {"body": {"n": 1}, "status": 201}
+    assert counter.calls == 1
+
+    # Simulate the stored row landing — same shape as the existing replay test.
+    stored = SimpleNamespace(
+        responseBody={"n": 1},
+        statusCode=201,
+        createdAt=datetime.now(timezone.utc),
+    )
+    mock_prisma.idempotencykey.find_unique = AsyncMock(return_value=stored)
+
+    # Second call with same header: replayed; handler does not run again.
+    resp2 = client.post("/probe", headers={"X-Request-Id": "rid-1"})
+    assert resp2.status_code == 200
+    assert resp2.json() == {"body": {"n": 1}, "status": 201}
+    assert counter.calls == 1, "handler must not run on dependency-driven replay"
+
+
+@pytest.mark.asyncio
+async def test_idempotency_key_dependency_missing_header_runs_handler(mock_prisma):
+    """Opt-in semantics survive the dependency layer: no X-Request-Id → no store hit."""
+    from fastapi import Depends, FastAPI
+    from fastapi.testclient import TestClient
+
+    app = FastAPI()
+    counter = SimpleNamespace(calls=0)
+
+    @app.post("/probe")
+    async def probe(idem: idempotency.IdempotencyKey = Depends(idempotency.idempotency_key)):
+        async def _do():
+            counter.calls += 1
+            return ({"n": counter.calls}, 201)
+        body, status = await idem.replay_or_record(user_id="u1", do=_do)
+        return {"body": body, "status": status}
+
+    client = TestClient(app)
+    resp = client.post("/probe")  # no X-Request-Id
+
+    assert resp.status_code == 200
+    assert resp.json() == {"body": {"n": 1}, "status": 201}
+    assert counter.calls == 1
+    mock_prisma.idempotencykey.find_unique.assert_not_awaited()
+    mock_prisma.idempotencykey.upsert.assert_not_awaited()


### PR DESCRIPTION
Closes #194.

## Summary

Adds a thin `Depends`-compatible wrapper over the existing `replay_or_record` helper so write-endpoint route handlers can collapse the `Header(default=None)` + raw-function-call boilerplate into a single `Depends` + one method call. The ticket explicitly called this out as a follow-up to #192: with #182, #183, #185, #186, #187 all eventually adopting idempotency, the boilerplate would be replicated 5+ times otherwise.

## Design

- `IdempotencyKey` — a frozen dataclass that holds the parsed `X-Request-Id` (or `None`) and exposes an `async def replay_or_record(*, user_id, do)` method.
- `idempotency_key(x_request_id: str | None = Header(...))` — a FastAPI dependency that builds the dataclass from the request header.
- `replay_or_record(...)` — **unchanged**. Stays exported as the underlying primitive for tests and any non-route caller that already holds a parsed request id. Per the ticket: "Keep `replay_or_record` as the underlying primitive — the wrapper layers on top, doesn't replace."

Route usage collapses from:

```python
async def create_feedback(
    payload: CreateFeedbackRequest,
    user: UserResponse = Depends(get_current_user_v1),
    x_request_id: Optional[str] = Header(default=None, alias="X-Request-Id"),
):
    ...
    body, status = await replay_or_record(
        user_id=user.id, request_id=x_request_id, do=_do
    )
```

to:

```python
async def create_feedback(
    payload: CreateFeedbackRequest,
    user: UserResponse = Depends(get_current_user_v1),
    idem: IdempotencyKey = Depends(idempotency_key),
):
    ...
    body, status = await idem.replay_or_record(user_id=user.id, do=_do)
```

## Migrated consumer

The existing `/v1/feedback` POST handler (the first and currently only real consumer of `replay_or_record`) is migrated to the dependency form, per the ticket's "At least one route consumer ... actually uses the dependency form." This made the wrapper API design react to a real call site instead of speculative usage. Future consumers (#185, #186, #187) should follow the same pattern.

## Tests

- 8 existing `replay_or_record` unit tests pass unchanged — no behaviour change to the primitive.
- 6 new tests for the wrapper:
  - Direct dataclass behaviour (header maps to `request_id`, missing header → `None`).
  - `IdempotencyKey.replay_or_record` delegates through the same composite-key path as the module function.
  - Opt-in semantics preserved through the dependency: no `X-Request-Id` → handler runs once, store untouched.
  - End-to-end `TestClient` round-trip: route registered with `Depends(idempotency_key)` replays correctly across two requests with the same header, runs the handler once when the header is absent.
- All 15 `/v1/feedback` integration tests still pass against the migrated route.

## OpenAPI snapshot

Regenerated. Two intentional diffs on `POST /v1/feedback`:
1. Description text updated to reference the dependency.
2. Parameter order: `X-Request-Id` and `User-Agent` swapped (because `idem` is declared before `user_agent` in the new signature). Both headers retain the same name/alias/type/required-ness/schema — contract unchanged.

No schema deltas on any other endpoint.

## Verification

```bash
cd apps/api
source .venv/bin/activate
python -m pytest tests/unit/test_idempotency.py -q       # 14/14 pass (8 existing + 6 new)
python -m pytest tests/unit/ -q                          # 158/158 pass (excluding pre-existing PIL-import issue in test_multipart_uploads.py)
python -m pytest tests/integration/test_feedback.py -q   # 15/15 pass
ruff check src tests                                     # clean
```

Per [memory] mypy is skipped locally and relies on the `api-ci.yml` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)