### PR TITLE
chore(api): align /v1/notifications/mark-read ID validation with Next (CUID shape)

### DIFF
--- a/apps/api/src/routers/v1/notifications.py
+++ b/apps/api/src/routers/v1/notifications.py
@@ -17,7 +17,7 @@ from prisma.errors import PrismaError
 
 from ...db import prisma
 from ...dependencies_v1 import get_current_user_v1
-from ...errors import internal_error, validation_error
+from ...errors import internal_error
 from ...schemas.auth import UserResponse
 from ...schemas.notifications import (
     MarkNotificationsReadRequest,
@@ -159,8 +159,6 @@ async def mark_read(
     user: UserResponse = Depends(get_current_user_v1),
 ):
     ids = payload.ids
-    if ids is not None and any(not isinstance(i, str) or not i for i in ids):
-        return validation_error("Invalid notification ID")
 
     try:
         # Family scoping: even though `recipientId == user.id` is enough to

--- a/apps/api/src/schemas/notifications.py
+++ b/apps/api/src/schemas/notifications.py
@@ -73,7 +73,7 @@ class MarkNotificationsReadRequest(BaseModel):
         if v is None:
             return v
         for entry in v:
-            if not isinstance(entry, str) or not is_cuid(entry):
+            if not is_cuid(entry):
                 raise ValueError("Invalid notification ID")
         return v
 

--- a/apps/api/src/schemas/notifications.py
+++ b/apps/api/src/schemas/notifications.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 
 from typing import List, Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+from ..utils import is_cuid
 
 
 NotificationType = Literal["comment", "reaction_batch", "cooked"]
@@ -59,8 +61,21 @@ class NotificationsListResponse(BaseModel):
 
 class MarkNotificationsReadRequest(BaseModel):
     # Optional list of IDs to mark; omitted/empty = mark all unread for caller.
-    # Capped to mirror the Next.js Zod schema in src/lib/validation.ts.
+    # Cap + CUID shape mirror the Next.js Zod (`markNotificationsSchema` in
+    # src/lib/validation.ts) so both surfaces reject the same payloads at the
+    # schema boundary instead of relying on the recipientId/familySpaceId
+    # filter to silently zero-out junk IDs (issue #198).
     ids: Optional[List[str]] = Field(default=None, max_length=50)
+
+    @field_validator("ids")
+    @classmethod
+    def _ids_are_cuids(cls, v: Optional[List[str]]) -> Optional[List[str]]:
+        if v is None:
+            return v
+        for entry in v:
+            if not isinstance(entry, str) or not is_cuid(entry):
+                raise ValueError("Invalid notification ID")
+        return v
 
 
 class MarkNotificationsReadResponse(BaseModel):

--- a/apps/api/tests/integration/test_notifications.py
+++ b/apps/api/tests/integration/test_notifications.py
@@ -262,15 +262,16 @@ class TestMarkRead:
         mock_prisma.notification.update_many = AsyncMock(return_value=None)
         mock_prisma.notification.count = AsyncMock(return_value=2)
 
+        ids = ["cknotif1234567890123456789", "cknotif9876543210987654321"]
         response = client.post(
             "/v1/notifications/mark-read",
-            json={"ids": ["n1", "n2"]},
+            json={"ids": ids},
             headers=_bearer_headers(mock_user.id, mock_family_space.id),
         )
         assert response.status_code == 200
         assert response.json()["unreadCount"] == 2
         call_kwargs = mock_prisma.notification.update_many.await_args.kwargs
-        assert call_kwargs["where"]["id"] == {"in": ["n1", "n2"]}
+        assert call_kwargs["where"]["id"] == {"in": ids}
         assert call_kwargs["where"]["recipientId"] == mock_user.id
 
     def test_cannot_mark_other_users_notifications(
@@ -286,7 +287,7 @@ class TestMarkRead:
 
         response = client.post(
             "/v1/notifications/mark-read",
-            json={"ids": ["someone_elses_id"]},
+            json={"ids": ["ckother1234567890123456789"]},
             headers=_bearer_headers(mock_user.id, mock_family_space.id),
         )
         assert response.status_code == 200
@@ -298,12 +299,37 @@ class TestMarkRead:
         self, client, mock_prisma, mock_user, mock_family_space
     ):
         _seed_user_lookup(mock_prisma, mock_user, mock_family_space)
+        # Use CUID-shape IDs so the cap (max_length=50) is what's tested,
+        # not the per-item CUID validator added in #198.
+        ids = [f"cknotif{i:018d}aaaaaa" for i in range(51)]
         response = client.post(
             "/v1/notifications/mark-read",
-            json={"ids": [f"id_{i}" for i in range(51)]},
+            json={"ids": ids},
             headers=_bearer_headers(mock_user.id, mock_family_space.id),
         )
         assert response.status_code in (400, 422)
+
+    def test_non_cuid_id_rejected_by_schema(
+        self, client, mock_prisma, mock_user, mock_family_space
+    ):
+        """#198 — FastAPI's mark-read previously accepted any non-empty
+        string and relied on the recipientId/familySpaceId filter to
+        silently no-op. Now matches Next's `z.string().cuid()` so junk
+        IDs are rejected at the schema boundary with the standard
+        VALIDATION_ERROR envelope, before any DB call."""
+        _seed_user_lookup(mock_prisma, mock_user, mock_family_space)
+        mock_prisma.notification.update_many = AsyncMock(return_value=None)
+
+        response = client.post(
+            "/v1/notifications/mark-read",
+            json={"ids": ["not-a-cuid"]},
+            headers=_bearer_headers(mock_user.id, mock_family_space.id),
+        )
+        assert response.status_code == 400
+        assert response.json() == {
+            "error": {"code": "VALIDATION_ERROR", "message": "Invalid input"}
+        }
+        mock_prisma.notification.update_many.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Tightens FastAPI's `MarkNotificationsReadRequest.ids` validator to match the Next `markNotificationsSchema` (`z.array(z.string().cuid())`). Previously FastAPI accepted any non-empty string and relied on the `recipientId + familySpaceId` filter on `update_many` to silently zero-out junk IDs — Next rejected the same payload at the schema boundary with `400 VALIDATION_ERROR`.
- Uses a Pydantic `field_validator` calling the existing `is_cuid` helper. A non-CUID entry raises `ValueError`, which the global `RequestValidationError` handler maps to the standard `400 VALIDATION_ERROR` envelope (post-#190).
- Drops the now-redundant inline truthiness guard in `mark_read` — Pydantic catches it earlier.
- OpenAPI snapshot regenerated: no diff. Pydantic `field_validator` constraints are runtime-only, not surfaced as JSON Schema (same pattern as `feedback.py`'s `_email_shape`).

Closes #198

## Test plan

- [x] `pytest tests/` — 532 passed (was 531; +1 for new rejection test)
- [x] New `test_non_cuid_id_rejected_by_schema` asserts `{ids: ["not-a-cuid"]}` → `400 VALIDATION_ERROR` envelope and `update_many` is not awaited
- [x] Existing happy path (`test_mark_specific_ids_passes_in_filter`) and cross-user safety test (`test_cannot_mark_other_users_notifications`) updated to use CUID-shape IDs and still pass
- [x] `test_too_many_ids_rejected_by_schema` updated to CUID-shape IDs so it still tests the `max_length=50` cap rather than the new per-item validator
- [x] `ruff check .` clean
- [x] OpenAPI snapshot regenerated — no spec drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)