### PR TITLE
chore(api): shield _delete_claim against asyncio.CancelledError (#224)

### DIFF
--- a/apps/api/src/idempotency.py
+++ b/apps/api/src/idempotency.py
@@ -55,6 +55,14 @@ The Postgres unique constraint on `(user_id, request_id)` is what makes
 this safe — only one INSERT can succeed per key, regardless of how many
 concurrent retries arrive.
 
+If the winner's coroutine is cancelled mid-handler (e.g. Cloud Run SIGTERM
+on deploy), the `except BaseException` branch fires and calls
+`_delete_claim`. Because the outer task is already being cancelled, a bare
+`await _delete_claim(...)` would itself be immediately cancelled — leaving
+a `status_code = 0` sentinel in the table and locking that key for up to
+24h. To prevent this, the cleanup is wrapped in `asyncio.shield(...)` so
+the DELETE completes even though the outer coroutine is being torn down.
+
 ## TTL strategy: passive overwrite, not lazy delete
 
 Stale rows are not deleted. The replay window is enforced at *read* time:
@@ -159,7 +167,9 @@ async def replay_or_record(
     except BaseException:
         # Handler crashed before producing a result. Drop the claim so the
         # next retry can run fresh — same rationale as the 5xx skip path.
-        await _delete_claim(claim_id)
+        # asyncio.shield ensures the DELETE lands even when the outer task
+        # is being cancelled (e.g. Cloud Run SIGTERM mid-request).
+        await asyncio.shield(_delete_claim(claim_id))
         raise
 
     if status_code >= 500:
@@ -280,7 +290,7 @@ async def _take_over_stale(
     try:
         body, status_code = await do()
     except BaseException:
-        await _delete_claim(refreshed["id"])
+        await asyncio.shield(_delete_claim(refreshed["id"]))
         raise
 
     if status_code >= 500:

--- a/apps/api/tests/unit/test_idempotency.py
+++ b/apps/api/tests/unit/test_idempotency.py
@@ -586,6 +586,44 @@ async def test_idempotency_key_dependency_replays_under_fastapi_routing(mock_pri
 
 
 @pytest.mark.asyncio
+async def test_cancellation_during_handler_still_deletes_claim(mock_prisma):
+    """If the winner task is cancelled mid-handler (e.g. Cloud Run SIGTERM),
+    the cleanup DELETE must still land — the claim must not be left stuck at
+    status_code=0 for 24h.
+
+    asyncio.shield() in the except BaseException block is what makes this
+    safe: the inner _delete_claim coroutine runs to completion even though
+    the outer task receives CancelledError.
+    """
+    handler_started = asyncio.Event()
+
+    async def slow_handler():
+        handler_started.set()
+        await asyncio.sleep(10)  # will be cancelled before this resolves
+        return ({}, 201)
+
+    _install_winning_claim(mock_prisma, claim_id="claim-cancel")
+
+    task = asyncio.create_task(
+        idempotency.replay_or_record(
+            user_id="u1", request_id="req-cancel", do=slow_handler
+        )
+    )
+
+    await handler_started.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # Despite cancellation, the DELETE must have been issued.
+    assert mock_prisma.execute_raw.await_count == 1
+    sql, claim_id_arg = mock_prisma.execute_raw.await_args.args[:2]
+    assert sql.lstrip().startswith("DELETE")
+    assert claim_id_arg == "claim-cancel"
+
+
+@pytest.mark.asyncio
 async def test_idempotency_key_dependency_missing_header_runs_handler(mock_prisma):
     """Opt-in semantics survive the dependency layer: no X-Request-Id → no store hit."""
     from fastapi import Depends, FastAPI

--- a/apps/api/tests/unit/test_idempotency.py
+++ b/apps/api/tests/unit/test_idempotency.py
@@ -624,6 +624,52 @@ async def test_cancellation_during_handler_still_deletes_claim(mock_prisma):
 
 
 @pytest.mark.asyncio
+async def test_cancellation_during_stale_takeover_still_deletes_claim(mock_prisma):
+    """Same guarantee as the winner path, but for _take_over_stale:
+    if the task is cancelled while the handler runs inside a stale takeover,
+    asyncio.shield() must ensure the DELETE lands before the task tears down.
+    """
+    handler_started = asyncio.Event()
+
+    async def slow_handler():
+        handler_started.set()
+        await asyncio.sleep(10)  # will be cancelled before this resolves
+        return ({}, 201)
+
+    stale = _row(
+        status_code=201,
+        body={"created": "stale"},
+        created_at=datetime.now(timezone.utc) - idempotency.REPLAY_WINDOW - timedelta(seconds=1),
+        row_id="stale-cancel",
+    )
+    # First query_first: losing claim INSERT (None).
+    # Second query_first: stale takeover UPDATE succeeds (returns refreshed id).
+    mock_prisma.query_first = AsyncMock(
+        side_effect=[None, {"id": "stale-cancel"}]
+    )
+    mock_prisma.execute_raw = AsyncMock(return_value=1)
+    _install_existing_row(mock_prisma, stale)
+
+    task = asyncio.create_task(
+        idempotency.replay_or_record(
+            user_id="u1", request_id="req-stale-cancel", do=slow_handler
+        )
+    )
+
+    await handler_started.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # Despite cancellation, the DELETE must have been issued against the stale row.
+    assert mock_prisma.execute_raw.await_count == 1
+    sql, claim_id_arg = mock_prisma.execute_raw.await_args.args[:2]
+    assert sql.lstrip().startswith("DELETE")
+    assert claim_id_arg == "stale-cancel"
+
+
+@pytest.mark.asyncio
 async def test_idempotency_key_dependency_missing_header_runs_handler(mock_prisma):
     """Opt-in semantics survive the dependency layer: no X-Request-Id → no store hit."""
     from fastapi import Depends, FastAPI


### PR DESCRIPTION
## Summary

- Wraps both `await _delete_claim(...)` calls in `except BaseException` with `asyncio.shield()` — one in `replay_or_record`, one in `_take_over_stale`
- Without the shield, a Cloud Run SIGTERM mid-handler cancels the cleanup `await` before the DELETE lands, leaving a `status_code = 0` sentinel in `idempotency_keys` for up to 24h and 409-ing every retry for that key
- Updates the module docstring's at-most-once section to document the cancellation guard

## Test plan

- [x] New `test_cancellation_during_handler_still_deletes_claim`: cancels the winner task mid-handler via `task.cancel()` and asserts `execute_raw` was called with a DELETE SQL and the correct `claim_id`
- [x] All 20 existing idempotency tests still pass (`pytest tests/unit/test_idempotency.py`)
- [x] `ruff check` clean

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)