### PR TITLE
chore(api): align LoginRequest.emailOrUsername min-length with Next (3 → 1)

### DIFF
--- a/apps/api/openapi.snapshot.json
+++ b/apps/api/openapi.snapshot.json
@@ -695,7 +695,7 @@
         "properties": {
           "emailOrUsername": {
             "maxLength": 200,
-            "minLength": 3,
+            "minLength": 1,
             "title": "Emailorusername",
             "type": "string"
           },

--- a/apps/api/src/schemas/auth.py
+++ b/apps/api/src/schemas/auth.py
@@ -31,9 +31,10 @@ class LoginRequest(BaseModel):
     # Intentionally a plain `str`, not `EmailStr` — this field accepts
     # either an email OR a username (see `loginSchema.emailOrUsername` in
     # src/lib/validation.ts), and `EmailStr` would reject perfectly valid
-    # username logins. The `min_length=3` is a pre-existing divergence
-    # from Next's `z.string().min(1)`, tracked separately in #211.
-    emailOrUsername: str = Field(min_length=3, max_length=200)
+    # username logins. `min_length=1` mirrors Next's `z.string().min(1)`;
+    # a too-short value falls through to the `find_first` lookup and
+    # surfaces as 401 INVALID_CREDENTIALS, not 400 VALIDATION_ERROR.
+    emailOrUsername: str = Field(min_length=1, max_length=200)
     password: str = Field(min_length=6, max_length=200)
     rememberMe: bool = False
 

--- a/apps/api/tests/integration/test_auth.py
+++ b/apps/api/tests/integration/test_auth.py
@@ -210,7 +210,7 @@ class TestAuthLogin:
     def test_login_invalid_payload(self, client):
         response = client.post(
             "/auth/login",
-            json={"emailOrUsername": "ab", "password": "123"},
+            json={"emailOrUsername": "user@example.com", "password": "123"},
         )
 
         assert_error_envelope(response, status_code=400, code="VALIDATION_ERROR")

--- a/apps/api/tests/integration/test_auth_v1.py
+++ b/apps/api/tests/integration/test_auth_v1.py
@@ -101,6 +101,20 @@ class TestV1Login:
         assert response.status_code == 401
         assert response.json()["error"]["code"] == "INVALID_CREDENTIALS"
 
+    def test_login_two_char_username_falls_through_to_lookup(
+        self, client, mock_prisma
+    ):
+        # Mirrors Next's `loginSchema` (`z.string().min(1)`) — a 1- or 2-char
+        # input is accepted at validation and rejected at the DB lookup with
+        # 401 INVALID_CREDENTIALS, not 400 VALIDATION_ERROR. See #211.
+        mock_prisma.user.find_first.return_value = None
+        response = client.post(
+            "/v1/auth/login",
+            json={"emailOrUsername": "ab", "password": "password123"},
+        )
+        assert response.status_code == 401
+        assert response.json()["error"]["code"] == "INVALID_CREDENTIALS"
+
     def test_login_remember_me_extends_cookie_max_age(
         self, client, mock_prisma, monkeypatch
     ):


### PR DESCRIPTION
## Summary

- Closes #211. Flips `LoginRequest.emailOrUsername` `min_length=3` → `min_length=1` in [apps/api/src/schemas/auth.py](apps/api/src/schemas/auth.py) so a 1- or 2-character input matches Next's `loginSchema` (`z.string().min(1)`) and falls through to the user-lookup branch as `401 INVALID_CREDENTIALS` instead of bouncing at validation with a confusing `400 VALIDATION_ERROR`. Pre-Phase-4 alignment so the frontend swap doesn't surface a behavioral diff.
- New `/v1/auth/login` test asserts the new fall-through (`emailOrUsername="ab"` → 401 INVALID_CREDENTIALS). Legacy `/auth/login` test payload tightened so `test_login_invalid_payload` still proves what its name claims.
- OpenAPI snapshot regenerated — single one-line delta (`"minLength": 3` → `"minLength": 1`).

## Test plan

- [x] `pytest tests/` in `apps/api/` — 531 passed
- [x] `ruff check` on changed files — clean
- [x] `npx jest __tests__/integration/openapi-contract.test.ts` — 14 passed (Next-side contract test reads the new snapshot)
- [x] `npm run type-check` — clean
- [ ] CI green on `api-ci.yml` (mypy, openapi-diff job confirms the snapshot is in sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)