### PR TITLE
chore(api): tighten is_cuid to a strict 25-char lowercase CUID shape (#221)

### DIFF
--- a/apps/api/src/utils.py
+++ b/apps/api/src/utils.py
@@ -2,7 +2,7 @@ import re
 from datetime import datetime
 from typing import Optional
 
-CUID_REGEX = re.compile(r"^[a-z0-9]{25,}$")
+CUID_REGEX = re.compile(r"^c[a-z0-9]{24}$")
 
 
 def is_cuid(value: str) -> bool:

--- a/apps/api/tests/integration/test_comments.py
+++ b/apps/api/tests/integration/test_comments.py
@@ -10,7 +10,7 @@ import pytest
 
 pytestmark = pytest.mark.usefixtures("mock_prisma", "prisma_user_with_membership")
 POST_ID = "ckpost1234567890123456789"
-COMMENT_ID = "ckcomment1234567890123456789"
+COMMENT_ID = "ckcomment1234567890123456"
 
 
 class TestListComments:

--- a/apps/api/tests/integration/test_family.py
+++ b/apps/api/tests/integration/test_family.py
@@ -12,7 +12,7 @@ from src.settings import settings
 pytestmark = pytest.mark.usefixtures("mock_prisma", "prisma_user_with_membership")
 
 _NOW = datetime(2024, 1, 1, tzinfo=timezone.utc)
-_VALID_CUID = "cl0123456789abcdefghijklmn"
+_VALID_CUID = "cl0123456789abcdefghijklm"
 
 
 def _make_user(idx: int = 1, **overrides) -> SimpleNamespace:

--- a/apps/api/tests/integration/test_notifications.py
+++ b/apps/api/tests/integration/test_notifications.py
@@ -262,7 +262,7 @@ class TestMarkRead:
         mock_prisma.notification.update_many = AsyncMock(return_value=None)
         mock_prisma.notification.count = AsyncMock(return_value=2)
 
-        ids = ["cknotif1234567890123456789", "cknotif9876543210987654321"]
+        ids = ["cknotif123456789012345678", "cknotif987654321098765432"]
         response = client.post(
             "/v1/notifications/mark-read",
             json={"ids": ids},
@@ -287,7 +287,7 @@ class TestMarkRead:
 
         response = client.post(
             "/v1/notifications/mark-read",
-            json={"ids": ["ckother1234567890123456789"]},
+            json={"ids": ["ckother123456789012345678"]},
             headers=_bearer_headers(mock_user.id, mock_family_space.id),
         )
         assert response.status_code == 200
@@ -301,7 +301,7 @@ class TestMarkRead:
         _seed_user_lookup(mock_prisma, mock_user, mock_family_space)
         # Use CUID-shape IDs so the cap (max_length=50) is what's tested,
         # not the per-item CUID validator added in #198.
-        ids = [f"cknotif{i:018d}aaaaaa" for i in range(51)]
+        ids = [f"cknotif{i:018d}" for i in range(51)]
         response = client.post(
             "/v1/notifications/mark-read",
             json={"ids": ids},

--- a/apps/api/tests/integration/test_reactions.py
+++ b/apps/api/tests/integration/test_reactions.py
@@ -8,7 +8,7 @@ import pytest
 pytestmark = pytest.mark.usefixtures("mock_prisma", "prisma_user_with_membership")
 
 POST_ID = "ckpost1234567890123456789"
-COMMENT_ID = "ckcomment1234567890123456789"
+COMMENT_ID = "ckcomment1234567890123456"
 
 
 class TestToggleReaction:

--- a/apps/api/tests/unit/test_utils.py
+++ b/apps/api/tests/unit/test_utils.py
@@ -12,21 +12,28 @@ from src.utils import is_cuid, iso
 
 class TestIsCuid:
     def test_valid_cuid(self):
-        """is_cuid should return True for valid CUIDs."""
-        # CUIDs are 25+ lowercase alphanumeric characters
+        """is_cuid should return True for valid CUIDs (leading 'c', exactly 25 chars)."""
         valid_cuids = [
             "cjld2cjxh0000qzrmn831i7rn",
             "cjld2cyuq0000t3rmniod1foy",
             "cm1234567890abcdefghijklm",
-            "abcdefghijklmnopqrstuvwxy",
         ]
         for cuid in valid_cuids:
             assert is_cuid(cuid) is True, f"Expected {cuid} to be valid"
 
-    def test_invalid_cuid_too_short(self):
-        """is_cuid should return False for strings shorter than 25 chars."""
+    def test_invalid_cuid_wrong_length(self):
+        """is_cuid should return False for strings that aren't exactly 25 chars."""
         assert is_cuid("abc123") is False
         assert is_cuid("cjld2cjxh0000qzrmn831i7r") is False  # 24 chars
+        # 26 chars — Zod rejects trailing slack, so we must too.
+        assert is_cuid("cabcdefghijklmnopqrstuvwxyz") is False
+
+    def test_invalid_cuid_no_leading_c(self):
+        """is_cuid should return False when the first char isn't 'c' (Zod requirement)."""
+        # 25 chars but starts with a digit.
+        assert is_cuid("0abcdefghijklmnopqrstuvwx") is False
+        # 25 chars but starts with a non-'c' letter.
+        assert is_cuid("abcdefghijklmnopqrstuvwxy") is False
 
     def test_invalid_cuid_uppercase(self):
         """is_cuid should return False for uppercase characters."""

--- a/apps/api/tests/unit/test_utils.py
+++ b/apps/api/tests/unit/test_utils.py
@@ -22,21 +22,34 @@ class TestIsCuid:
             assert is_cuid(cuid) is True, f"Expected {cuid} to be valid"
 
     def test_invalid_cuid_wrong_length(self):
-        """is_cuid should return False for strings that aren't exactly 25 chars."""
+        """is_cuid should return False for strings that aren't exactly 25 chars.
+
+        Prisma always emits 25-char CUIDs, so this regex is intentionally
+        stricter than Zod's `z.string().cuid()` (which accepts any `c` + 8+
+        non-whitespace, non-hyphen chars). Over-rejecting weird-but-Zod-legal
+        shapes is fine here because every call site uses is_cuid as a 404
+        guard before a prisma.*.find_unique — the rejection outcome is the
+        same, just one step earlier.
+        """
         assert is_cuid("abc123") is False
         assert is_cuid("cjld2cjxh0000qzrmn831i7r") is False  # 24 chars
-        # 26 chars — Zod rejects trailing slack, so we must too.
+        # Zod would accept this 27-char `c…` string; we reject it because
+        # no Prisma-issued CUID is ever >25 chars.
         assert is_cuid("cabcdefghijklmnopqrstuvwxyz") is False
 
     def test_invalid_cuid_no_leading_c(self):
-        """is_cuid should return False when the first char isn't 'c' (Zod requirement)."""
+        """is_cuid should return False when the first char isn't 'c'."""
         # 25 chars but starts with a digit.
         assert is_cuid("0abcdefghijklmnopqrstuvwx") is False
         # 25 chars but starts with a non-'c' letter.
         assert is_cuid("abcdefghijklmnopqrstuvwxy") is False
 
     def test_invalid_cuid_uppercase(self):
-        """is_cuid should return False for uppercase characters."""
+        """is_cuid should return False for uppercase characters.
+
+        Stricter than Zod (whose cuid regex is case-insensitive via /i);
+        justified because Prisma's `@default(cuid())` always emits lowercase.
+        """
         assert is_cuid("CJLD2CJXH0000QZRMN831I7RN") is False
         assert is_cuid("cjld2cjxh0000qzrmn831i7rN") is False  # mixed case
 


### PR DESCRIPTION
Closes #221.

## Summary

- Tightens `CUID_REGEX` in [apps/api/src/utils.py](apps/api/src/utils.py) from `^[a-z0-9]{25,}$` to `^c[a-z0-9]{24}$` — leading `c`, exactly 25 lowercase-alnum chars. Matches the shape Prisma's `@default(cuid())` actually emits.
- **Stricter than Zod**, not at parity with it. Zod 3.25's `z.string().cuid()` is `/^c[^\s-]{8,}$/i` (leading `c`, 8+ non-whitespace/non-hyphen chars, case-insensitive). The audit confirmed `is_cuid` is only ever used as a 404/422 guard before a `prisma.*.find_unique`, so over-rejecting weird-but-Zod-legal shapes (uppercase, 26+ chars) gives the same rejection outcome one step earlier on real traffic — and Prisma never produces those shapes anyway.
- Trims four integration-test fixture IDs (`test_family._VALID_CUID`, `test_notifications` mark-read ID arrays, `test_comments.COMMENT_ID`, `test_reactions.COMMENT_ID`) from 26–28 chars to 25 so they continue to pass the field validator on `/v1/notifications/mark-read` and the path-param guards on posts/comments/reactions/family routes.

## Why stricter than Zod is fine here

Audited all 11 `is_cuid` call sites (5 routers + 1 schema). Every one is `if not is_cuid(x): return not_found(...)` (or a Pydantic `ValueError`) immediately before a `prisma.*.find_unique` keyed on a CUID column. The set of inputs that change behavior is exactly: strings Zod would accept but Prisma's CUID column would never produce. For those, the outcome was already a 404 via the Prisma lookup — now it's a 404 via the regex one frame earlier. No happy-path traffic affected.

The OpenAPI snapshot is unchanged because `is_cuid` runs in field validators, not as a JSON Schema constraint.

## Test plan

- [x] `ruff check .` clean in `apps/api/`
- [x] Full pytest: 533 passed (4 pre-existing `InsecureKeyLengthWarning`s unrelated to this change)
- [x] `python scripts/dump_openapi.py` produces a no-op diff vs the committed snapshot
- [x] New `test_invalid_cuid_no_leading_c` and `test_invalid_cuid_wrong_length` cases in `test_utils.py` pin the strict accept/reject sets, with comments explicitly labeling each over-rejection as deliberately stricter than Zod
- [x] Existing 500+ integration tests for posts/comments/reactions/notifications/family pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)