### PR TITLE
chore(api): EmailStr for /v1/auth/* request schemas (parity with Next Zod) (#205)

### DIFF
--- a/apps/api/openapi.snapshot.json
+++ b/apps/api/openapi.snapshot.json
@@ -898,8 +898,8 @@
         "description": "Master-key-gated password reset \u2014 mirrors the Next handler at\n`src/app/api/auth/reset/route.ts`.\n\nNo email/token flow: the caller proves identity by supplying the family\nmaster key. Aligned with what's deployed today; a token-based flow is\ndeferred to a future ticket gated on email infrastructure.",
         "properties": {
           "email": {
+            "format": "email",
             "maxLength": 200,
-            "minLength": 3,
             "title": "Email",
             "type": "string"
           },
@@ -939,8 +939,8 @@
       "SignupRequest": {
         "properties": {
           "email": {
+            "format": "email",
             "maxLength": 200,
-            "minLength": 3,
             "title": "Email",
             "type": "string"
           },

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -1,6 +1,7 @@
 fastapi==0.125.0
 uvicorn[standard]==0.32.0
 prisma==0.15.0
+email-validator==2.2.0
 PyJWT==2.12.0
 bcrypt==4.1.2
 pydantic-settings==2.7.0

--- a/apps/api/src/schemas/auth.py
+++ b/apps/api/src/schemas/auth.py
@@ -1,11 +1,17 @@
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, EmailStr, Field
 
 
 class SignupRequest(BaseModel):
     name: str = Field(min_length=1, max_length=200)
-    email: str = Field(min_length=3, max_length=200)
+    # `EmailStr` enforces RFC-shape parity with Next's `z.string().email()`
+    # in src/lib/validation.ts, so malformed addresses fail at the validation
+    # boundary (400 VALIDATION_ERROR) instead of reaching the DB lookup.
+    # Side-effect: the validator strips surrounding whitespace and lowercases
+    # the domain part — the handler's existing `.strip()` was already
+    # tolerating whitespace, and domain-case-insensitivity is RFC-correct.
+    email: EmailStr = Field(max_length=200)
     username: str = Field(min_length=3, max_length=30, pattern=r"^[a-zA-Z0-9_]+$")
     password: str = Field(min_length=6, max_length=200)
     familyMasterKey: str = Field(min_length=6, max_length=200)
@@ -13,6 +19,9 @@ class SignupRequest(BaseModel):
 
 
 class LoginRequest(BaseModel):
+    # Intentionally a plain `str` — this field accepts either an email or a
+    # username, mirroring Next's `z.string().min(3)` in `loginSchema`. Using
+    # `EmailStr` here would reject perfectly valid username logins.
     emailOrUsername: str = Field(min_length=3, max_length=200)
     password: str = Field(min_length=6, max_length=200)
     rememberMe: bool = False
@@ -44,7 +53,10 @@ class ResetPasswordRequest(BaseModel):
     master key. Aligned with what's deployed today; a token-based flow is
     deferred to a future ticket gated on email infrastructure.
     """
-    email: str = Field(min_length=3, max_length=200)
+    # See `SignupRequest.email` for the rationale on using `EmailStr` —
+    # malformed addresses now fail at validation with 400 VALIDATION_ERROR
+    # instead of falling through to the DB lookup and 401 INVALID_CREDENTIALS.
+    email: EmailStr = Field(max_length=200)
     masterKey: str = Field(min_length=1, max_length=200)
     newPassword: str = Field(min_length=8, max_length=200)
 

--- a/apps/api/src/schemas/auth.py
+++ b/apps/api/src/schemas/auth.py
@@ -19,9 +19,11 @@ class SignupRequest(BaseModel):
 
 
 class LoginRequest(BaseModel):
-    # Intentionally a plain `str` — this field accepts either an email or a
-    # username, mirroring Next's `z.string().min(3)` in `loginSchema`. Using
-    # `EmailStr` here would reject perfectly valid username logins.
+    # Intentionally a plain `str`, not `EmailStr` — this field accepts
+    # either an email OR a username (see `loginSchema.emailOrUsername` in
+    # src/lib/validation.ts), and `EmailStr` would reject perfectly valid
+    # username logins. The `min_length=3` is a pre-existing divergence
+    # from Next's `z.string().min(1)`, tracked separately in #211.
     emailOrUsername: str = Field(min_length=3, max_length=200)
     password: str = Field(min_length=6, max_length=200)
     rememberMe: bool = False

--- a/apps/api/tests/integration/test_auth_v1.py
+++ b/apps/api/tests/integration/test_auth_v1.py
@@ -158,6 +158,29 @@ class TestV1Signup:
         assert settings.refresh_cookie_name in cookie_header
         assert settings.csrf_cookie_name in cookie_header
 
+    def test_signup_malformed_email_returns_400_validation_error(
+        self, client, mock_prisma
+    ):
+        # `EmailStr` enforces RFC shape at the validation boundary so a
+        # bogus address never reaches the user-lookup branch in the handler.
+        # Mirrors Next's `z.string().email()` rejection in `signupSchema`.
+        response = client.post(
+            "/v1/auth/signup",
+            json={
+                "name": "New User",
+                "email": "not-an-email",
+                "username": "newuser",
+                "password": "password123",
+                "familyMasterKey": "secret-key",
+                "rememberMe": False,
+            },
+        )
+
+        assert response.status_code == 400
+        assert response.json()["error"]["code"] == "VALIDATION_ERROR"
+        # Bail-out before any DB work — proves we short-circuited at validation.
+        mock_prisma.user.find_first.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # /v1/auth/me — access-token bearer auth
@@ -570,6 +593,21 @@ class TestV1Reset:
         )
         assert response.status_code == 400
         assert response.json()["error"]["code"] == "VALIDATION_ERROR"
+
+    def test_reset_malformed_email_returns_400_validation_error(
+        self, client, mock_prisma
+    ):
+        # Parity with Next's `z.string().email()` in resetPasswordSchema.
+        # Before #205, the FastAPI schema accepted any min-length-3 string and
+        # the bad email fell through to `find_unique` → INVALID_CREDENTIALS,
+        # which leaked the existence-or-not of malformed inputs as a 401.
+        response = client.post(
+            "/v1/auth/reset",
+            json={**self._VALID_PAYLOAD, "email": "not-an-email"},
+        )
+        assert response.status_code == 400
+        assert response.json()["error"]["code"] == "VALIDATION_ERROR"
+        mock_prisma.user.find_unique.assert_not_called()
 
     def test_reset_missing_field_returns_400_validation_error(self, client):
         response = client.post(


### PR DESCRIPTION
Closes #205.

## What

Tighten the `email` field on `SignupRequest` and `ResetPasswordRequest` from a raw `str` to `pydantic.EmailStr` so the FastAPI validation layer rejects malformed addresses up-front, matching Next's `z.string().email()` in [src/lib/validation.ts](src/lib/validation.ts).

Surfaced from the [PR #204 review](https://github.com/wnorowskie/family-recipe/pull/204#issuecomment-4432316979) as a project-wide parity gap, not a regression in that PR.

## Why

Before this change, the FastAPI auth schemas accepted strings like `"not-an-email"` and the bogus value fell through to the DB lookup before failing with `INVALID_CREDENTIALS`. Worse, on signup, a malformed email could silently match a username via the `OR` clause in `find_first`. Now malformed addresses fail at the validation boundary with a clean `400 VALIDATION_ERROR` envelope — exactly what Next does.

## Scope

- ✅ `SignupRequest.email` → `EmailStr`
- ✅ `ResetPasswordRequest.email` → `EmailStr`
- ⏭️ `LoginRequest.emailOrUsername` stays a plain `str` — it accepts an email OR a username, mirroring Next's `z.string().min(3)` in `loginSchema`. Documented inline so the inconsistency reads as intentional.
- ⏭️ Legacy `apps/api/src/routers/auth.py` (session-cookie endpoints) — slated for Phase 4 removal (#38), not worth churning.

## Behavioral notes

- **Whitespace tolerance preserved.** `EmailStr` strips surrounding whitespace before validation, and the handler additionally calls `.strip()`. The existing `test_reset_trims_email_whitespace_before_lookup` test still passes unchanged.
- **Domain case is now normalized.** `EmailStr` lowercases the domain part (`TEST@Example.COM` → `TEST@example.com`); the local part keeps its case. This is RFC-correct and matches what every modern email provider does on delivery. In a single-family beta with lowercase test fixtures this is a no-op in practice but is the one observable delta vs Next.

## OpenAPI snapshot diff

```diff
-            "minLength": 3,
+            "format": "email",
             "maxLength": 200,
```

Affects `SignupRequest.email` and `ResetPasswordRequest.email`. The `format: email` constraint subsumes `minLength: 3`.

## Tests

- **New:** `test_signup_malformed_email_returns_400_validation_error` — `POST /v1/auth/signup` with `email="not-an-email"` returns `400 VALIDATION_ERROR` and never reaches `prisma.user.find_first`.
- **New:** `test_reset_malformed_email_returns_400_validation_error` — `POST /v1/auth/reset` with `email="not-an-email"` returns `400 VALIDATION_ERROR` and never reaches `prisma.user.find_unique`.
- **All 516 FastAPI tests pass**, including the existing whitespace-trim and happy-path cases.
- **All 1059 Next.js tests pass** (`npm test`) — no Next-side code changed.
- `ruff check .` clean.

## Verification

Followed [docs/verification/fastapi.md](docs/verification/fastapi.md):
- `pytest tests/` — 516 passed
- `ruff check .` — clean
- OpenAPI snapshot regenerated via `python scripts/dump_openapi.py > openapi.snapshot.json`
- Skipped mypy locally per project memory (`feedback_mypy_local_stall.md`); CI's `api-ci.yml` mypy job will validate.
- Did not run the L0 curl smoke against a live sandbox — this is a pure schema tightening with full integration coverage exercising the validation path, no runtime behavior change in the handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)