### PR TITLE
feat(api): Phase 3-B5 — account delete endpoint on FastAPI (#186)

### DIFF
--- a/apps/api/openapi.snapshot.json
+++ b/apps/api/openapi.snapshot.json
@@ -269,6 +269,29 @@
         "title": "CreateFeedbackResponse",
         "type": "object"
       },
+      "DeleteAccountRequest": {
+        "description": "Self-service account-delete payload \u2014 mirrors\n`deleteAccountSchema` in src/lib/validation.ts.\n\nThe endpoint requires two confirmations even though the caller is\nalready authenticated: a fresh password proves possession of the\naccount (not just a stolen access token), and the literal string\n`DELETE` in `confirmation` is the same anti-fat-finger guard the\nNext handler uses. Both are validated up-front so the destructive\n`prisma.user.delete` call never runs on a malformed request.",
+        "properties": {
+          "confirmation": {
+            "maxLength": 50,
+            "minLength": 1,
+            "title": "Confirmation",
+            "type": "string"
+          },
+          "currentPassword": {
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Currentpassword",
+            "type": "string"
+          }
+        },
+        "required": [
+          "currentPassword",
+          "confirmation"
+        ],
+        "title": "DeleteAccountRequest",
+        "type": "object"
+      },
       "FavoriteResponse": {
         "properties": {
           "favorited": {
@@ -3056,6 +3079,46 @@
         "summary": "Healthcheck",
         "tags": [
           "health"
+        ]
+      }
+    },
+    "/v1/me/delete": {
+      "delete": {
+        "description": "Delete the authenticated caller's account.\n\nReturns 204 No Content on success \u2014 see module docstring for the\nintentional divergence from the Next handler's 200 body.",
+        "operationId": "delete_account_v1_me_delete_delete",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteAccountRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Delete Account",
+        "tags": [
+          "me-v1"
         ]
       }
     },

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -9,6 +9,7 @@ from .errors import ApiError, error_response, validation_error
 from .routers import auth, comments, family, health, me, posts, profile, reactions, recipes, tags, timeline
 from .routers.v1 import auth as auth_v1
 from .routers.v1 import feedback as feedback_v1
+from .routers.v1 import me as me_v1
 from .routers.v1 import notifications as notifications_v1
 from .routers.v1 import recipes as recipes_v1
 from .settings import settings, validate_settings
@@ -99,3 +100,8 @@ app.include_router(feedback_v1.router)
 # browse/search under cookie auth, and adding the importer there would
 # mix two auth modes on one router. See routers/v1/recipes.py docstring.
 app.include_router(recipes_v1.router)
+# `/v1/me/delete` (issue #186): bearer-auth-only account delete. Same
+# rationale as feedback/notifications/recipes_v1 — the cookie-auth twin
+# at `routers/me.py` stays alive through Phase 4, and there is no
+# behavioural overlap to alias.
+app.include_router(me_v1.router)

--- a/apps/api/src/routers/v1/me.py
+++ b/apps/api/src/routers/v1/me.py
@@ -1,0 +1,153 @@
+"""/v1/me/* — current-user surface on the v1 namespace.
+
+Today this file only exposes `DELETE /v1/me/delete` (issue #186,
+sub-task of #37). The legacy cookie-auth twin lives in
+`src/routers/me.py` and is kept alive until Phase 4 (#38).
+Bearer-token auth via `get_current_user_v1` — never mounted unprefixed
+because the Phase 2 frontend only hits this surface when
+`USE_FASTAPI_AUTH` is on (and is therefore already sending access
+tokens). A dual-mounted cookie-auth alias would have no caller.
+
+## Divergences from the Next handler (intentional)
+
+Two contract differences from `src/app/api/me/delete/route.ts`,
+both following the AC in #186 rather than the legacy behaviour:
+
+- **204 No Content** on success, with no body. Next returns
+  `200 { status: 'deleted' }`. The 204 is what the migration plan and
+  ticket spec, and once the Next handler is removed in Phase 4 the
+  body served no purpose anyway — the SPA already treats any 2xx as
+  success and clears its in-memory auth state.
+- Cookies cleared on the response are `refresh_token` + `csrf_token`
+  (the v1 token-auth pair). Next clears its single legacy `session`
+  cookie. Different auth model, different cookies; the legacy cookie
+  is owned by the Next handler.
+
+## Cascade semantics
+
+`prisma.user.delete(where={id})` triggers Postgres-side cascades
+declared in [prisma/schema.postgres.prisma](../../../../prisma/schema.postgres.prisma).
+For the User model these are:
+
+  - `FamilyMembership.user`        onDelete: Cascade  (membership row removed)
+  - `Post.author`                  onDelete: Cascade  (authored posts removed)
+  - `Comment.author`               onDelete: Cascade  (authored comments removed)
+  - `Reaction.user`                onDelete: Cascade  (post/comment reactions removed)
+  - `CookedEvent.user`             onDelete: Cascade  (cooked entries removed)
+  - `Favorite.user`                onDelete: Cascade  (favorites removed)
+  - `Notification.recipient/actor` onDelete: Cascade  (notifications removed)
+  - `RefreshToken.user`            onDelete: Cascade  (refresh-token rows removed)
+  - `IdempotencyKey.user`          onDelete: Cascade  (idempotency cache removed)
+  - `FeedbackSubmission.user`      onDelete: SetNull  (orphaned, anonymized)
+
+This matches the Next handler verbatim — both rely on the same
+schema-level cascades and neither hand-rolls a transaction. The
+`SetNull` on `FeedbackSubmission` is intentional: deleting a user
+should anonymize their feedback, not erase the bug/suggestion log.
+
+The cascade hard-deletes refresh-token rows (not "revoked", which
+would just set `revokedAt`); a subsequent `/v1/auth/refresh` therefore
+returns 401 on the row-not-found branch rather than the revoked-row
+branch. End-state for the caller is identical.
+
+## What this endpoint refuses
+
+- **Owners and admins** — same as the Next handler. The V1 product
+  has exactly one owner per family space; letting them self-delete
+  would leave the family without an owner. Operators handle the
+  edge case via a manual migration, not via this endpoint.
+- **Wrong password** — defense in depth. A stolen access token alone
+  cannot destroy an account; the attacker also needs the password.
+- **Confirmation phrase mismatch** — UX guardrail mirroring the Next
+  handler's `confirmation === 'DELETE'` check.
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, Response, status
+from prisma.errors import PrismaError
+
+from ...cookies import clear_csrf_cookie, clear_refresh_cookie
+from ...db import prisma
+from ...dependencies_v1 import get_current_user_v1
+from ...errors import (
+    forbidden,
+    internal_error,
+    invalid_credentials,
+    not_found,
+    validation_error,
+)
+from ...schemas.auth import DeleteAccountRequest, UserResponse
+from ...security import verify_password
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/v1/me", tags=["me-v1"])
+
+
+_CONFIRMATION_PHRASE = "DELETE"
+
+
+@router.delete("/delete", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_account(
+    payload: DeleteAccountRequest,
+    response: Response,
+    user: UserResponse = Depends(get_current_user_v1),
+):
+    """Delete the authenticated caller's account.
+
+    Returns 204 No Content on success — see module docstring for the
+    intentional divergence from the Next handler's 200 body.
+    """
+    # Owner/admin guard runs before any DB lookup so a privileged
+    # caller's request never even touches `passwordHash`; matches
+    # the Next handler's ordering.
+    if user.role in ("owner", "admin"):
+        return forbidden("Owners and admins cannot delete their accounts")
+
+    if payload.confirmation.strip().upper() != _CONFIRMATION_PHRASE:
+        return validation_error("Confirmation must be DELETE")
+
+    try:
+        current_user = await prisma.user.find_unique(
+            where={"id": user.id},
+        )
+    except PrismaError as error:
+        logger.exception("account.delete.lookup_prisma_error userId=%s: %s", user.id, error)
+        return internal_error("Unable to delete account")
+
+    if not current_user:
+        # `get_current_user_v1` already verified the token resolves to
+        # a real user — hitting this branch means a concurrent delete
+        # raced us. Surface 404 rather than 500 because the requested
+        # post-condition (user gone) is already true.
+        return not_found("User not found")
+
+    if not verify_password(payload.currentPassword, current_user.passwordHash):
+        logger.warning("account.delete.invalid_password userId=%s", user.id)
+        return invalid_credentials("Incorrect password")
+
+    try:
+        await prisma.user.delete(where={"id": user.id})
+    except PrismaError as error:
+        # Postgres cascade fired and something downstream rejected.
+        # No partial state: Prisma wraps the delete + cascade in a
+        # single statement, so a failure here means the user row is
+        # still present and the caller can retry safely.
+        logger.exception("account.delete.prisma_error userId=%s: %s", user.id, error)
+        return internal_error("Unable to delete account")
+
+    logger.info(
+        "account.delete.success userId=%s familySpaceId=%s",
+        user.id, user.familySpaceId,
+    )
+
+    # Clear the v1 cookie pair on the response. The httpOnly refresh
+    # cookie is the one that matters for security; the csrf cookie
+    # is cleared in lockstep so the SPA's double-submit assertion
+    # doesn't get confused on the next request.
+    clear_refresh_cookie(response)
+    clear_csrf_cookie(response)
+    response.status_code = status.HTTP_204_NO_CONTENT
+    return response

--- a/apps/api/src/schemas/auth.py
+++ b/apps/api/src/schemas/auth.py
@@ -18,6 +18,24 @@ class LoginRequest(BaseModel):
     rememberMe: bool = False
 
 
+class DeleteAccountRequest(BaseModel):
+    """Self-service account-delete payload — mirrors
+    `deleteAccountSchema` in src/lib/validation.ts.
+
+    The endpoint requires two confirmations even though the caller is
+    already authenticated: a fresh password proves possession of the
+    account (not just a stolen access token), and the literal string
+    `DELETE` in `confirmation` is the same anti-fat-finger guard the
+    Next handler uses. Both are validated up-front so the destructive
+    `prisma.user.delete` call never runs on a malformed request.
+    """
+    currentPassword: str = Field(min_length=1, max_length=200)
+    # Pydantic doesn't have z.string().transform — case-insensitivity
+    # is handled in the router so the schema stays declarative. Accept
+    # any case here; the handler upper-cases and trims before checking.
+    confirmation: str = Field(min_length=1, max_length=50)
+
+
 class ResetPasswordRequest(BaseModel):
     """Master-key-gated password reset — mirrors the Next handler at
     `src/app/api/auth/reset/route.ts`.

--- a/apps/api/tests/integration/conftest.py
+++ b/apps/api/tests/integration/conftest.py
@@ -39,6 +39,7 @@ def mock_prisma(monkeypatch):
     monkeypatch.setattr("src.routers.v1.auth.prisma", mock)
     monkeypatch.setattr("src.routers.v1.notifications.prisma", mock)
     monkeypatch.setattr("src.routers.v1.feedback.prisma", mock)
+    monkeypatch.setattr("src.routers.v1.me.prisma", mock)
     # src.routers.v1.recipes (issue #185) doesn't touch prisma directly
     # — auth happens via dependencies_v1 and the rest is a proxy to the
     # importer service. The patch is still included so a future

--- a/apps/api/tests/integration/test_me_v1_delete.py
+++ b/apps/api/tests/integration/test_me_v1_delete.py
@@ -1,0 +1,431 @@
+"""Integration tests for DELETE /v1/me/delete — issue #186.
+
+Bearer-token auth via `dependencies_v1.get_current_user_v1`. The
+handler relies on Postgres schema-level cascades for the actual
+data deletion (see the router's module docstring), so these tests
+focus on what the FastAPI layer *itself* owns:
+
+  - The 204 contract
+  - The owner/admin guard
+  - Password verification
+  - Confirmation-phrase validation
+  - Refresh + csrf cookies cleared on the response
+
+Cascade behaviour itself is verified by Prisma + the live DB
+schema; mock-Prisma can't faithfully reproduce a multi-row cascade,
+so we assert the handler issues exactly one `prisma.user.delete`
+call with the right `where` and let the schema do the rest.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from src import tokens
+from src.settings import settings
+from tests.helpers.error_envelope import assert_error_envelope
+from tests.helpers.test_data import make_mock_membership, make_mock_user
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirror the pattern in test_feedback.py / test_recipes_import.py)
+# ---------------------------------------------------------------------------
+
+
+def _bearer_headers(
+    user_id: str, family_space_id: str, role: str = "member"
+) -> dict:
+    token = tokens.mint_access_token(
+        user_id=user_id, family_space_id=family_space_id, role=role
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _seed_user_lookup(
+    mock_prisma, user, family_space, *, role: str = "member"
+):
+    """Wire the /v1 bearer dep's `user.find_unique` to resolve our user.
+
+    Also wires a second `find_unique` return for the handler's own
+    password-fetch lookup. The bearer dep and the handler both call
+    `prisma.user.find_unique`, but on the mock client they share a
+    single `AsyncMock`, so a single `return_value` covers both.
+    """
+    membership = make_mock_membership(
+        userId=user.id,
+        familySpaceId=family_space.id,
+        role=role,
+        familySpace=family_space,
+    )
+    user_with_membership = make_mock_user(memberships=[membership], id=user.id)
+    # Copy any password-hash override across so the password-verify
+    # branch sees the right hash on the second `find_unique` call.
+    if hasattr(user, "passwordHash"):
+        user_with_membership.passwordHash = user.passwordHash
+    mock_prisma.user.find_unique = AsyncMock(return_value=user_with_membership)
+    return user_with_membership
+
+
+_VALID_PAYLOAD = {"currentPassword": "correct-password", "confirmation": "DELETE"}
+
+
+# ---------------------------------------------------------------------------
+# Auth gates
+# ---------------------------------------------------------------------------
+
+
+class TestUnauthenticated:
+    def test_no_bearer_returns_401_envelope(self, client):
+        response = client.request(
+            "DELETE", "/v1/me/delete", json=_VALID_PAYLOAD
+        )
+        assert_error_envelope(response, status_code=401, code="UNAUTHORIZED")
+
+    def test_malformed_bearer_returns_401_envelope(self, client):
+        response = client.request(
+            "DELETE",
+            "/v1/me/delete",
+            json=_VALID_PAYLOAD,
+            headers={"Authorization": "Bearer not-a-jwt"},
+        )
+        assert_error_envelope(response, status_code=401, code="UNAUTHORIZED")
+
+    def test_legacy_session_cookie_does_not_authenticate_v1(
+        self, client, member_auth
+    ):
+        # The legacy `session` cookie is the cookie-auth pathway and
+        # is honoured only by /api/me/delete. /v1/me/delete is bearer-
+        # only, so a cookie-only request must 401.
+        response = client.request(
+            "DELETE", "/v1/me/delete", json=_VALID_PAYLOAD, headers=member_auth
+        )
+        assert_error_envelope(response, status_code=401, code="UNAUTHORIZED")
+
+
+# ---------------------------------------------------------------------------
+# Role guard
+# ---------------------------------------------------------------------------
+
+
+class TestRoleGuard:
+    def test_owner_cannot_delete_account(self, client, mock_prisma):
+        from tests.helpers.test_data import make_mock_family_space
+        family = make_mock_family_space()
+        user = make_mock_user(id="owner_1")
+        _seed_user_lookup(mock_prisma, user, family, role="owner")
+        mock_prisma.user.delete = AsyncMock(return_value=None)
+
+        response = client.request(
+            "DELETE",
+            "/v1/me/delete",
+            json=_VALID_PAYLOAD,
+            headers=_bearer_headers(user.id, family.id, role="owner"),
+        )
+
+        assert_error_envelope(response, status_code=403, code="FORBIDDEN")
+        # Guard fires before the destructive call.
+        mock_prisma.user.delete.assert_not_called()
+
+    def test_admin_cannot_delete_account(self, client, mock_prisma):
+        from tests.helpers.test_data import make_mock_family_space
+        family = make_mock_family_space()
+        user = make_mock_user(id="admin_1")
+        _seed_user_lookup(mock_prisma, user, family, role="admin")
+        mock_prisma.user.delete = AsyncMock(return_value=None)
+
+        response = client.request(
+            "DELETE",
+            "/v1/me/delete",
+            json=_VALID_PAYLOAD,
+            headers=_bearer_headers(user.id, family.id, role="admin"),
+        )
+
+        assert_error_envelope(response, status_code=403, code="FORBIDDEN")
+        mock_prisma.user.delete.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Request validation
+# ---------------------------------------------------------------------------
+
+
+class TestRequestValidation:
+    def test_missing_password_returns_400(self, client, mock_prisma):
+        from tests.helpers.test_data import make_mock_family_space
+        family = make_mock_family_space()
+        user = make_mock_user()
+        _seed_user_lookup(mock_prisma, user, family)
+
+        response = client.request(
+            "DELETE",
+            "/v1/me/delete",
+            json={"confirmation": "DELETE"},
+            headers=_bearer_headers(user.id, family.id),
+        )
+        assert_error_envelope(response, status_code=400, code="VALIDATION_ERROR")
+
+    def test_missing_confirmation_returns_400(self, client, mock_prisma):
+        from tests.helpers.test_data import make_mock_family_space
+        family = make_mock_family_space()
+        user = make_mock_user()
+        _seed_user_lookup(mock_prisma, user, family)
+
+        response = client.request(
+            "DELETE",
+            "/v1/me/delete",
+            json={"currentPassword": "x"},
+            headers=_bearer_headers(user.id, family.id),
+        )
+        assert_error_envelope(response, status_code=400, code="VALIDATION_ERROR")
+
+    def test_wrong_confirmation_phrase_returns_400(
+        self, client, mock_prisma, monkeypatch
+    ):
+        from tests.helpers.test_data import make_mock_family_space
+        family = make_mock_family_space()
+        user = make_mock_user()
+        _seed_user_lookup(mock_prisma, user, family)
+        mock_prisma.user.delete = AsyncMock(return_value=None)
+
+        response = client.request(
+            "DELETE",
+            "/v1/me/delete",
+            json={"currentPassword": "x", "confirmation": "delete-please"},
+            headers=_bearer_headers(user.id, family.id),
+        )
+
+        assert_error_envelope(
+            response,
+            status_code=400,
+            code="VALIDATION_ERROR",
+            message_contains="DELETE",
+        )
+        mock_prisma.user.delete.assert_not_called()
+
+    def test_case_insensitive_confirmation_is_accepted(
+        self, client, mock_prisma, monkeypatch
+    ):
+        # Matches the Next handler's `val.toUpperCase() === 'DELETE'`
+        # behaviour after trim.
+        from tests.helpers.test_data import make_mock_family_space
+        family = make_mock_family_space()
+        user = make_mock_user()
+        _seed_user_lookup(mock_prisma, user, family)
+        mock_prisma.user.delete = AsyncMock(return_value=None)
+        monkeypatch.setattr("src.routers.v1.me.verify_password", lambda *_: True)
+
+        response = client.request(
+            "DELETE",
+            "/v1/me/delete",
+            json={"currentPassword": "x", "confirmation": "  delete  "},
+            headers=_bearer_headers(user.id, family.id),
+        )
+        assert response.status_code == 204
+        mock_prisma.user.delete.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Password verification
+# ---------------------------------------------------------------------------
+
+
+class TestPasswordVerification:
+    def test_wrong_password_returns_401_invalid_credentials(
+        self, client, mock_prisma, monkeypatch
+    ):
+        from tests.helpers.test_data import make_mock_family_space
+        family = make_mock_family_space()
+        user = make_mock_user(passwordHash="$2b$10$real-hash")
+        _seed_user_lookup(mock_prisma, user, family)
+        mock_prisma.user.delete = AsyncMock(return_value=None)
+        # Force verify_password to false to simulate a wrong password
+        # without needing real bcrypt rounds in the test.
+        monkeypatch.setattr("src.routers.v1.me.verify_password", lambda *_: False)
+
+        response = client.request(
+            "DELETE",
+            "/v1/me/delete",
+            json=_VALID_PAYLOAD,
+            headers=_bearer_headers(user.id, family.id),
+        )
+
+        assert_error_envelope(
+            response, status_code=401, code="INVALID_CREDENTIALS"
+        )
+        # Critical: the delete must NOT fire on a bad password.
+        mock_prisma.user.delete.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    def test_member_delete_returns_204_no_body(
+        self, client, mock_prisma, monkeypatch
+    ):
+        from tests.helpers.test_data import make_mock_family_space
+        family = make_mock_family_space()
+        user = make_mock_user(id="user_to_delete")
+        _seed_user_lookup(mock_prisma, user, family)
+        mock_prisma.user.delete = AsyncMock(return_value=None)
+        monkeypatch.setattr("src.routers.v1.me.verify_password", lambda *_: True)
+
+        response = client.request(
+            "DELETE",
+            "/v1/me/delete",
+            json=_VALID_PAYLOAD,
+            headers=_bearer_headers(user.id, family.id),
+        )
+
+        assert response.status_code == 204
+        # 204 must have no body; FastAPI/Starlette enforces this but we
+        # also assert it because the contract is documented.
+        assert response.content == b""
+
+    def test_delete_targets_caller_only(
+        self, client, mock_prisma, monkeypatch
+    ):
+        from tests.helpers.test_data import make_mock_family_space
+        family = make_mock_family_space()
+        user = make_mock_user(id="user_to_delete")
+        _seed_user_lookup(mock_prisma, user, family)
+        mock_prisma.user.delete = AsyncMock(return_value=None)
+        monkeypatch.setattr("src.routers.v1.me.verify_password", lambda *_: True)
+
+        client.request(
+            "DELETE",
+            "/v1/me/delete",
+            json=_VALID_PAYLOAD,
+            headers=_bearer_headers(user.id, family.id),
+        )
+
+        # The single delete call targets the caller's user id and
+        # nothing else. Family-scoping is irrelevant at this call site
+        # (the user row is unique by id), and cascade fan-out happens
+        # in Postgres — see the router docstring.
+        mock_prisma.user.delete.assert_awaited_once_with(
+            where={"id": user.id}
+        )
+
+    def test_response_clears_refresh_and_csrf_cookies(
+        self, client, mock_prisma, monkeypatch
+    ):
+        from tests.helpers.test_data import make_mock_family_space
+        family = make_mock_family_space()
+        user = make_mock_user()
+        _seed_user_lookup(mock_prisma, user, family)
+        mock_prisma.user.delete = AsyncMock(return_value=None)
+        monkeypatch.setattr("src.routers.v1.me.verify_password", lambda *_: True)
+
+        response = client.request(
+            "DELETE",
+            "/v1/me/delete",
+            json=_VALID_PAYLOAD,
+            headers=_bearer_headers(user.id, family.id),
+        )
+
+        assert response.status_code == 204
+        # Starlette serializes a cookie-clear as a Set-Cookie header
+        # with an empty value and Max-Age=0 (or expires in the past).
+        # We just assert both cookie names appear in Set-Cookie; the
+        # cookie-attribute correctness is covered by tests in
+        # test_auth_v1.py for /v1/auth/logout, which uses the same
+        # helpers.
+        set_cookies = response.headers.get_list("set-cookie")
+        assert any(
+            settings.refresh_cookie_name in c for c in set_cookies
+        ), f"refresh cookie not cleared: {set_cookies}"
+        assert any(
+            settings.csrf_cookie_name in c for c in set_cookies
+        ), f"csrf cookie not cleared: {set_cookies}"
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPaths:
+    def test_user_lookup_returns_none_yields_404(
+        self, client, mock_prisma, monkeypatch
+    ):
+        # Race condition: the bearer dep resolved the user, but the
+        # handler's own find_unique returns None (e.g. concurrent
+        # delete won the race). We surface 404 because the requested
+        # post-condition is already satisfied; treating this as 500
+        # would mislead operators investigating logs.
+        from tests.helpers.test_data import make_mock_family_space
+        family = make_mock_family_space()
+        user = make_mock_user(memberships=[
+            make_mock_membership(
+                userId="user_test", familySpaceId=family.id,
+                role="member", familySpace=family,
+            )
+        ])
+        mock_prisma.user.find_unique = AsyncMock(
+            side_effect=[user, None]  # bearer dep ok, handler lookup gone
+        )
+        mock_prisma.user.delete = AsyncMock(return_value=None)
+
+        response = client.request(
+            "DELETE",
+            "/v1/me/delete",
+            json=_VALID_PAYLOAD,
+            headers=_bearer_headers(user.id, family.id),
+        )
+
+        assert_error_envelope(response, status_code=404, code="NOT_FOUND")
+        mock_prisma.user.delete.assert_not_called()
+
+    def test_prisma_delete_failure_returns_500(
+        self, client, mock_prisma, monkeypatch
+    ):
+        from prisma.errors import PrismaError
+        from tests.helpers.test_data import make_mock_family_space
+        family = make_mock_family_space()
+        user = make_mock_user()
+        _seed_user_lookup(mock_prisma, user, family)
+        mock_prisma.user.delete = AsyncMock(
+            side_effect=PrismaError("FK violation in a downstream cascade")
+        )
+        monkeypatch.setattr("src.routers.v1.me.verify_password", lambda *_: True)
+
+        response = client.request(
+            "DELETE",
+            "/v1/me/delete",
+            json=_VALID_PAYLOAD,
+            headers=_bearer_headers(user.id, family.id),
+        )
+
+        assert_error_envelope(response, status_code=500, code="INTERNAL_ERROR")
+
+    def test_prisma_lookup_failure_returns_500(
+        self, client, mock_prisma, monkeypatch
+    ):
+        # The bearer dep's lookup succeeds (mock returns a user), then
+        # the handler's own lookup raises — covers the lookup-side
+        # PrismaError path independently from the delete-side one.
+        from prisma.errors import PrismaError
+        from tests.helpers.test_data import make_mock_family_space
+        family = make_mock_family_space()
+        user = make_mock_user(memberships=[
+            make_mock_membership(
+                userId="user_test", familySpaceId=family.id,
+                role="member", familySpace=family,
+            )
+        ])
+        mock_prisma.user.find_unique = AsyncMock(
+            side_effect=[user, PrismaError("connection lost")]
+        )
+        mock_prisma.user.delete = AsyncMock(return_value=None)
+
+        response = client.request(
+            "DELETE",
+            "/v1/me/delete",
+            json=_VALID_PAYLOAD,
+            headers=_bearer_headers(user.id, family.id),
+        )
+
+        assert_error_envelope(response, status_code=500, code="INTERNAL_ERROR")
+        mock_prisma.user.delete.assert_not_called()

--- a/apps/api/tests/integration/test_v1_aliases.py
+++ b/apps/api/tests/integration/test_v1_aliases.py
@@ -48,6 +48,13 @@ V1_ONLY_PATHS: frozenset[str] = frozenset(
         # would force two auth modes onto one router; see
         # routers/v1/recipes.py module docstring.
         "/v1/recipes/import",
+        # /v1/me/delete (issue #186) is Bearer-token only. The legacy
+        # cookie-auth twin lives at /api/me/delete in the Next monolith,
+        # not on this FastAPI service — the unprefixed FastAPI me
+        # router (routers/me.py) intentionally does NOT expose delete
+        # to avoid mounting a destructive endpoint behind two auth modes.
+        # See routers/v1/me.py module docstring.
+        "/v1/me/delete",
     }
 )
 


### PR DESCRIPTION
Closes #186.

## What

Adds `DELETE /v1/me/delete` to the FastAPI v1 namespace, mirroring the Next handler at [src/app/api/me/delete/route.ts](src/app/api/me/delete/route.ts) so Phase 4 (#38) can retire the Next route. Bearer-token auth via `get_current_user_v1`.

## Behaviour

| Condition | Status | Code |
|---|---|---|
| Owner / admin role | 403 | `FORBIDDEN` (matches Next handler) |
| Missing / malformed bearer | 401 | `UNAUTHORIZED` |
| Missing `currentPassword` or `confirmation` | 400 | `VALIDATION_ERROR` |
| `confirmation` ≠ "DELETE" (case-insensitive, trim) | 400 | `VALIDATION_ERROR` |
| Wrong password | 401 | `INVALID_CREDENTIALS` |
| Concurrent-delete race (user gone before our lookup) | 404 | `NOT_FOUND` |
| Prisma error during lookup/delete | 500 | `INTERNAL_ERROR` |
| **Success** | **204** | **No Content** + `refresh_token` + `csrf_token` cookies cleared |

## Cascade — the destructive bit

`prisma.user.delete(where={id})` fires Postgres-side cascades declared in [prisma/schema.postgres.prisma](prisma/schema.postgres.prisma). This is **exactly what the Next handler does** — both surfaces hand the work to the schema, neither hand-rolls a transaction. The full per-relation table is in the module docstring of [apps/api/src/routers/v1/me.py](apps/api/src/routers/v1/me.py); summary:

- `Cascade` on: `FamilyMembership`, `Post.author`, `Comment.author`, `Reaction`, `CookedEvent`, `Favorite`, `Notification.recipient`/`actor`, `RefreshToken`, `IdempotencyKey`
- `SetNull` on: `FeedbackSubmission.userId` (anonymizes bug/suggestion log — intentional)

Note: the cascade **hard-deletes** refresh-token rows (not "revoked"); the AC says "all refresh tokens for the caller are revoked" but the end-state is strictly stronger — any subsequent `/v1/auth/refresh` lookup returns null → 401 either way. I deliberately did **not** run an `update_many(...revokedReason)` before the delete because that would race with the cascade and leave orphan rows.

## Contract divergences from the Next handler (intentional)

Two — both following the AC in #186 rather than the legacy behaviour. Documented in the router module docstring so the reasoning survives this PR.

1. **204 No Content** instead of Next's `200 { status: 'deleted' }`. The AC explicitly specifies 204; SPA-side this is a no-op since any 2xx clears in-memory auth state.
2. **Clears `refresh_token` + `csrf_token`** (v1 auth model) instead of the legacy single `session` cookie. Different auth model, different cookies; the legacy cookie is owned by the still-alive Next handler at `/api/me/delete`.

## V1-only (no dual-mount)

Same rationale as `/v1/feedback`, `/v1/notifications/*`, `/v1/recipes/import`: bearer-only, and the cookie-auth twin is the Next handler at `/api/me/delete`. Adding a delete to the unprefixed FastAPI me router would force two auth modes onto one router and (worse) expose a destructive endpoint behind cookie auth on FastAPI for no caller benefit. Added `/v1/me/delete` to `V1_ONLY_PATHS` in [apps/api/tests/integration/test_v1_aliases.py](apps/api/tests/integration/test_v1_aliases.py) with the same rationale comment as the others.

## Testing

`pytest tests/ --ignore=tests/unit/test_multipart_uploads.py` → **504 passed** locally. `ruff check src tests` → clean.

The new file `tests/integration/test_me_v1_delete.py` adds 16 tests:

- **Unauthenticated** (3): no bearer, malformed bearer, legacy `session` cookie does not authenticate v1
- **Role guard** (2): owner forbidden, admin forbidden — delete call never fires
- **Request validation** (4): missing password, missing confirmation, wrong phrase rejected, case-insensitive `"  delete  "` accepted
- **Password verification** (1): wrong password → 401, delete call never fires
- **Happy path** (3): 204 with no body, `prisma.user.delete` called exactly once with `{id}`, both cookies cleared in `Set-Cookie`
- **Error paths** (3): user-vanished-mid-request → 404, prisma delete error → 500, prisma lookup error → 500

Cascade behaviour itself is not asserted by these tests — mock-Prisma can't faithfully reproduce a multi-row cascade. It's enforced by the live schema and verified by the existing CI's Prisma validate job.

## OpenAPI snapshot

Regenerated. Diff is two additions only (`DeleteAccountRequest` schema + `/v1/me/delete` path) — no unrelated churn.

## Files

- `apps/api/src/routers/v1/me.py` — new router (the handler + module docstring carrying the full cascade table and divergence rationale)
- `apps/api/src/schemas/auth.py` — new `DeleteAccountRequest`
- `apps/api/src/main.py` — wire router in
- `apps/api/tests/integration/test_me_v1_delete.py` — new test file
- `apps/api/tests/integration/test_v1_aliases.py` — `/v1/me/delete` added to `V1_ONLY_PATHS`
- `apps/api/tests/integration/conftest.py` — added `src.routers.v1.me.prisma` to the mock patch list
- `apps/api/openapi.snapshot.json` — regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
