### PR TITLE
chore(api): Phase 3-C2 — payload key alignment (signup name, profile avatar, password keys) (#188)

### DIFF
--- a/apps/api/openapi.snapshot.json
+++ b/apps/api/openapi.snapshot.json
@@ -1060,19 +1060,19 @@
           },
           "familyMasterKey": {
             "maxLength": 200,
-            "minLength": 6,
+            "minLength": 1,
             "title": "Familymasterkey",
             "type": "string"
           },
           "name": {
-            "maxLength": 200,
+            "maxLength": 100,
             "minLength": 1,
             "title": "Name",
             "type": "string"
           },
           "password": {
             "maxLength": 200,
-            "minLength": 6,
+            "minLength": 8,
             "title": "Password",
             "type": "string"
           },
@@ -1530,8 +1530,9 @@
       }
     },
     "/me/password": {
-      "put": {
-        "operationId": "change_password_me_password_put",
+      "post": {
+        "description": "Change the current user's password.\n\n`POST` (not `PUT`) and the `{ status: 'updated' }` response body mirror\nNext's `src/app/api/me/password/route.ts` so the Phase-2 frontend can swap\nto the FastAPI base URL in Phase 4 (#38) without an adapter shim \u2014 see\n#188. On success the legacy `session` cookie is cleared, matching Next's\n`clearSessionCookie` call, so the next request re-authenticates.\n\nBody keys are `currentPassword` / `newPassword` \u2014 the live Next contract\nand what `AccountSettingsForm` sends. (The migration plan's `nextPassword`\nis stale and was never shipped on either side.)",
+        "operationId": "change_password_me_password_post",
         "requestBody": {
           "content": {
             "application/json": {
@@ -3329,8 +3330,9 @@
       }
     },
     "/v1/me/password": {
-      "put": {
-        "operationId": "change_password_v1_me_password_put",
+      "post": {
+        "description": "Change the current user's password.\n\n`POST` (not `PUT`) and the `{ status: 'updated' }` response body mirror\nNext's `src/app/api/me/password/route.ts` so the Phase-2 frontend can swap\nto the FastAPI base URL in Phase 4 (#38) without an adapter shim \u2014 see\n#188. On success the legacy `session` cookie is cleared, matching Next's\n`clearSessionCookie` call, so the next request re-authenticates.\n\nBody keys are `currentPassword` / `newPassword` \u2014 the live Next contract\nand what `AccountSettingsForm` sends. (The migration plan's `nextPassword`\nis stale and was never shipped on either side.)",
+        "operationId": "change_password_v1_me_password_post",
         "requestBody": {
           "content": {
             "application/json": {

--- a/apps/api/src/routers/me.py
+++ b/apps/api/src/routers/me.py
@@ -259,8 +259,24 @@ async def update_profile(
         return internal_error("Failed to update profile")
 
 
-@router.put("/password")
-async def change_password(payload: dict, user: UserResponse = Depends(get_current_user)):
+@router.post("/password")
+async def change_password(
+    payload: dict,
+    response: Response,
+    user: UserResponse = Depends(get_current_user),
+):
+    """Change the current user's password.
+
+    `POST` (not `PUT`) and the `{ status: 'updated' }` response body mirror
+    Next's `src/app/api/me/password/route.ts` so the Phase-2 frontend can swap
+    to the FastAPI base URL in Phase 4 (#38) without an adapter shim — see
+    #188. On success the legacy `session` cookie is cleared, matching Next's
+    `clearSessionCookie` call, so the next request re-authenticates.
+
+    Body keys are `currentPassword` / `newPassword` — the live Next contract
+    and what `AccountSettingsForm` sends. (The migration plan's `nextPassword`
+    is stale and was never shipped on either side.)
+    """
     current_password = payload.get("currentPassword")
     new_password = payload.get("newPassword")
     if not isinstance(current_password, str) or not current_password:
@@ -277,7 +293,8 @@ async def change_password(payload: dict, user: UserResponse = Depends(get_curren
             where={"id": user.id},
             data={"passwordHash": hash_password(new_password)},
         )
-        return {"message": "Password updated"}
+        clear_session_cookie(response)
+        return {"status": "updated"}
     except PrismaError:
         return internal_error("Failed to update password")
     except (ValueError, TypeError, AttributeError, KeyError):

--- a/apps/api/src/schemas/auth.py
+++ b/apps/api/src/schemas/auth.py
@@ -4,7 +4,10 @@ from pydantic import BaseModel, EmailStr, Field
 
 
 class SignupRequest(BaseModel):
-    name: str = Field(min_length=1, max_length=200)
+    # Constraints mirror `signupSchema` in src/lib/validation.ts field-for-field
+    # so a frontend client sees identical validation regardless of which backend
+    # it points at — see #188 (payload key alignment).
+    name: str = Field(min_length=1, max_length=100)
     # `EmailStr` enforces RFC-shape parity with Next's `z.string().email()`
     # in src/lib/validation.ts, so malformed addresses fail at the validation
     # boundary (400 VALIDATION_ERROR) instead of reaching the DB lookup.
@@ -13,8 +16,14 @@ class SignupRequest(BaseModel):
     # tolerating whitespace, and domain-case-insensitivity is RFC-correct.
     email: EmailStr = Field(max_length=200)
     username: str = Field(min_length=3, max_length=30, pattern=r"^[a-zA-Z0-9_]+$")
-    password: str = Field(min_length=6, max_length=200)
-    familyMasterKey: str = Field(min_length=6, max_length=200)
+    # `min_length=8` mirrors Next's `z.string().min(8)`. The Next side has no
+    # explicit max; the 200 cap here is a defensive bound, not a parity field.
+    password: str = Field(min_length=8, max_length=200)
+    # Next's `z.string().min(1)` — the master key is verified by bcrypt compare
+    # against the env hash, so length is not a security boundary here; a too-short
+    # key simply fails the compare. Accepting it at the validation layer matches
+    # Next so the error surfaces as "Invalid Family Master Key", not a 400.
+    familyMasterKey: str = Field(min_length=1, max_length=200)
     rememberMe: bool = False
 
 

--- a/apps/api/tests/integration/test_me.py
+++ b/apps/api/tests/integration/test_me.py
@@ -248,17 +248,20 @@ def test_change_password_success(client, mock_prisma, member_auth, prisma_user_w
     monkeypatch.setattr("src.routers.me.verify_password", fake_verify)
     monkeypatch.setattr("src.routers.me.hash_password", fake_hash)
 
-    response = client.put(
+    response = client.post(
         "/me/password",
         headers=member_auth,
         json={"currentPassword": "oldpass", "newPassword": "newpassword"},
     )
 
     assert response.status_code == 200
-    assert response.json() == {"message": "Password updated"}
+    # Response shape mirrors Next's `{ status: 'updated' }` (see #188).
+    assert response.json() == {"status": "updated"}
     assert captured["verified"] == ("oldpass", "stored")
     updated_data = mock_prisma.user.update.await_args.kwargs["data"]
     assert updated_data["passwordHash"] == "hashed:newpassword"
+    # Session cookie is cleared on success, matching Next's clearSessionCookie.
+    assert "session=" in response.headers.get("set-cookie", "")
 
 
 def test_change_password_wrong_current_400(client, mock_prisma, member_auth, prisma_user_with_membership, monkeypatch):
@@ -277,7 +280,7 @@ def test_change_password_wrong_current_400(client, mock_prisma, member_auth, pri
 
     monkeypatch.setattr("src.routers.me.verify_password", fake_verify)
 
-    response = client.put(
+    response = client.post(
         "/me/password",
         headers=member_auth,
         json={"currentPassword": "oldpass", "newPassword": "newpassword"},
@@ -289,7 +292,7 @@ def test_change_password_wrong_current_400(client, mock_prisma, member_auth, pri
 
 
 def test_change_password_too_short_400(client, member_auth):
-    response = client.put(
+    response = client.post(
         "/me/password",
         headers=member_auth,
         json={"currentPassword": "oldpass", "newPassword": "short"},
@@ -300,7 +303,7 @@ def test_change_password_too_short_400(client, member_auth):
 
 
 def test_change_password_missing_current_400(client, member_auth):
-    response = client.put(
+    response = client.post(
         "/me/password",
         headers=member_auth,
         json={"newPassword": "newpassword"},
@@ -311,7 +314,7 @@ def test_change_password_missing_current_400(client, member_auth):
 
 
 def test_change_password_missing_new_400(client, member_auth):
-    response = client.put(
+    response = client.post(
         "/me/password",
         headers=member_auth,
         json={"currentPassword": "oldpass"},
@@ -322,6 +325,6 @@ def test_change_password_missing_new_400(client, member_auth):
 
 
 def test_change_password_requires_auth(client):
-    response = client.put("/me/password", json={"currentPassword": "old", "newPassword": "newpassword"})
+    response = client.post("/me/password", json={"currentPassword": "old", "newPassword": "newpassword"})
 
     assert response.status_code == 401


### PR DESCRIPTION
## Summary

- **Signup** — `SignupRequest` constraints now mirror `signupSchema` in `src/lib/validation.ts` field-for-field: `name` `max_length` 200→100, `password` `min_length` 6→8, `familyMasterKey` `min_length` 6→1. Frontend already sends a single `name` field, so no frontend change.
- **Password change** — `change_password` is now `POST /me/password` (was `PUT`), returns `{ status: 'updated' }` (was `{ message: ... }`), and clears the legacy `session` cookie on success — all matching Next's `src/app/api/me/password/route.ts`. Dual-mount makes this `POST /v1/me/password` too. The migration plan's `{ currentPassword, nextPassword }` is stale; both Next and `AccountSettingsForm` ship `newPassword`, which is the canonical key.
- **Profile avatar** (`PATCH /v1/me/profile`) — already aligned by #187 (multipart part name `avatar`, flat form fields, `user.avatarUrl` response). No change needed; verified during this work.
- Regenerated `apps/api/openapi.snapshot.json` — diff is the intended deltas only (3 SignupRequest constraint changes + `put`→`post` on `/me/password` and `/v1/me/password`).

This is the FastAPI side of the alignment — Next was the live contract the frontend already depends on, so no `src/` changes were required.

### Scope note

The ticket scoped signup to "name fields," but `password` and `familyMasterKey` had the same class of constraint drift. Per direction on the issue, all three signup divergences are fixed here so the signup surface is fully aligned in one pass.

## Closes

Closes #188

## Test notes

- `cd apps/api && ruff check src/ tests/` — clean.
- `python -m pytest tests/` — **530 passed**. Updated the 6 `test_me.py` password tests for the `POST` verb + `{ status: 'updated' }` body, and added a `set-cookie: session=` assertion on the success path. No signup test broke (existing fixtures use `password123` / `secret-key`, both within the tightened bounds).
- `python scripts/dump_openapi.py | diff - openapi.snapshot.json` — clean (CI's `openapi-diff` gate will pass).
- Not run: live dev-server smoke (signup / profile / password round-trip via the shared API client). Unit + integration coverage exercises the changed contract; recommend a manual smoke during release verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)