### PR TITLE
chore(api): replace payload:dict with Pydantic ChangePasswordRequest (#216)

### DIFF
--- a/apps/api/openapi.snapshot.json
+++ b/apps/api/openapi.snapshot.json
@@ -293,6 +293,29 @@
         "title": "Body_update_profile_multipart_v1_me_profile_patch",
         "type": "object"
       },
+      "ChangePasswordRequest": {
+        "description": "Self-service password-change payload \u2014 mirrors\n`changePasswordSchema` in `src/lib/validation.ts`.\n\nReplaces the hand-rolled `payload: dict` + `isinstance` checks that\npreviously kept the request body out of the OpenAPI snapshot (#216).\nThe \"current password is incorrect\" branch stays in the handler \u2014 that\nis a bcrypt verify failure, not a schema validation failure.",
+        "properties": {
+          "currentPassword": {
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Currentpassword",
+            "type": "string"
+          },
+          "newPassword": {
+            "maxLength": 200,
+            "minLength": 8,
+            "title": "Newpassword",
+            "type": "string"
+          }
+        },
+        "required": [
+          "currentPassword",
+          "newPassword"
+        ],
+        "title": "ChangePasswordRequest",
+        "type": "object"
+      },
       "CookedRequest": {
         "properties": {
           "note": {
@@ -1531,15 +1554,13 @@
     },
     "/me/password": {
       "post": {
-        "description": "Change the current user's password.\n\n`POST` (not `PUT`) and the `{ status: 'updated' }` response body mirror\nNext's `src/app/api/me/password/route.ts` so the Phase-2 frontend can swap\nto the FastAPI base URL in Phase 4 (#38) without an adapter shim \u2014 see\n#188. On success the legacy `session` cookie is cleared, matching Next's\n`clearSessionCookie` call, so the next request re-authenticates.\n\nBody keys are `currentPassword` / `newPassword` \u2014 the live Next contract\nand what `AccountSettingsForm` sends. (The migration plan's `nextPassword`\nis stale and was never shipped on either side.)",
+        "description": "Change the current user's password.\n\n`POST` (not `PUT`) and the `{ status: 'updated' }` response body mirror\nNext's `src/app/api/me/password/route.ts` so the Phase-2 frontend can swap\nto the FastAPI base URL in Phase 4 (#38) without an adapter shim \u2014 see\n#188. On success the legacy `session` cookie is cleared, matching Next's\n`clearSessionCookie` call, so the next request re-authenticates.\n\nBody keys are `currentPassword` / `newPassword` \u2014 the live Next contract\nand what `AccountSettingsForm` sends. (The migration plan's `nextPassword`\nis stale and was never shipped on either side.) Body shape is validated\nvia `ChangePasswordRequest`; missing/short fields surface as the standard\n`VALIDATION_ERROR` envelope through `_validation_error_handler` (#216).",
         "operationId": "change_password_me_password_post",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "additionalProperties": true,
-                "title": "Payload",
-                "type": "object"
+                "$ref": "#/components/schemas/ChangePasswordRequest"
               }
             }
           },
@@ -3331,15 +3352,13 @@
     },
     "/v1/me/password": {
       "post": {
-        "description": "Change the current user's password.\n\n`POST` (not `PUT`) and the `{ status: 'updated' }` response body mirror\nNext's `src/app/api/me/password/route.ts` so the Phase-2 frontend can swap\nto the FastAPI base URL in Phase 4 (#38) without an adapter shim \u2014 see\n#188. On success the legacy `session` cookie is cleared, matching Next's\n`clearSessionCookie` call, so the next request re-authenticates.\n\nBody keys are `currentPassword` / `newPassword` \u2014 the live Next contract\nand what `AccountSettingsForm` sends. (The migration plan's `nextPassword`\nis stale and was never shipped on either side.)",
+        "description": "Change the current user's password.\n\n`POST` (not `PUT`) and the `{ status: 'updated' }` response body mirror\nNext's `src/app/api/me/password/route.ts` so the Phase-2 frontend can swap\nto the FastAPI base URL in Phase 4 (#38) without an adapter shim \u2014 see\n#188. On success the legacy `session` cookie is cleared, matching Next's\n`clearSessionCookie` call, so the next request re-authenticates.\n\nBody keys are `currentPassword` / `newPassword` \u2014 the live Next contract\nand what `AccountSettingsForm` sends. (The migration plan's `nextPassword`\nis stale and was never shipped on either side.) Body shape is validated\nvia `ChangePasswordRequest`; missing/short fields surface as the standard\n`VALIDATION_ERROR` envelope through `_validation_error_handler` (#216).",
         "operationId": "change_password_v1_me_password_post",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "additionalProperties": true,
-                "title": "Payload",
-                "type": "object"
+                "$ref": "#/components/schemas/ChangePasswordRequest"
               }
             }
           },

--- a/apps/api/src/routers/me.py
+++ b/apps/api/src/routers/me.py
@@ -21,7 +21,7 @@ from ..multipart_uploads import (
     process_upload,
 )
 from ..schemas.auth import UserResponse
-from ..schemas.me import UpdateProfileRequest
+from ..schemas.me import ChangePasswordRequest, UpdateProfileRequest
 from ..security import clear_session_cookie, hash_password, verify_password
 from ..uploads import create_signed_url_resolver, get_signed_upload_url
 from ..utils import iso
@@ -261,7 +261,7 @@ async def update_profile(
 
 @router.post("/password")
 async def change_password(
-    payload: dict,
+    payload: ChangePasswordRequest,
     response: Response,
     user: UserResponse = Depends(get_current_user),
 ):
@@ -275,23 +275,18 @@ async def change_password(
 
     Body keys are `currentPassword` / `newPassword` — the live Next contract
     and what `AccountSettingsForm` sends. (The migration plan's `nextPassword`
-    is stale and was never shipped on either side.)
+    is stale and was never shipped on either side.) Body shape is validated
+    via `ChangePasswordRequest`; missing/short fields surface as the standard
+    `VALIDATION_ERROR` envelope through `_validation_error_handler` (#216).
     """
-    current_password = payload.get("currentPassword")
-    new_password = payload.get("newPassword")
-    if not isinstance(current_password, str) or not current_password:
-        return bad_request("Current password is required")
-    if not isinstance(new_password, str) or len(new_password) < 8:
-        return bad_request("New password must be at least 8 characters")
-
     try:
         record = await prisma.user.find_unique(where={"id": user.id})
-        if not record or not verify_password(current_password, record.passwordHash):
+        if not record or not verify_password(payload.currentPassword, record.passwordHash):
             return bad_request("Current password is incorrect")
 
         await prisma.user.update(
             where={"id": user.id},
-            data={"passwordHash": hash_password(new_password)},
+            data={"passwordHash": hash_password(payload.newPassword)},
         )
         clear_session_cookie(response)
         return {"status": "updated"}

--- a/apps/api/src/schemas/me.py
+++ b/apps/api/src/schemas/me.py
@@ -33,3 +33,21 @@ class UpdateProfileRequest(BaseModel):
         max_length=30,
         pattern=r"^[a-zA-Z0-9_]+$",
     )
+
+
+class ChangePasswordRequest(BaseModel):
+    """Self-service password-change payload — mirrors
+    `changePasswordSchema` in `src/lib/validation.ts`.
+
+    Replaces the hand-rolled `payload: dict` + `isinstance` checks that
+    previously kept the request body out of the OpenAPI snapshot (#216).
+    The "current password is incorrect" branch stays in the handler — that
+    is a bcrypt verify failure, not a schema validation failure.
+    """
+
+    # `min_length=1` mirrors Next's `z.string().min(1)` on currentPassword.
+    # The 200 cap is a defensive upper bound, not a parity field; bcrypt
+    # itself truncates at 72 bytes so anything beyond that is wasted input.
+    currentPassword: str = Field(min_length=1, max_length=200)
+    # `min_length=8` mirrors Next's `z.string().min(8)` on newPassword.
+    newPassword: str = Field(min_length=8, max_length=200)

--- a/apps/api/tests/integration/test_me.py
+++ b/apps/api/tests/integration/test_me.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from tests.helpers.error_envelope import assert_error_envelope
+
 
 pytestmark = pytest.mark.usefixtures("mock_prisma", "prisma_user_with_membership")
 
@@ -298,8 +300,9 @@ def test_change_password_too_short_400(client, member_auth):
         json={"currentPassword": "oldpass", "newPassword": "short"},
     )
 
-    assert response.status_code == 400
-    assert response.json()["error"]["message"] == "New password must be at least 8 characters"
+    # Schema-level rejection now flows through `_validation_error_handler`
+    # rather than the legacy hand-rolled `bad_request` (see #216).
+    assert_error_envelope(response, status_code=400, code="VALIDATION_ERROR")
 
 
 def test_change_password_missing_current_400(client, member_auth):
@@ -309,8 +312,7 @@ def test_change_password_missing_current_400(client, member_auth):
         json={"newPassword": "newpassword"},
     )
 
-    assert response.status_code == 400
-    assert response.json()["error"]["message"] == "Current password is required"
+    assert_error_envelope(response, status_code=400, code="VALIDATION_ERROR")
 
 
 def test_change_password_missing_new_400(client, member_auth):
@@ -320,8 +322,7 @@ def test_change_password_missing_new_400(client, member_auth):
         json={"currentPassword": "oldpass"},
     )
 
-    assert response.status_code == 400
-    assert response.json()["error"]["message"] == "New password must be at least 8 characters"
+    assert_error_envelope(response, status_code=400, code="VALIDATION_ERROR")
 
 
 def test_change_password_requires_auth(client):


### PR DESCRIPTION
## Summary

Closes #216.

- Adds `ChangePasswordRequest` in [apps/api/src/schemas/me.py](apps/api/src/schemas/me.py) mirroring `changePasswordSchema` in [src/lib/validation.ts:196](src/lib/validation.ts#L196).
- Updates `POST /me/password` in [apps/api/src/routers/me.py:262](apps/api/src/routers/me.py#L262) to consume the Pydantic model; drops the hand-rolled `isinstance` + `bad_request` checks. The bcrypt-verify "Current password is incorrect" branch is preserved (that's a business-rule failure, not a schema-validation failure).
- Updates the three schema-rejection tests in [apps/api/tests/integration/test_me.py](apps/api/tests/integration/test_me.py) to assert the standard `VALIDATION_ERROR` envelope via `assert_error_envelope`. The wrong-current-password test is unchanged.
- Regenerates [apps/api/openapi.snapshot.json](apps/api/openapi.snapshot.json): `ChangePasswordRequest` now appears under `components.schemas`, and both `/me/password` + `/v1/me/password` `$ref` it instead of the generic `{additionalProperties: true}` dict — unblocking #189.

## Test plan

- [x] `pytest tests/integration/` — 345 passed
- [x] `pytest tests/unit/` — 185 passed
- [x] `ruff check src/ tests/` — clean
- [x] `apps/api/openapi.snapshot.json` regenerated and diff inspected; shows `ChangePasswordRequest` added + both operations switched to `$ref`
- [ ] CI `api-ci.yml` mypy + openapi-diff gates green

🤖 Generated with [Claude Code](https://claude.com/claude-code)