### PR TITLE
chore: frontend OpenAPI contract test in CI (#189)

### DIFF
--- a/__tests__/integration/openapi-contract.test.ts
+++ b/__tests__/integration/openapi-contract.test.ts
@@ -35,8 +35,6 @@ type HttpMethod = 'get' | 'post' | 'patch' | 'put' | 'delete';
 interface FrontendCall {
   method: HttpMethod;
   path: string;
-  // Concrete-path stand-ins for `{post_id}` etc. used to find the operation.
-  // The snapshot uses templated paths; we look them up directly.
   body?: unknown;
   query?: Record<string, unknown>;
   // Where this call lives in src/. Failure messages cite this so the diff is
@@ -100,6 +98,11 @@ const FRONTEND_CALLS: readonly FrontendCall[] = [
     path: '/v1/notifications',
     query: { limit: 20, offset: 0 },
     callSite: 'src/components/notifications/NotificationsFeed.tsx',
+  },
+  {
+    method: 'get',
+    path: '/v1/notifications/unread-count',
+    callSite: 'src/components/navigation/NotificationBell.tsx',
   },
   {
     method: 'post',
@@ -190,9 +193,12 @@ function refToBody(
   schemaRef: AnySchemaObject | undefined
 ): AnySchemaObject | null {
   if (!schemaRef) return null;
-  if (typeof schemaRef.$ref === 'string') {
+  // Local `$ref: "#/components/..."` values need to be prefixed with the
+  // registered snapshot $id so AJV can resolve them against the in-memory
+  // schema rather than treating them as document-relative.
+  if (typeof schemaRef.$ref === 'string' && schemaRef.$ref.startsWith('#')) {
     return {
-      $ref: `family-recipe-openapi${schemaRef.$ref.replace(/^#/, '#')}`,
+      $ref: `family-recipe-openapi${schemaRef.$ref}`,
     } as AnySchemaObject;
   }
   return schemaRef;

--- a/__tests__/integration/openapi-contract.test.ts
+++ b/__tests__/integration/openapi-contract.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Frontend contract test against the FastAPI OpenAPI snapshot.
+ *
+ * For each `/v1/*` endpoint the Next frontend actually calls today, this
+ * file declares an example request payload and validates it against the
+ * snapshot at `apps/api/openapi.snapshot.json` via AJV. If the snapshot's
+ * schema for an endpoint drifts away from what the frontend constructs,
+ * the test fails and points at the regen command.
+ *
+ * Adding a new /v1/* call from the frontend? Add an entry to FRONTEND_CALLS
+ * below. The manifest is the single place to look when auditing what the
+ * frontend depends on from the FastAPI contract.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import Ajv2020, { type AnySchemaObject, type ErrorObject } from 'ajv/dist/2020';
+import addFormats from 'ajv-formats';
+
+const SNAPSHOT_PATH = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'apps',
+  'api',
+  'openapi.snapshot.json'
+);
+
+const REGEN_HINT =
+  'Regenerate with: cd apps/api && python scripts/dump_openapi.py > openapi.snapshot.json';
+
+type HttpMethod = 'get' | 'post' | 'patch' | 'put' | 'delete';
+
+interface FrontendCall {
+  method: HttpMethod;
+  path: string;
+  // Concrete-path stand-ins for `{post_id}` etc. used to find the operation.
+  // The snapshot uses templated paths; we look them up directly.
+  body?: unknown;
+  query?: Record<string, unknown>;
+  // Where this call lives in src/. Failure messages cite this so the diff is
+  // actionable.
+  callSite: string;
+}
+
+/**
+ * Curated manifest of every /v1/* request the Next frontend constructs today.
+ *
+ * Phase 4 of the FastAPI migration will flip more endpoints over to /v1/*.
+ * When a new fetch/apiClient call lands in src/ pointing at /v1/*, add it
+ * here with a representative body/query. The test will then guard it.
+ */
+const FRONTEND_CALLS: readonly FrontendCall[] = [
+  {
+    method: 'post',
+    path: '/v1/auth/login',
+    body: {
+      emailOrUsername: 'alice@example.com',
+      password: 'hunter2hunter2',
+      rememberMe: true,
+    },
+    callSite: 'src/app/(auth)/login/page.tsx',
+  },
+  {
+    method: 'post',
+    path: '/v1/auth/signup',
+    body: {
+      name: 'Alice Example',
+      email: 'alice@example.com',
+      username: 'alice_e',
+      password: 'hunter2hunter2',
+      familyMasterKey: 'family-master-key',
+      rememberMe: false,
+    },
+    callSite: 'src/app/(auth)/signup/page.tsx',
+  },
+  {
+    method: 'post',
+    path: '/v1/auth/logout',
+    callSite: 'src/components/LogoutButton.tsx',
+  },
+  {
+    method: 'post',
+    path: '/v1/auth/refresh',
+    callSite: 'src/lib/auth/bootstrapFromCookies.ts',
+  },
+  {
+    method: 'get',
+    path: '/v1/auth/session',
+    callSite: 'src/lib/auth/bootstrapFromCookies.ts',
+  },
+  {
+    method: 'get',
+    path: '/v1/auth/me',
+    callSite: 'src/lib/auth/bootstrapFromCookies.ts',
+  },
+  {
+    method: 'get',
+    path: '/v1/notifications',
+    query: { limit: 20, offset: 0 },
+    callSite: 'src/components/notifications/NotificationsFeed.tsx',
+  },
+  {
+    method: 'post',
+    path: '/v1/notifications/mark-read',
+    body: {},
+    callSite: 'src/components/notifications/NotificationsFeed.tsx',
+  },
+];
+
+interface OpenApiSnapshot {
+  openapi: string;
+  paths: Record<string, Record<string, OpenApiOperation>>;
+  components?: { schemas?: Record<string, AnySchemaObject> };
+}
+
+interface OpenApiOperation {
+  operationId?: string;
+  parameters?: OpenApiParameter[];
+  requestBody?: {
+    required?: boolean;
+    content?: Record<string, { schema?: AnySchemaObject }>;
+  };
+}
+
+interface OpenApiParameter {
+  name: string;
+  in: 'query' | 'path' | 'header' | 'cookie';
+  required?: boolean;
+  schema?: AnySchemaObject;
+}
+
+function loadSnapshot(): OpenApiSnapshot {
+  if (!fs.existsSync(SNAPSHOT_PATH)) {
+    throw new Error(
+      `OpenAPI snapshot missing at ${SNAPSHOT_PATH}. ${REGEN_HINT}`
+    );
+  }
+  const raw = fs.readFileSync(SNAPSHOT_PATH, 'utf8');
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `OpenAPI snapshot at ${SNAPSHOT_PATH} is not valid JSON. ${REGEN_HINT}\n${(err as Error).message}`
+    );
+  }
+  if (
+    !parsed ||
+    typeof parsed !== 'object' ||
+    typeof (parsed as { openapi?: unknown }).openapi !== 'string' ||
+    typeof (parsed as { paths?: unknown }).paths !== 'object'
+  ) {
+    throw new Error(
+      `OpenAPI snapshot at ${SNAPSHOT_PATH} is missing top-level "openapi" or "paths". ${REGEN_HINT}`
+    );
+  }
+  return parsed as OpenApiSnapshot;
+}
+
+function buildAjv(snapshot: OpenApiSnapshot): Ajv2020 {
+  const ajv = new Ajv2020({
+    strict: false,
+    allErrors: true,
+    // OpenAPI 3.1 uses JSON Schema 2020-12. Component refs need to be
+    // resolvable via $ref. We register the schemas under their snapshot
+    // path so `$ref: "#/components/schemas/Foo"` resolves.
+    schemas: [
+      {
+        $id: 'family-recipe-openapi',
+        ...snapshot,
+      } as AnySchemaObject,
+    ],
+  });
+  addFormats(ajv);
+  return ajv;
+}
+
+function formatErrors(errors: ErrorObject[] | null | undefined): string {
+  if (!errors || errors.length === 0) return '(no AJV errors)';
+  return errors
+    .map(
+      (err) => `${err.instancePath || '<root>'}: ${err.message ?? 'invalid'}`
+    )
+    .join('\n  ');
+}
+
+function refToBody(
+  schemaRef: AnySchemaObject | undefined
+): AnySchemaObject | null {
+  if (!schemaRef) return null;
+  if (typeof schemaRef.$ref === 'string') {
+    return {
+      $ref: `family-recipe-openapi${schemaRef.$ref.replace(/^#/, '#')}`,
+    } as AnySchemaObject;
+  }
+  return schemaRef;
+}
+
+describe('OpenAPI contract — frontend → FastAPI /v1/*', () => {
+  let snapshot: OpenApiSnapshot;
+  let ajv: Ajv2020;
+
+  beforeAll(() => {
+    snapshot = loadSnapshot();
+    ajv = buildAjv(snapshot);
+  });
+
+  it('snapshot file exists, parses, and declares OpenAPI 3.x', () => {
+    expect(snapshot.openapi).toMatch(/^3\./);
+    expect(Object.keys(snapshot.paths).length).toBeGreaterThan(0);
+  });
+
+  describe.each(
+    FRONTEND_CALLS.map((call) => ({
+      ...call,
+      label: `${call.method.toUpperCase()} ${call.path}`,
+    }))
+  )('$label  ($callSite)', (call) => {
+    it('is defined in the snapshot', () => {
+      const pathItem = snapshot.paths[call.path];
+      if (!pathItem) {
+        throw new Error(
+          `Frontend calls ${call.method.toUpperCase()} ${call.path} from ${call.callSite}, ` +
+            `but the OpenAPI snapshot has no path for it. Either the frontend is ahead of ` +
+            `the FastAPI router or the snapshot is stale. ${REGEN_HINT}`
+        );
+      }
+      const operation = pathItem[call.method];
+      if (!operation) {
+        throw new Error(
+          `Frontend calls ${call.method.toUpperCase()} ${call.path} from ${call.callSite}, ` +
+            `but the OpenAPI snapshot defines the path without that method. ` +
+            `Available methods on this path: ${Object.keys(pathItem).join(', ')}. ${REGEN_HINT}`
+        );
+      }
+    });
+
+    if (call.body !== undefined) {
+      it('request body matches the snapshot schema', () => {
+        const operation = snapshot.paths[call.path][call.method];
+        const schema =
+          operation.requestBody?.content?.['application/json']?.schema;
+        const bodySchema = refToBody(schema);
+        if (!bodySchema) {
+          throw new Error(
+            `Frontend sends a JSON body to ${call.method.toUpperCase()} ${call.path}, ` +
+              `but the snapshot has no application/json request body schema. ${REGEN_HINT}`
+          );
+        }
+        const validate = ajv.compile(bodySchema);
+        const ok = validate(call.body);
+        if (!ok) {
+          throw new Error(
+            `Frontend body fixture for ${call.method.toUpperCase()} ${call.path} ` +
+              `(from ${call.callSite}) does not match the FastAPI schema:\n  ` +
+              `${formatErrors(validate.errors)}\n${REGEN_HINT}`
+          );
+        }
+      });
+    }
+
+    if (call.query !== undefined) {
+      it('every query parameter is declared in the snapshot', () => {
+        const operation = snapshot.paths[call.path][call.method];
+        const declared = new Map(
+          (operation.parameters ?? [])
+            .filter((p) => p.in === 'query')
+            .map((p) => [p.name, p] as const)
+        );
+        const queryEntries = Object.entries(call.query!);
+        for (const [name, value] of queryEntries) {
+          const param = declared.get(name);
+          if (!param) {
+            throw new Error(
+              `Frontend sends query param "${name}" on ${call.method.toUpperCase()} ${call.path} ` +
+                `(from ${call.callSite}), but the snapshot does not declare it. ` +
+                `Declared: ${[...declared.keys()].join(', ') || '(none)'}. ${REGEN_HINT}`
+            );
+          }
+          if (param.schema) {
+            const validate = ajv.compile(param.schema);
+            const ok = validate(value);
+            if (!ok) {
+              throw new Error(
+                `Frontend value for query param "${name}" on ${call.method.toUpperCase()} ` +
+                  `${call.path} (from ${call.callSite}) does not match the snapshot schema:\n  ` +
+                  `${formatErrors(validate.errors)}\n${REGEN_HINT}`
+              );
+            }
+          }
+        }
+      });
+    }
+  });
+});

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -63,6 +63,8 @@ python scripts/dump_openapi.py > openapi.snapshot.json
 
 The script stubs `prisma` in-process (no client generation or DB needed) and writes deterministic, sort-key JSON. Reviewers should treat snapshot diffs as the contract changelog.
 
+The Next side validates its `/v1/*` requests against this snapshot via [\_\_tests\_\_/integration/openapi-contract.test.ts](../../__tests__/integration/openapi-contract.test.ts). When the frontend adds a new `/v1/*` call, append an entry to the `FRONTEND_CALLS` manifest in that file so the contract test guards it.
+
 ## Verification
 
 Before opening a PR that touches this service, run the [FastAPI playbook](../../docs/verification/fastapi.md) — includes the curl+cookie loop, contract parity check against the Next mirror, and the local quality gates.

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,8 @@
         "@types/node": "^20.11.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
         "autoprefixer": "^10.4.0",
         "bcryptjs": "^2.4.3",
         "eslint": "^9.39.4",
@@ -957,6 +959,30 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/js": {
       "version": "9.39.4",
@@ -3711,20 +3737,38 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-escapes": {
@@ -5900,6 +5944,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
@@ -5912,6 +5973,13 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/espree": {
       "version": "10.4.0",
@@ -6124,6 +6192,23 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -8659,9 +8744,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
@@ -10699,6 +10784,16 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "@types/node": "^20.11.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
     "autoprefixer": "^10.4.0",
     "bcryptjs": "^2.4.3",
     "eslint": "^9.39.4",


### PR DESCRIPTION
Closes #189.

## Summary

- New Jest test [\`__tests__/integration/openapi-contract.test.ts\`](__tests__/integration/openapi-contract.test.ts) validates every \`/v1/*\` request the Next frontend constructs today against the FastAPI snapshot at \`apps/api/openapi.snapshot.json\` via AJV.
- A curated \`FRONTEND_CALLS\` manifest is the single place to look when auditing what the frontend depends on from the FastAPI contract; new \`/v1/*\` calls land here as Phase 4 of the migration progresses.
- Adds \`ajv@^8\` and \`ajv-formats@^3\` as devDependencies (standard JSON-Schema 2020-12 validator).

## Decisions

- **Kept \`apps/api/openapi.snapshot.json\` filename** rather than renaming to \`openapi.json\` per the migration plan. Lower blast radius — \`api-ci.yml\`, \`scripts/dump_openapi.py\`, and \`apps/api/CLAUDE.md\` keep working unchanged, and the freshness/diff check already enforces what the rename was meant to imply.
- **Manifest-of-fixtures approach** over AST-scanning call sites. The plan's wording allows "a representative sample of typed call sites" — explicit fixtures keep the test understandable and the failure messages actionable (each cites the source file). AST extraction would be heavier and brittle on dynamic body construction.
- **Runs under \`npm test\`** via the existing \`testMatch\` glob. No \`ci.yml\` edit needed — the new test appears in the existing \`test\` job's output.
- **Drift surfaces actionably**: every failure message points at \`cd apps/api && python scripts/dump_openapi.py > openapi.snapshot.json\`.

## What's covered today

8 \`/v1/*\` endpoints (the calls actually wired in \`src/\` now):

- \`POST /v1/auth/{login,signup,logout,refresh}\`
- \`GET /v1/auth/{session,me}\`
- \`GET /v1/notifications\` (with query)
- \`POST /v1/notifications/mark-read\`

Phase 4 cutover will add more — the manifest is the entry point for those.

## Test plan

- [x] \`npx jest __tests__/integration/openapi-contract.test.ts\` — 13 tests pass
- [x] Negative: break a body fixture (login \`password\` too short) → test fails with the AJV error and regen hint
- [x] Negative: add an undeclared query param → test fails citing the call site
- [x] Negative: change a path to one not in the snapshot → test fails
- [x] Negative: remove the snapshot file → \`beforeAll\` throws with the regen command
- [x] \`npm test\` — 1072 tests pass across 53 suites
- [x] \`npm run type-check\` clean
- [x] \`npm run lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)