### PR TITLE
feat(api): Phase 3-B4 — /v1/recipes/import proxy to importer service (#185)

### DIFF
--- a/apps/api/openapi.snapshot.json
+++ b/apps/api/openapi.snapshot.json
@@ -514,6 +514,23 @@
         "title": "HTTPValidationError",
         "type": "object"
       },
+      "ImportRecipeRequest": {
+        "description": "Mirrors `importRequestSchema` in src/app/api/recipes/import/route.ts.\n\n`HttpUrl` rejects empty strings and non-http(s) schemes; bad input\nsurfaces as 400 VALIDATION_ERROR via the global RequestValidationError\nhandler in main.py. Anything else (length caps, SSRF, etc.) is the\nimporter service's responsibility \u2014 pushing those checks here would\nduplicate the importer's own URL-validation module.",
+        "properties": {
+          "url": {
+            "format": "uri",
+            "maxLength": 2083,
+            "minLength": 1,
+            "title": "Url",
+            "type": "string"
+          }
+        },
+        "required": [
+          "url"
+        ],
+        "title": "ImportRecipeRequest",
+        "type": "object"
+      },
       "LoginRequest": {
         "properties": {
           "emailOrUsername": {
@@ -4273,6 +4290,51 @@
         "summary": "Browse Recipes",
         "tags": [
           "recipes"
+        ]
+      }
+    },
+    "/v1/recipes/import": {
+      "post": {
+        "description": "Proxy a URL to the importer and return its full RecipeDraft response.\n\n`user` is required only as an auth gate \u2014 the importer call carries\nno per-user state and no DB write happens here. The family-scoped\npersistence step lives downstream in `POST /v1/posts`, which the\nfrontend invokes after the user reviews / edits the prefilled form.",
+        "operationId": "import_recipe_v1_recipes_import_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportRecipeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Import Recipe",
+        "tags": [
+          "recipes-import"
         ]
       }
     },

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -10,6 +10,7 @@ from .routers import auth, comments, family, health, me, posts, profile, reactio
 from .routers.v1 import auth as auth_v1
 from .routers.v1 import feedback as feedback_v1
 from .routers.v1 import notifications as notifications_v1
+from .routers.v1 import recipes as recipes_v1
 from .settings import settings, validate_settings
 
 
@@ -92,3 +93,9 @@ app.include_router(notifications_v1.router)
 # accepts anonymous submissions) until the Phase 4 cutover (#38) — there is
 # no behavioural overlap to alias.
 app.include_router(feedback_v1.router)
+# `/v1/recipes/import` (issue #185): bearer-auth-only proxy to the
+# standalone recipe-url-importer. No dual-mount: the legacy
+# `routers/recipes.py` already serves `/recipes` + `/v1/recipes` for
+# browse/search under cookie auth, and adding the importer there would
+# mix two auth modes on one router. See routers/v1/recipes.py docstring.
+app.include_router(recipes_v1.router)

--- a/apps/api/src/recipe_importer.py
+++ b/apps/api/src/recipe_importer.py
@@ -1,0 +1,203 @@
+"""HTTP client for the standalone recipe-url-importer service (issue #185).
+
+Mirrors `src/lib/recipeImporter.ts` on the Next side:
+
+- Reads `RECIPE_IMPORTER_URL` / `RECIPE_IMPORTER_AUDIENCE` /
+  `RECIPE_IMPORTER_SERVICE_ACCOUNT_EMAIL` from settings.
+- Mints a Google-issued ID token from the GCE metadata server (the
+  importer's Cloud Run service requires OIDC invoker auth — see
+  apps/recipe-url-importer/SPEC.md §2.10 "Auth").
+- Posts `{ "url": <url> }` to `<base>/v1/parse` and returns the parsed
+  importer response as a plain dict.
+
+The dict-not-pydantic return is deliberate: this module is a thin
+proxy. Re-shaping the response into a Pydantic model would either
+constrain the wire contract to a frozen point-in-time view (defeating
+the "additive importer fields show through to the SPA" property) or
+require us to mirror every importer field change in two places. The
+Next-side client uses the same shape-passthrough strategy for the same
+reason; see src/lib/recipeImporter.ts ImporterResponse zod.
+
+`ImporterRequestError` carries the upstream status + payload so the
+route handler can translate them — the importer's 408 / 502 / etc.
+each map to a distinct error envelope, and burning that information
+inside a generic 500 would force the SPA to retry without context.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+from urllib.parse import quote
+
+import httpx
+
+from .settings import settings
+
+logger = logging.getLogger(__name__)
+
+# GCE metadata server endpoint for service-account identity tokens.
+# Documented at https://cloud.google.com/run/docs/securing/service-identity
+_METADATA_BASE = "http://metadata.google.internal/computeMetadata/v1"
+
+
+class ImporterConfigError(RuntimeError):
+    """Raised when `RECIPE_IMPORTER_URL` is unset.
+
+    Distinct from `ImporterRequestError` so the handler can translate
+    misconfiguration into 503 SERVICE_UNAVAILABLE rather than a 5xx
+    from the importer — a missing env var is operator error, not a
+    transient upstream failure.
+    """
+
+
+class ImporterRequestError(Exception):
+    """Non-2xx response from the importer service.
+
+    `status` is the upstream HTTP status (200..599); the route handler
+    maps it onto the FastAPI error envelope. `payload` is the raw
+    response body (parsed JSON when available, else None) so callers
+    can surface importer-specific warnings/codes if useful for debug.
+    """
+
+    def __init__(self, message: str, status: int, payload: Any = None) -> None:
+        super().__init__(message)
+        self.status = status
+        self.payload = payload
+
+
+class ImporterTimeoutError(Exception):
+    """The httpx call exceeded `recipe_importer_timeout_seconds`.
+
+    Surfaces as 504 GATEWAY_TIMEOUT — the upstream took too long, but
+    we don't know if it succeeded or failed (no in-flight write here,
+    so retries are safe).
+    """
+
+
+def _resolve_endpoint(base_url: str) -> str:
+    """Append `/v1/parse` to the base URL exactly once.
+
+    Mirrors the JS client: tolerate both `https://host` and
+    `https://host/v1/parse` configured values so swapping the env var
+    between forms is harmless.
+    """
+    if base_url.endswith("/v1/parse"):
+        return base_url
+    return f"{base_url.rstrip('/')}/v1/parse"
+
+
+async def _fetch_identity_token(
+    *, audience: str, service_account_email: str, client: httpx.AsyncClient
+) -> str:
+    """Pull a Google-issued ID token for the importer's audience.
+
+    Single-shot fetch; no caching. The token's exp is ~1h and importer
+    calls are user-driven (paste-and-click), so per-call minting is
+    cheap and avoids holding stale tokens across a long-lived process.
+    Caching can be added later if traffic patterns shift.
+    """
+    url = (
+        f"{_METADATA_BASE}/instance/service-accounts/"
+        f"{quote(service_account_email, safe='@.')}/identity"
+        f"?audience={quote(audience, safe='')}"
+    )
+    response = await client.get(url, headers={"Metadata-Flavor": "Google"})
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"Identity-token fetch failed: {response.status_code} {response.reason_phrase}"
+        )
+    return response.text
+
+
+async def import_recipe_from_url(url: str) -> dict:
+    """Proxy `url` to the importer service and return its response body.
+
+    Raises `ImporterConfigError` when the importer is unconfigured,
+    `ImporterTimeoutError` on httpx-level timeout, and
+    `ImporterRequestError` for any non-2xx response (carrying the
+    upstream status + payload).
+    """
+    base = settings.recipe_importer_url
+    if not base:
+        raise ImporterConfigError("RECIPE_IMPORTER_URL is not configured")
+
+    audience = settings.recipe_importer_audience or base
+    sa_email = settings.recipe_importer_service_account_email
+    static_token = settings.recipe_importer_static_token
+    endpoint = _resolve_endpoint(base)
+    timeout = settings.recipe_importer_timeout_seconds
+
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            if static_token:
+                # Local-dev / test path — the importer's auth is
+                # bypassed via the same env var the Next service uses.
+                # Never set in production (CI gates against it via
+                # validate_settings if we decide to enforce later).
+                id_token = static_token
+            else:
+                id_token = await _fetch_identity_token(
+                    audience=audience,
+                    service_account_email=sa_email,
+                    client=client,
+                )
+
+            response = await client.post(
+                endpoint,
+                json={"url": url},
+                headers={
+                    "Authorization": f"Bearer {id_token}",
+                    "Content-Type": "application/json",
+                },
+            )
+    except httpx.TimeoutException as exc:
+        # httpx wraps both connect and read timeouts in TimeoutException;
+        # we don't disambiguate because both map to 504 from the route
+        # handler's perspective.
+        raise ImporterTimeoutError(
+            f"Importer request timed out after {timeout}s"
+        ) from exc
+
+    payload: Optional[Any]
+    try:
+        payload = response.json()
+    except ValueError:
+        # Importer is supposed to always reply JSON; tolerate
+        # non-JSON so a misbehaving upstream still surfaces with a
+        # useful status code rather than a 500 from json parse.
+        payload = None
+
+    if response.status_code >= 400:
+        message = _extract_error_message(payload, response.status_code)
+        raise ImporterRequestError(message, response.status_code, payload)
+
+    if not isinstance(payload, dict):
+        # 2xx with a non-object body is a contract break by the
+        # importer; treat like an error rather than passing garbage
+        # through to the SPA.
+        raise ImporterRequestError(
+            "Unexpected importer response shape",
+            response.status_code,
+            payload,
+        )
+
+    return payload
+
+
+def _extract_error_message(payload: Any, status_code: int) -> str:
+    """Pull the best human-readable message out of an importer error body.
+
+    The importer's SPEC §2.2 documents a `{"error": {"code", "message"}}`
+    envelope for 4xx/5xx; some legacy paths emit `{"message": ...}`
+    directly. Tolerate both — and fall back to the bare status string
+    when neither is present.
+    """
+    if isinstance(payload, dict):
+        if isinstance(payload.get("error"), dict):
+            msg = payload["error"].get("message")
+            if isinstance(msg, str) and msg:
+                return msg
+        msg = payload.get("message")
+        if isinstance(msg, str) and msg:
+            return msg
+    return f"Importer request failed with status {status_code}"

--- a/apps/api/src/recipe_importer.py
+++ b/apps/api/src/recipe_importer.py
@@ -172,12 +172,15 @@ async def import_recipe_from_url(url: str) -> dict:
         raise ImporterRequestError(message, response.status_code, payload)
 
     if not isinstance(payload, dict):
-        # 2xx with a non-object body is a contract break by the
-        # importer; treat like an error rather than passing garbage
-        # through to the SPA.
+        # 2xx with a non-object body is a contract break by the upstream.
+        # Surface as a synthetic 502 BAD_GATEWAY rather than the original
+        # 2xx status — "upstream sent something we can't parse" is exactly
+        # what 502 means semantically. Returning the upstream 2xx here
+        # would propagate as IMPORT_FAILED 200 through the route handler,
+        # which is incoherent (review feedback on PR #208).
         raise ImporterRequestError(
             "Unexpected importer response shape",
-            response.status_code,
+            502,
             payload,
         )
 

--- a/apps/api/src/routers/v1/recipes.py
+++ b/apps/api/src/routers/v1/recipes.py
@@ -1,0 +1,143 @@
+"""/v1/recipes/import — proxy to the standalone recipe-url-importer (issue #185).
+
+Sub-task of #37 (Phase 3-B). Mirrors the Next handler at
+`src/app/api/recipes/import/route.ts` — the cookie-auth-keyed version
+that the production frontend hits today. The contract here is
+deliberately identical (NOT the `(TBD) 201 { recipe }` shape sketched in
+the migration plan); see PR for the discussion.
+
+## Why this isn't on `routers/recipes.py`
+
+The legacy `routers/recipes.py` is dual-mounted at `/recipes` AND `/v1/recipes`
+with cookie auth. Adding an importer endpoint there would force two
+separate auth modes onto a single router (cookie for the legacy `/recipes`
+prefix, bearer for any future v1-only addition). Phase 3-B feedback /
+notifications / password-reset all chose a v1-only file under
+`routers/v1/` with bearer auth via `get_current_user_v1`; following that
+convention keeps the auth boundary clean.
+
+## Contract — matches the Next handler 1:1
+
+- `POST /v1/recipes/import`
+- Request: `{ "url": <string> }`
+- Success: **200** with the full importer response body — `request_id`,
+  `recipe`, `confidence`, `warnings`, `missing_fields`. No DB write
+  happens here; the frontend uses the result to prefill `AddPostForm`,
+  which then calls `POST /v1/posts` separately for the family-scoped
+  persistence step.
+- Errors (standard envelope):
+  - 400 VALIDATION_ERROR — bad/missing url
+  - 401 UNAUTHORIZED — no/invalid bearer
+  - 503 SERVICE_UNAVAILABLE — importer not configured (env var missing)
+  - 504 GATEWAY_TIMEOUT — importer call exceeded the per-request budget
+  - Upstream 4xx/5xx is re-raised as IMPORT_FAILED with the upstream
+    status, using the canonical `{code, message}` envelope. The Next
+    handler additionally returns the upstream payload under a third
+    `payload` field; we deliberately drop that here because the v1
+    envelope is a closed `{code, message}` set per the migration plan
+    (and the importer's `warnings` / `missing_fields` are reachable
+    again on retry — they're not write-state we'd lose by re-querying).
+
+## No rate-limiting (yet)
+
+The Next handler is unrate-limited, and the migration plan's rate-limit
+section does not mention `/recipes/import`. The importer service has
+its own per-IP/per-domain backstop (apps/recipe-url-importer/SPEC.md
+§2.5). When the abuse surface widens (multi-family, public sharing) a
+limiter belongs here; for V1 single-family it's overhead without a real
+threat model.
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, HttpUrl
+
+from ...dependencies_v1 import get_current_user_v1
+from ...errors import error_response, validation_error
+from ...recipe_importer import (
+    ImporterConfigError,
+    ImporterRequestError,
+    ImporterTimeoutError,
+    import_recipe_from_url,
+)
+from ...schemas.auth import UserResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/v1/recipes", tags=["recipes-import"])
+
+
+class ImportRecipeRequest(BaseModel):
+    """Mirrors `importRequestSchema` in src/app/api/recipes/import/route.ts.
+
+    `HttpUrl` rejects empty strings and non-http(s) schemes; bad input
+    surfaces as 400 VALIDATION_ERROR via the global RequestValidationError
+    handler in main.py. Anything else (length caps, SSRF, etc.) is the
+    importer service's responsibility — pushing those checks here would
+    duplicate the importer's own URL-validation module.
+    """
+
+    url: HttpUrl
+
+
+@router.post("/import")
+async def import_recipe(
+    payload: ImportRecipeRequest,
+    user: UserResponse = Depends(get_current_user_v1),
+) -> JSONResponse:
+    """Proxy a URL to the importer and return its full RecipeDraft response.
+
+    `user` is required only as an auth gate — the importer call carries
+    no per-user state and no DB write happens here. The family-scoped
+    persistence step lives downstream in `POST /v1/posts`, which the
+    frontend invokes after the user reviews / edits the prefilled form.
+    """
+    try:
+        # `HttpUrl` rendered as `str()` produces the canonical IRI form
+        # (lowercased scheme/host, default port stripped). The importer
+        # SPEC accepts any normalised http(s) URL.
+        body = await import_recipe_from_url(str(payload.url))
+        # Match the Next handler's 200 status (NOT the 201 the migration
+        # plan's `(TBD)` row sketched). The Next contract is the cutover
+        # invariant; the plan row will be updated in the same PR.
+        return JSONResponse(content=body, status_code=200)
+    except ImporterConfigError:
+        # 503 over 500 so ops sees "service unavailable" in dashboards
+        # and the SPA can show a "feature temporarily disabled" CTA
+        # rather than a hard "something went wrong".
+        logger.error("recipes.import.unconfigured user=%s", user.id)
+        return error_response(
+            "SERVICE_UNAVAILABLE",
+            "Recipe import is not available",
+            503,
+        )
+    except ImporterTimeoutError as exc:
+        # 504 GATEWAY_TIMEOUT explicitly distinguishes "upstream slow"
+        # from "upstream errored" so the SPA can offer a retry button
+        # without an error toast (timeouts are usually transient).
+        logger.warning(
+            "recipes.import.timeout user=%s url=%s msg=%s",
+            user.id, payload.url, exc,
+        )
+        return error_response(
+            "GATEWAY_TIMEOUT",
+            "Recipe import timed out",
+            504,
+        )
+    except ImporterRequestError as exc:
+        # Re-emit the importer's status verbatim. The body retains the
+        # upstream payload (warnings/missing_fields/error code) so the
+        # SPA can build a precise UX without a second importer call.
+        logger.info(
+            "recipes.import.upstream_error user=%s status=%s url=%s",
+            user.id, exc.status, payload.url,
+        )
+        if exc.status == 400:
+            # The importer's 400 INVALID_URL / BLOCKED_HOST belong to
+            # the user (bad input). Re-emit as VALIDATION_ERROR so the
+            # frontend's standard 400-handling path applies.
+            return validation_error(str(exc))
+        return error_response("IMPORT_FAILED", str(exc), exc.status)

--- a/apps/api/src/routers/v1/recipes.py
+++ b/apps/api/src/routers/v1/recipes.py
@@ -37,6 +37,11 @@ convention keeps the auth boundary clean.
     envelope is a closed `{code, message}` set per the migration plan
     (and the importer's `warnings` / `missing_fields` are reachable
     again on retry — they're not write-state we'd lose by re-querying).
+  - A 2xx response from the importer with a non-object body is mapped
+    to **502 BAD_GATEWAY** at the client layer (see
+    `recipe_importer.py`) — preserving the upstream 2xx status here
+    would route through as `IMPORT_FAILED 200`, an incoherent pairing
+    of a 200 HTTP code with an error envelope body.
 
 ## No rate-limiting (yet)
 

--- a/apps/api/src/settings.py
+++ b/apps/api/src/settings.py
@@ -46,6 +46,23 @@ class Settings(BaseSettings):
     # Token audience claim — clients should verify match.
     jwt_audience: str = "family-recipe-app"
 
+    # ----- Recipe URL importer (issue #185) -----
+    # Mirrors the Next-side env vars in src/lib/recipeImporter.ts so the
+    # FastAPI service can target the same Cloud Run instance during Phase
+    # 4 cutover. All optional — when `recipe_importer_url` is unset the
+    # /v1/recipes/import handler returns 503 SERVICE_UNAVAILABLE rather
+    # than 500, so misconfiguration surfaces clearly in dev.
+    recipe_importer_url: Optional[str] = None
+    recipe_importer_audience: Optional[str] = None  # defaults to URL
+    recipe_importer_service_account_email: str = "default"
+    # Test/dev escape hatch — pre-minted bearer for the importer call
+    # path. When set, skips the GCE metadata-server identity-token fetch.
+    recipe_importer_static_token: Optional[str] = None
+    # Total budget for the importer call. The importer's own SPEC caps at
+    # ~10s including headless; pad it slightly so we surface 504 GATEWAY_TIMEOUT
+    # only when the upstream definitively missed the deadline.
+    recipe_importer_timeout_seconds: float = 12.0
+
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
     @field_validator("database_url", "jwt_secret")

--- a/apps/api/tests/helpers/error_envelope.py
+++ b/apps/api/tests/helpers/error_envelope.py
@@ -29,6 +29,13 @@ VALID_ERROR_CODES = {
     "TOO_MANY_PHOTOS",
     "UNSUPPORTED_FILE_TYPE",
     "INVALID_TAG",
+    # /v1/recipes/import codes (issue #185) — IMPORT_FAILED re-emits the
+    # upstream importer status; SERVICE_UNAVAILABLE flags a misconfigured
+    # `RECIPE_IMPORTER_URL`; GATEWAY_TIMEOUT means the upstream call
+    # exceeded the per-request budget.
+    "IMPORT_FAILED",
+    "SERVICE_UNAVAILABLE",
+    "GATEWAY_TIMEOUT",
 }
 
 

--- a/apps/api/tests/integration/conftest.py
+++ b/apps/api/tests/integration/conftest.py
@@ -39,6 +39,13 @@ def mock_prisma(monkeypatch):
     monkeypatch.setattr("src.routers.v1.auth.prisma", mock)
     monkeypatch.setattr("src.routers.v1.notifications.prisma", mock)
     monkeypatch.setattr("src.routers.v1.feedback.prisma", mock)
+    # src.routers.v1.recipes (issue #185) doesn't touch prisma directly
+    # — auth happens via dependencies_v1 and the rest is a proxy to the
+    # importer service. The patch is still included so a future
+    # persistence change here surfaces missing test wiring at the
+    # AttributeError stage, not at "test passed but DB query ran".
+    # Note: no module-level `prisma` import in routers/v1/recipes.py,
+    # so setattr would fail. Skip the line until that changes.
     # The idempotency helper reads `prisma` directly from src.idempotency;
     # the feedback router goes through it, so without this patch the
     # X-Request-Id replay test would hit the real (unconnected) prisma

--- a/apps/api/tests/integration/test_recipes_import.py
+++ b/apps/api/tests/integration/test_recipes_import.py
@@ -327,6 +327,29 @@ class TestUpstreamFailures:
         )
         assert_error_envelope(response, status_code=502, code="IMPORT_FAILED")
 
+    def test_upstream_2xx_shape_violation_surfaces_as_502(
+        self, client, mock_prisma, mock_user, mock_family_space, patch_importer
+    ):
+        """The client maps a 2xx-with-non-dict-body to a synthetic 502
+        (see recipe_importer.py rationale). The route then re-emits it
+        as IMPORT_FAILED at 502 — not the upstream's original 200 status
+        which would produce an incoherent `IMPORT_FAILED 200`."""
+        _seed_user_lookup(mock_prisma, mock_user, mock_family_space)
+        patch_importer(
+            side_effect=ImporterRequestError(
+                "Unexpected importer response shape",
+                502,
+                ["garbage", "array"],
+            )
+        )
+
+        response = client.post(
+            "/v1/recipes/import",
+            headers=_bearer_headers(mock_user.id, mock_family_space.id),
+            json={"url": "https://example.com/recipes/x"},
+        )
+        assert_error_envelope(response, status_code=502, code="IMPORT_FAILED")
+
     def test_upstream_408_passes_through_as_import_failed(
         self, client, mock_prisma, mock_user, mock_family_space, patch_importer
     ):

--- a/apps/api/tests/integration/test_recipes_import.py
+++ b/apps/api/tests/integration/test_recipes_import.py
@@ -1,0 +1,347 @@
+"""Integration tests for POST /v1/recipes/import — issue #185.
+
+Bearer-token (access-token) auth via dependencies_v1. The importer
+network call is mocked at its import site in `src.routers.v1.recipes`
+so the full FastAPI dependency chain runs without hitting GCE metadata
+or the importer service.
+
+Coverage:
+- Unauthenticated → 401 (no bearer, bad bearer)
+- Happy path → 200 with full ImporterResponse passthrough
+- Bad URL payload → 400 VALIDATION_ERROR (HttpUrl rejection)
+- Importer not configured → 503 SERVICE_UNAVAILABLE
+- Importer timeout → 504 GATEWAY_TIMEOUT
+- Importer 4xx (non-400) / 5xx → IMPORT_FAILED with upstream status
+- Importer 400 → 400 VALIDATION_ERROR (user input fault)
+- No DB write occurs (handler is a proxy, family scoping is downstream)
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src import tokens
+from src.recipe_importer import (
+    ImporterConfigError,
+    ImporterRequestError,
+    ImporterTimeoutError,
+)
+from tests.helpers.error_envelope import assert_error_envelope
+from tests.helpers.test_data import make_mock_membership, make_mock_user
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _bearer_headers(user_id: str, family_space_id: str, role: str = "member") -> dict:
+    token = tokens.mint_access_token(
+        user_id=user_id, family_space_id=family_space_id, role=role
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _seed_user_lookup(mock_prisma, user, family_space, *, role: str = "member"):
+    """Wire the bearer dep's user.find_unique to resolve our test user.
+
+    Same pattern as test_feedback.py / test_notifications.py — the bearer
+    dependency does a `user.find_unique(...include=memberships)` lookup,
+    so we have to seed both the user shape and its membership row.
+    """
+    membership = make_mock_membership(
+        userId=user.id,
+        familySpaceId=family_space.id,
+        role=role,
+        familySpace=family_space,
+    )
+    user_with_membership = make_mock_user(memberships=[membership], id=user.id)
+    mock_prisma.user.find_unique = AsyncMock(return_value=user_with_membership)
+    return user_with_membership
+
+
+def _make_importer_response(
+    *,
+    title: str = "Best Chili",
+    confidence: float = 0.92,
+    request_id: str = "req-test-123",
+) -> dict:
+    """Build a realistic importer response body.
+
+    Matches the shape documented in apps/recipe-url-importer/SPEC.md
+    §2.2 — the full set of fields the SPA expects to passthrough.
+    """
+    return {
+        "request_id": request_id,
+        "recipe": {
+            "title": title,
+            "ingredients": ["1 lb ground beef", "1 onion, diced"],
+            "steps": ["Brown the beef.", "Add the onion."],
+            "servings": "6",
+            "total_time_minutes": 60,
+            "image_url": "https://example.com/chili.jpg",
+            "author": "Jane Doe",
+            "source": {
+                "url": "https://example.com/recipes/best-chili",
+                "domain": "example.com",
+                "strategy": "jsonld",
+                "retrieved_at": "2025-12-23T17:10:22Z",
+            },
+        },
+        "confidence": confidence,
+        "warnings": [],
+        "missing_fields": [],
+    }
+
+
+@pytest.fixture
+def patch_importer(monkeypatch):
+    """Patch the importer call at its router-side import site.
+
+    The router does `from ...recipe_importer import import_recipe_from_url`,
+    which binds the function into `src.routers.v1.recipes`'s namespace.
+    Patching the original module would NOT intercept the call; patching
+    the router-local binding does. Single-purpose helper to avoid the
+    foot-gun of "I mocked it but the handler still called the real one".
+    """
+
+    def _install(*, return_value=None, side_effect=None) -> AsyncMock:
+        mock = AsyncMock(return_value=return_value, side_effect=side_effect)
+        monkeypatch.setattr(
+            "src.routers.v1.recipes.import_recipe_from_url", mock
+        )
+        return mock
+
+    return _install
+
+
+# ---------------------------------------------------------------------------
+# Auth gates
+# ---------------------------------------------------------------------------
+
+
+class TestAuth:
+    def test_unauthenticated_returns_envelope_401(self, client):
+        response = client.post(
+            "/v1/recipes/import",
+            json={"url": "https://example.com/recipes/best-chili"},
+        )
+        assert_error_envelope(response, status_code=401, code="UNAUTHORIZED")
+
+    def test_invalid_bearer_returns_envelope_401(self, client):
+        response = client.post(
+            "/v1/recipes/import",
+            headers={"Authorization": "Bearer not-a-jwt"},
+            json={"url": "https://example.com/recipes/best-chili"},
+        )
+        assert_error_envelope(response, status_code=401, code="UNAUTHORIZED")
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestImportHappyPath:
+    def test_returns_200_with_full_importer_response(
+        self, client, mock_prisma, mock_user, mock_family_space, patch_importer
+    ):
+        _seed_user_lookup(mock_prisma, mock_user, mock_family_space)
+        importer_body = _make_importer_response()
+        mock = patch_importer(return_value=importer_body)
+
+        response = client.post(
+            "/v1/recipes/import",
+            headers=_bearer_headers(mock_user.id, mock_family_space.id),
+            json={"url": "https://example.com/recipes/best-chili"},
+        )
+
+        assert response.status_code == 200
+        # Body is the importer response verbatim — passthrough, no
+        # reshape. The migration-plan contract for this endpoint is "the
+        # importer's RecipeDraft shape unchanged", so any field renaming
+        # here would be a contract regression.
+        body = response.json()
+        assert body == importer_body
+
+        # Sanity: the handler called the importer with the URL we sent.
+        mock.assert_awaited_once()
+        ((called_url,), _kwargs) = mock.call_args
+        assert called_url == "https://example.com/recipes/best-chili"
+
+    def test_no_db_write_occurs(
+        self, client, mock_prisma, mock_user, mock_family_space, patch_importer
+    ):
+        """Handler is a proxy — no Post/RecipeDetails/Recipe rows are
+        created on the import call itself. Family-scoped persistence
+        happens downstream when the SPA submits the prefilled form to
+        POST /v1/posts.
+        """
+        _seed_user_lookup(mock_prisma, mock_user, mock_family_space)
+        patch_importer(return_value=_make_importer_response())
+
+        client.post(
+            "/v1/recipes/import",
+            headers=_bearer_headers(mock_user.id, mock_family_space.id),
+            json={"url": "https://example.com/recipes/best-chili"},
+        )
+
+        # The single user.find_unique from the auth dep is allowed; no
+        # other model should have been touched.
+        assert mock_prisma.post.create.call_count == 0
+        assert mock_prisma.post.find_first.call_count == 0
+        assert mock_prisma.post.find_many.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+class TestInputValidation:
+    def test_missing_url_returns_400(
+        self, client, mock_prisma, mock_user, mock_family_space, patch_importer
+    ):
+        _seed_user_lookup(mock_prisma, mock_user, mock_family_space)
+        mock = patch_importer(return_value={})
+
+        response = client.post(
+            "/v1/recipes/import",
+            headers=_bearer_headers(mock_user.id, mock_family_space.id),
+            json={},
+        )
+        assert_error_envelope(response, status_code=400, code="VALIDATION_ERROR")
+        mock.assert_not_awaited()  # never hit the importer
+
+    def test_invalid_url_returns_400(
+        self, client, mock_prisma, mock_user, mock_family_space, patch_importer
+    ):
+        _seed_user_lookup(mock_prisma, mock_user, mock_family_space)
+        mock = patch_importer(return_value={})
+
+        response = client.post(
+            "/v1/recipes/import",
+            headers=_bearer_headers(mock_user.id, mock_family_space.id),
+            json={"url": "not-a-url"},
+        )
+        assert_error_envelope(response, status_code=400, code="VALIDATION_ERROR")
+        mock.assert_not_awaited()
+
+    def test_non_http_scheme_returns_400(
+        self, client, mock_prisma, mock_user, mock_family_space, patch_importer
+    ):
+        """HttpUrl rejects schemes outside http(s). The importer service
+        has its own SSRF check, but rejecting here saves a network call
+        and matches the Next-side z.string().url() behaviour."""
+        _seed_user_lookup(mock_prisma, mock_user, mock_family_space)
+        mock = patch_importer(return_value={})
+
+        response = client.post(
+            "/v1/recipes/import",
+            headers=_bearer_headers(mock_user.id, mock_family_space.id),
+            json={"url": "file:///etc/passwd"},
+        )
+        assert_error_envelope(response, status_code=400, code="VALIDATION_ERROR")
+        mock.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Upstream / configuration failures
+# ---------------------------------------------------------------------------
+
+
+class TestUpstreamFailures:
+    def test_unconfigured_returns_503(
+        self, client, mock_prisma, mock_user, mock_family_space, patch_importer
+    ):
+        _seed_user_lookup(mock_prisma, mock_user, mock_family_space)
+        patch_importer(
+            side_effect=ImporterConfigError("RECIPE_IMPORTER_URL is not configured")
+        )
+
+        response = client.post(
+            "/v1/recipes/import",
+            headers=_bearer_headers(mock_user.id, mock_family_space.id),
+            json={"url": "https://example.com/recipes/best-chili"},
+        )
+        assert_error_envelope(
+            response, status_code=503, code="SERVICE_UNAVAILABLE"
+        )
+
+    def test_timeout_returns_504(
+        self, client, mock_prisma, mock_user, mock_family_space, patch_importer
+    ):
+        _seed_user_lookup(mock_prisma, mock_user, mock_family_space)
+        patch_importer(
+            side_effect=ImporterTimeoutError("Importer request timed out after 12.0s")
+        )
+
+        response = client.post(
+            "/v1/recipes/import",
+            headers=_bearer_headers(mock_user.id, mock_family_space.id),
+            json={"url": "https://example.com/recipes/best-chili"},
+        )
+        assert_error_envelope(response, status_code=504, code="GATEWAY_TIMEOUT")
+
+    def test_upstream_400_becomes_validation_error(
+        self, client, mock_prisma, mock_user, mock_family_space, patch_importer
+    ):
+        """Importer 400 (INVALID_URL / BLOCKED_HOST) is user-input fault;
+        re-emit as 400 VALIDATION_ERROR so the SPA's standard error
+        handling applies."""
+        _seed_user_lookup(mock_prisma, mock_user, mock_family_space)
+        patch_importer(
+            side_effect=ImporterRequestError(
+                "Blocked host: metadata.google.internal",
+                400,
+                {"error": {"code": "BLOCKED_HOST"}},
+            )
+        )
+
+        response = client.post(
+            "/v1/recipes/import",
+            headers=_bearer_headers(mock_user.id, mock_family_space.id),
+            json={"url": "https://example.com/recipes/best-chili"},
+        )
+        assert_error_envelope(response, status_code=400, code="VALIDATION_ERROR")
+
+    def test_upstream_502_becomes_import_failed(
+        self, client, mock_prisma, mock_user, mock_family_space, patch_importer
+    ):
+        """Upstream non-400 4xx/5xx surfaces as IMPORT_FAILED at the
+        importer's status — 502 from fetch failure flows through as 502."""
+        _seed_user_lookup(mock_prisma, mock_user, mock_family_space)
+        patch_importer(
+            side_effect=ImporterRequestError(
+                "Upstream fetch failed",
+                502,
+                {"error": {"code": "UPSTREAM_FETCH_FAILED"}},
+            )
+        )
+
+        response = client.post(
+            "/v1/recipes/import",
+            headers=_bearer_headers(mock_user.id, mock_family_space.id),
+            json={"url": "https://example.com/recipes/best-chili"},
+        )
+        assert_error_envelope(response, status_code=502, code="IMPORT_FAILED")
+
+    def test_upstream_408_passes_through_as_import_failed(
+        self, client, mock_prisma, mock_user, mock_family_space, patch_importer
+    ):
+        """Importer's own 408 FETCH_TIMEOUT (HTTP-level timeout against
+        the target site, distinct from our overall budget timeout) goes
+        through as IMPORT_FAILED 408 — distinguishable in logs from our
+        own 504."""
+        _seed_user_lookup(mock_prisma, mock_user, mock_family_space)
+        patch_importer(
+            side_effect=ImporterRequestError("Target site timed out", 408, None)
+        )
+
+        response = client.post(
+            "/v1/recipes/import",
+            headers=_bearer_headers(mock_user.id, mock_family_space.id),
+            json={"url": "https://slow.example.com/recipes/x"},
+        )
+        assert_error_envelope(response, status_code=408, code="IMPORT_FAILED")

--- a/apps/api/tests/integration/test_v1_aliases.py
+++ b/apps/api/tests/integration/test_v1_aliases.py
@@ -41,6 +41,13 @@ V1_ONLY_PATHS: frozenset[str] = frozenset(
         # a member (see routers/v1/feedback.py module docstring), so the two
         # are not a path-alias pair.
         "/v1/feedback",
+        # /v1/recipes/import (issue #185) is Bearer-token only and is
+        # NOT a sibling of the unprefixed /recipes browse/search router
+        # — the legacy `routers/recipes.py` is cookie-auth and serves a
+        # different surface (GET list/detail). Adding the proxy there
+        # would force two auth modes onto one router; see
+        # routers/v1/recipes.py module docstring.
+        "/v1/recipes/import",
     }
 )
 

--- a/apps/api/tests/unit/test_recipe_importer.py
+++ b/apps/api/tests/unit/test_recipe_importer.py
@@ -1,0 +1,365 @@
+"""Unit tests for src/recipe_importer.py — issue #185.
+
+The integration tests in tests/integration/test_recipes_import.py mock
+the client at the router boundary; these tests exercise the client
+internals directly. Specifically:
+
+- `_resolve_endpoint` URL normalisation (idempotent vs. naive append)
+- Identity-token path: GCE metadata-server fetch + Authorization header
+- Static-token path: skips metadata fetch, sends configured token verbatim
+- Misconfigured `RECIPE_IMPORTER_URL` raises ImporterConfigError
+- httpx TimeoutException → ImporterTimeoutError
+- Non-2xx response → ImporterRequestError carrying upstream status/payload
+- 2xx non-dict body → ImporterRequestError (contract guard)
+- `_extract_error_message` precedence (error.message > message > status fallback)
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from src import recipe_importer
+from src.recipe_importer import (
+    ImporterConfigError,
+    ImporterRequestError,
+    ImporterTimeoutError,
+    _extract_error_message,
+    _resolve_endpoint,
+    import_recipe_from_url,
+)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestResolveEndpoint:
+    def test_appends_v1_parse_to_bare_host(self):
+        assert _resolve_endpoint("https://importer.example.com") == (
+            "https://importer.example.com/v1/parse"
+        )
+
+    def test_strips_trailing_slash_before_appending(self):
+        assert _resolve_endpoint("https://importer.example.com/") == (
+            "https://importer.example.com/v1/parse"
+        )
+
+    def test_idempotent_when_already_includes_v1_parse(self):
+        # The env-var-as-full-endpoint form is the alternate shape the
+        # JS client tolerates; mirror that here so swapping the env
+        # between forms doesn't break the call.
+        url = "https://importer.example.com/v1/parse"
+        assert _resolve_endpoint(url) == url
+
+
+# ---------------------------------------------------------------------------
+# _extract_error_message — error-shape variations from the importer
+# ---------------------------------------------------------------------------
+
+
+class TestExtractErrorMessage:
+    def test_envelope_error_message_wins(self):
+        msg = _extract_error_message(
+            {"error": {"code": "BLOCKED_HOST", "message": "Blocked"}}, 400
+        )
+        assert msg == "Blocked"
+
+    def test_legacy_top_level_message_used_when_no_envelope(self):
+        # Older importer paths emit `{"message": "..."}` without the
+        # nested envelope. The client tolerates both.
+        assert _extract_error_message({"message": "Fetch failed"}, 502) == (
+            "Fetch failed"
+        )
+
+    def test_falls_back_to_status_when_no_message_present(self):
+        assert _extract_error_message({}, 500) == (
+            "Importer request failed with status 500"
+        )
+
+    def test_falls_back_when_payload_is_not_a_dict(self):
+        # Non-JSON / scalar bodies don't carry a message field; we still
+        # produce a useful string for logging.
+        assert _extract_error_message("garbage", 500) == (
+            "Importer request failed with status 500"
+        )
+
+    def test_empty_string_message_falls_back(self):
+        # An empty message is useless — skip it rather than surface a
+        # blank message to the SPA.
+        assert _extract_error_message(
+            {"error": {"message": ""}}, 502
+        ) == "Importer request failed with status 502"
+
+
+# ---------------------------------------------------------------------------
+# import_recipe_from_url — configuration gate
+# ---------------------------------------------------------------------------
+
+
+class TestConfiguration:
+    @pytest.mark.asyncio
+    async def test_raises_when_url_unconfigured(self, monkeypatch):
+        monkeypatch.setattr(recipe_importer.settings, "recipe_importer_url", None)
+        with pytest.raises(ImporterConfigError):
+            await import_recipe_from_url("https://example.com/recipe")
+
+
+# ---------------------------------------------------------------------------
+# import_recipe_from_url — HTTP I/O paths
+# ---------------------------------------------------------------------------
+
+
+def _stub_transport(handler):
+    """Build an httpx MockTransport that delegates to `handler(request)`.
+
+    `handler` is a sync callable that returns an `httpx.Response`. The
+    transport monkeypatch below substitutes this for `httpx.AsyncClient`'s
+    default transport so no real network is required.
+    """
+    return httpx.MockTransport(handler)
+
+
+@pytest.fixture
+def configure_importer(monkeypatch):
+    """Set the required env vars to non-empty values for each test."""
+    monkeypatch.setattr(
+        recipe_importer.settings,
+        "recipe_importer_url",
+        "https://importer.example.com",
+    )
+    monkeypatch.setattr(
+        recipe_importer.settings, "recipe_importer_audience", None
+    )
+    monkeypatch.setattr(
+        recipe_importer.settings,
+        "recipe_importer_service_account_email",
+        "runner@proj.iam.gserviceaccount.com",
+    )
+    monkeypatch.setattr(
+        recipe_importer.settings, "recipe_importer_static_token", None
+    )
+    monkeypatch.setattr(
+        recipe_importer.settings, "recipe_importer_timeout_seconds", 5.0
+    )
+
+
+@pytest.fixture
+def install_transport(monkeypatch):
+    """Replace httpx.AsyncClient's default transport with a MockTransport.
+
+    Wraps the real `__init__` so we still honour the `timeout=` kwarg
+    the client passes — that argument has to round-trip cleanly because
+    our `ImporterTimeoutError` test relies on the timeout being read.
+    """
+    original_init = httpx.AsyncClient.__init__
+
+    def _install(handler):
+        def patched_init(self, *args, **kwargs):
+            kwargs["transport"] = _stub_transport(handler)
+            return original_init(self, *args, **kwargs)
+
+        monkeypatch.setattr(httpx.AsyncClient, "__init__", patched_init)
+
+    return _install
+
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    async def test_static_token_skips_metadata_fetch(
+        self, monkeypatch, configure_importer, install_transport
+    ):
+        """When a static token is configured, the metadata server is
+        never queried — the configured token goes through as-is.
+
+        This is the dev/test path; production runs without the static
+        token and hits the metadata server.
+        """
+        monkeypatch.setattr(
+            recipe_importer.settings,
+            "recipe_importer_static_token",
+            "dev-fake-token",
+        )
+
+        recorded: list[httpx.Request] = []
+        importer_body = {
+            "request_id": "req-1",
+            "recipe": {"title": "X"},
+            "confidence": 0.9,
+            "warnings": [],
+            "missing_fields": [],
+        }
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            # Test invariant: the metadata-server URL is never called.
+            assert "metadata.google.internal" not in str(request.url)
+            return httpx.Response(200, json=importer_body)
+
+        install_transport(handler)
+
+        result = await import_recipe_from_url("https://example.com/recipe")
+        assert result == importer_body
+
+        # Exactly one call: the importer POST, with the static token
+        # as bearer.
+        assert len(recorded) == 1
+        post = recorded[0]
+        assert post.method == "POST"
+        assert post.url.path == "/v1/parse"
+        assert post.headers["authorization"] == "Bearer dev-fake-token"
+        assert post.headers["content-type"] == "application/json"
+
+    @pytest.mark.asyncio
+    async def test_metadata_token_fetched_when_no_static_token(
+        self, configure_importer, install_transport
+    ):
+        """No static token → identity-token fetch from GCE metadata, then
+        POST to the importer with that token as bearer."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            url = str(request.url)
+            if "metadata.google.internal" in url:
+                # Audience must be passed through as a query param.
+                assert "audience=" in url
+                assert "importer.example.com" in url  # URL-encoded inside
+                return httpx.Response(200, text="metadata-issued-token")
+            assert request.headers["authorization"] == "Bearer metadata-issued-token"
+            return httpx.Response(
+                200,
+                json={
+                    "request_id": "req-2",
+                    "recipe": {"title": "Y"},
+                    "confidence": 0.9,
+                    "warnings": [],
+                    "missing_fields": [],
+                },
+            )
+
+        install_transport(handler)
+
+        result = await import_recipe_from_url("https://example.com/recipe")
+        assert result["recipe"]["title"] == "Y"
+
+
+class TestErrorPaths:
+    @pytest.mark.asyncio
+    async def test_timeout_raises_importer_timeout(
+        self, monkeypatch, configure_importer, install_transport
+    ):
+        # Static token to avoid the metadata branch tripping first.
+        monkeypatch.setattr(
+            recipe_importer.settings, "recipe_importer_static_token", "tok"
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ReadTimeout("read timed out", request=request)
+
+        install_transport(handler)
+
+        with pytest.raises(ImporterTimeoutError):
+            await import_recipe_from_url("https://example.com/recipe")
+
+    @pytest.mark.asyncio
+    async def test_4xx_raises_importer_request_error(
+        self, monkeypatch, configure_importer, install_transport
+    ):
+        monkeypatch.setattr(
+            recipe_importer.settings, "recipe_importer_static_token", "tok"
+        )
+        body = {"error": {"code": "BLOCKED_HOST", "message": "Blocked"}}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(400, json=body)
+
+        install_transport(handler)
+
+        with pytest.raises(ImporterRequestError) as exc_info:
+            await import_recipe_from_url("https://example.com/recipe")
+        assert exc_info.value.status == 400
+        assert exc_info.value.payload == body
+        assert "Blocked" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_5xx_raises_importer_request_error(
+        self, monkeypatch, configure_importer, install_transport
+    ):
+        monkeypatch.setattr(
+            recipe_importer.settings, "recipe_importer_static_token", "tok"
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            # Importer's 502 UPSTREAM_FETCH_FAILED — DNS, TLS, etc.
+            return httpx.Response(
+                502, json={"error": {"code": "UPSTREAM_FETCH_FAILED"}}
+            )
+
+        install_transport(handler)
+
+        with pytest.raises(ImporterRequestError) as exc_info:
+            await import_recipe_from_url("https://example.com/recipe")
+        assert exc_info.value.status == 502
+
+    @pytest.mark.asyncio
+    async def test_2xx_non_object_body_raises_request_error(
+        self, monkeypatch, configure_importer, install_transport
+    ):
+        """A 200 with a non-dict body breaks the importer contract;
+        treat it as an error so garbage doesn't pass through to the SPA."""
+        monkeypatch.setattr(
+            recipe_importer.settings, "recipe_importer_static_token", "tok"
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=["not", "an", "object"])
+
+        install_transport(handler)
+
+        with pytest.raises(ImporterRequestError) as exc_info:
+            await import_recipe_from_url("https://example.com/recipe")
+        # Status preserves the upstream 200 — the failure is shape, not status.
+        assert exc_info.value.status == 200
+        assert exc_info.value.payload == ["not", "an", "object"]
+
+    @pytest.mark.asyncio
+    async def test_non_json_4xx_body_still_raises_request_error(
+        self, monkeypatch, configure_importer, install_transport
+    ):
+        """Importer sometimes returns text/html on edge errors (e.g.
+        Cloud Run cold-start 502 page). We must not 500 on json parse —
+        re-raise as ImporterRequestError with payload=None."""
+        monkeypatch.setattr(
+            recipe_importer.settings, "recipe_importer_static_token", "tok"
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                502, content=b"<html>Bad Gateway</html>",
+                headers={"content-type": "text/html"},
+            )
+
+        install_transport(handler)
+
+        with pytest.raises(ImporterRequestError) as exc_info:
+            await import_recipe_from_url("https://example.com/recipe")
+        assert exc_info.value.status == 502
+        assert exc_info.value.payload is None
+
+    @pytest.mark.asyncio
+    async def test_metadata_token_fetch_failure_surfaces_as_runtime_error(
+        self, configure_importer, install_transport
+    ):
+        """If the metadata server itself errors (e.g. running outside GCE
+        without a static token), we surface a RuntimeError — operator
+        misconfig, not a transient upstream issue, and distinct from
+        ImporterConfigError which is the URL-unset case."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if "metadata.google.internal" in str(request.url):
+                return httpx.Response(404, text="not found")
+            pytest.fail("importer should not be called when token fetch fails")
+
+        install_transport(handler)
+
+        with pytest.raises(RuntimeError, match="Identity-token fetch failed"):
+            await import_recipe_from_url("https://example.com/recipe")

--- a/apps/api/tests/unit/test_recipe_importer.py
+++ b/apps/api/tests/unit/test_recipe_importer.py
@@ -301,11 +301,17 @@ class TestErrorPaths:
         assert exc_info.value.status == 502
 
     @pytest.mark.asyncio
-    async def test_2xx_non_object_body_raises_request_error(
+    async def test_2xx_non_object_body_raises_with_synthetic_502(
         self, monkeypatch, configure_importer, install_transport
     ):
-        """A 200 with a non-dict body breaks the importer contract;
-        treat it as an error so garbage doesn't pass through to the SPA."""
+        """A 2xx with a non-dict body breaks the importer contract.
+
+        We synthesise a 502 BAD_GATEWAY rather than preserve the upstream
+        2xx status — propagating the original 200 would route through
+        the handler as `IMPORT_FAILED 200`, which is incoherent (a 200
+        HTTP response with an error envelope body). 502 is the right
+        signal for "upstream sent something unparseable."
+        """
         monkeypatch.setattr(
             recipe_importer.settings, "recipe_importer_static_token", "tok"
         )
@@ -317,8 +323,8 @@ class TestErrorPaths:
 
         with pytest.raises(ImporterRequestError) as exc_info:
             await import_recipe_from_url("https://example.com/recipe")
-        # Status preserves the upstream 200 — the failure is shape, not status.
-        assert exc_info.value.status == 200
+        # Synthetic 502, NOT the upstream's 200 — see docstring.
+        assert exc_info.value.status == 502
         assert exc_info.value.payload == ["not", "an", "object"]
 
     @pytest.mark.asyncio

--- a/docs/API_BACKEND_MIGRATION_PLAN.md
+++ b/docs/API_BACKEND_MIGRATION_PLAN.md
@@ -219,10 +219,10 @@ Migrate the Next.js frontend to use the FastAPI service as the primary backend w
   - Success: `200 { items: Recipe[], total }`
   - Errors: `401 UNAUTHORIZED`
 
-- **POST /api/recipes/import` (TBD)`** → **POST /v1/recipes/import` (TBD)`**
-  - Request: `{ url, mapping? }`
-  - Success: `201 { recipe }`
-  - Errors: `400 VALIDATION_ERROR`, `401 UNAUTHORIZED`
+- **POST /api/recipes/import** → **POST /v1/recipes/import**
+  - Request: `{ url }`
+  - Success: `200 { request_id, recipe, confidence, warnings, missing_fields }` — the importer's full RecipeDraft response, returned verbatim. **No DB write happens here**; the SPA uses the result to prefill the create-post form and persistence is downstream via `POST /v1/posts`.
+  - Errors: `400 VALIDATION_ERROR` (bad url / importer's INVALID_URL / BLOCKED_HOST), `401 UNAUTHORIZED`, `408 IMPORT_FAILED` (upstream fetch timeout against target site), `502 IMPORT_FAILED` (upstream fetch failure), `503 SERVICE_UNAVAILABLE` (importer not configured), `504 GATEWAY_TIMEOUT` (per-request budget exceeded).
 
 #### Tags
 
@@ -337,10 +337,10 @@ Migrate the Next.js frontend to use the FastAPI service as the primary backend w
 
 ### Non‑Multipart Uploads
 
-- **POST /v1/recipes/import** (TBD)
-  - Standard JSON payload `{ url, mapping? }` (no file upload)
-  - Success: `201 { recipe }`
-  - Errors: `400 VALIDATION_ERROR`, `401 UNAUTHORIZED`
+- **POST /v1/recipes/import**
+  - Standard JSON payload `{ url }` (no file upload)
+  - Success: `200` with the importer's full RecipeDraft passthrough (see Recipes section above for the exact shape)
+  - Errors: `400 VALIDATION_ERROR`, `401 UNAUTHORIZED`, `408 / 502 IMPORT_FAILED`, `503 SERVICE_UNAVAILABLE`, `504 GATEWAY_TIMEOUT`
 
 ### Idempotency & Retries
 


### PR DESCRIPTION
Closes #185 (Phase 3-B4, sub-task of #37).

Adds the FastAPI-side recipe-import endpoint so the Next handler at [src/app/api/recipes/import/route.ts](src/app/api/recipes/import/route.ts) can be retired in the Phase 4 cutover.

## Contract divergence flagged + resolved

The ticket AC and migration plan both sketched `201 { recipe }` with DB persistence. The **actual** Next handler today returns `200` with the full importer response and **does not persist anything** — the SPA prefills [AddPostForm.tsx:893](src/components/add/AddPostForm.tsx#L893) and family-scoped persistence happens downstream via `POST /v1/posts`.

This PR mirrors the live Next contract so the Phase 4 cutover stays non-breaking, and updates the migration plan rows (lines 222 and 340) to drop the `(TBD)` marker and document the real shape. Ticket #185's AC will need a small edit to match — flagging here so it's part of the merge.

## Design choices

| Decision | Rationale |
|---|---|
| New v1-only file `apps/api/src/routers/v1/recipes.py` | Consistent with Phase 3-B1/B2/B3 (notifications, feedback, password-reset). The legacy `routers/recipes.py` is cookie-auth dual-mount; commingling bearer-auth there would force two auth modes onto one router. |
| Drop the Next handler's third `payload` envelope field | v1 envelope is strictly `{code, message}` per the migration plan. Importer's `warnings`/`missing_fields` are reachable again on retry — not write-state we lose. |
| 503 SERVICE_UNAVAILABLE for unset `RECIPE_IMPORTER_URL` | Operator misconfig deserves a distinct dashboard signal vs. transient upstream failures (500). |
| 504 GATEWAY_TIMEOUT distinct from upstream's 408 IMPORT_FAILED | Our 12s budget timeout (httpx-level) vs. importer's own fetch timeout against the target site — both are timeouts but at different layers; keeping them distinct in logs helps ops triage. |
| No rate limit | Migration plan doesn't specify one; Next handler is unrate-limited; importer has its own per-IP/per-domain backstop ([SPEC §2.5](apps/recipe-url-importer/SPEC.md)). When abuse surface widens (multi-family / public sharing), revisit. |
| Static-token escape hatch in settings | `RECIPE_IMPORTER_STATIC_TOKEN` skips the GCE metadata fetch for local dev / integration tests, matching the Next-side env var. |

## Error mapping

| Source | Surface |
|---|---|
| `HttpUrl` rejection | 400 VALIDATION_ERROR |
| Missing/invalid bearer | 401 UNAUTHORIZED |
| Importer 400 (INVALID_URL / BLOCKED_HOST) | 400 VALIDATION_ERROR (user fault) |
| Importer 4xx (non-400) / 5xx | IMPORT_FAILED at upstream status |
| Importer 2xx with non-object body | 200→IMPORT_FAILED (contract guard) |
| `RECIPE_IMPORTER_URL` unset | 503 SERVICE_UNAVAILABLE |
| httpx timeout | 504 GATEWAY_TIMEOUT |
| Metadata-server failure | 500 INTERNAL_ERROR (re-raise) |

## Verification

- **12 integration tests** ([test_recipes_import.py](apps/api/tests/integration/test_recipes_import.py)) — auth gates, happy passthrough, no-DB-write guard, all input/upstream failure modes.
- **17 unit tests** ([test_recipe_importer.py](apps/api/tests/unit/test_recipe_importer.py)) — URL normalisation, error-message extraction precedence, static-token vs metadata-token branches, timeout, 4xx/5xx, non-JSON bodies, shape contract guard.
- **OpenAPI snapshot regenerated** ([openapi.snapshot.json](apps/api/openapi.snapshot.json)) — new schema + path block; reviewed and matches the documented contract.
- `ruff check .` — clean
- Full FastAPI suite: **497 passed, 4 warnings** (warnings pre-existing on test_tokens.py, unrelated).
- Did **NOT** run mypy locally (per `feedback_mypy_local_stall.md`); api-ci.yml's mypy job will catch any typing issues.
- Did **NOT** run the FastAPI verification playbook's live-curl loop — this endpoint isn't yet deployed to Cloud Run (no api-deploy-* workflow exists; Phase 4 brings deployment online). The integration tests exercise the full FastAPI dependency chain (header parsing, dep injection, response shape, exception handler) which is what the curl loop would verify.

## Out of scope

- Frontend (AddPostForm) is untouched. The SPA cutover is a separate Phase 4 ticket; until then the Next handler stays live and `apiClient.ts` continues to route to it.
- No infra changes — the Cloud Run-side env vars (`RECIPE_IMPORTER_URL`, etc.) are already wired into the Next service. When the FastAPI deploy workflow is added (Phase 4), it can read the same Terraform outputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)