### PR TITLE
chore(api): extract gcs_client.py from uploads.py (#195)

### DIFF
--- a/apps/api/src/gcs_client.py
+++ b/apps/api/src/gcs_client.py
@@ -1,0 +1,145 @@
+import base64
+import hashlib
+import time
+from typing import Optional
+
+import httpx
+
+GCS_API_BASE = "https://storage.googleapis.com"
+
+
+def _encode_rfc3986(value: str) -> str:
+    encoded = str(httpx.QueryParams({value: ""}))
+    return encoded.replace("=", "").replace("+", "%20").replace("%7E", "~")
+
+
+def _encode_path(object_key: str) -> str:
+    return "/".join(_encode_rfc3986(segment) for segment in object_key.split("/"))
+
+
+async def _fetch_metadata(pathname: str) -> str:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"http://metadata.google.internal/computeMetadata/v1/{pathname}",
+            headers={"Metadata-Flavor": "Google"},
+            timeout=3.0,
+        )
+    response.raise_for_status()
+    return response.text
+
+
+async def get_gcp_access_token() -> str:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token",
+            headers={"Metadata-Flavor": "Google"},
+            timeout=3.0,
+        )
+    response.raise_for_status()
+    data = response.json()
+    token = data.get("access_token")
+    if not token:
+        raise RuntimeError("METADATA_TOKEN_MISSING")
+    return str(token)
+
+
+async def _sign_string_with_iam(string_to_sign: str, access_token: str, service_account_email: str) -> str:
+    body = {"payload": base64.b64encode(string_to_sign.encode("utf-8")).decode("utf-8")}
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{_encode_rfc3986(service_account_email)}:signBlob",
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "Content-Type": "application/json",
+            },
+            json=body,
+            timeout=5.0,
+        )
+    response.raise_for_status()
+    signed_blob = response.json().get("signedBlob")
+    if not signed_blob:
+        raise RuntimeError("SIGN_BLOB_MISSING")
+    return signed_blob
+
+
+async def _generate_signed_url_v4(
+    bucket: str,
+    object_key: str,
+    expires_in_seconds: int,
+    access_token: str,
+    service_account_email: str,
+    private_key: Optional[str] = None,
+) -> str:
+    now = time.gmtime()
+    datestamp = time.strftime("%Y%m%d", now)
+    timestamp = time.strftime("%Y%m%dT%H%M%SZ", now)
+    credential_scope = f"{datestamp}/auto/storage/goog4_request"
+    credential = f"{service_account_email}/{credential_scope}"
+
+    canonical_query = "&".join(
+        [
+            "X-Goog-Algorithm=GOOG4-RSA-SHA256",
+            f"X-Goog-Credential={_encode_rfc3986(credential)}",
+            f"X-Goog-Date={timestamp}",
+            f"X-Goog-Expires={expires_in_seconds}",
+            "X-Goog-SignedHeaders=host",
+        ]
+    )
+
+    canonical_uri = f"/{bucket}/{_encode_path(object_key)}"
+    canonical_request = "\n".join(
+        [
+            "GET",
+            canonical_uri,
+            canonical_query,
+            "host:storage.googleapis.com",
+            "",
+            "host",
+            "UNSIGNED-PAYLOAD",
+        ]
+    )
+
+    hash_hex = hashlib.sha256(canonical_request.encode("utf-8")).hexdigest()
+    string_to_sign = "\n".join(
+        [
+            "GOOG4-RSA-SHA256",
+            timestamp,
+            credential_scope,
+            hash_hex,
+        ]
+    )
+
+    if private_key:
+        import rsa  # type: ignore
+
+        key = rsa.PrivateKey.load_pkcs1(private_key.encode("utf-8"))
+        signature_bytes = rsa.sign(string_to_sign.encode("utf-8"), key, "SHA-256")
+        signature = signature_bytes.hex()
+    else:
+        signed_blob = await _sign_string_with_iam(string_to_sign, access_token, service_account_email)
+        signature = base64.b64decode(signed_blob).hex()
+
+    return f"{GCS_API_BASE}{canonical_uri}?{canonical_query}&X-Goog-Signature={signature}"
+
+
+async def upload_to_gcs(
+    bucket: str,
+    object_key: str,
+    buffer: bytes,
+    content_type: str,
+    access_token: str,
+) -> None:
+    upload_url = f"{GCS_API_BASE}/upload/storage/v1/b/{_encode_rfc3986(bucket)}/o"
+    params = {"uploadType": "media", "name": object_key}
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            upload_url,
+            params=params,
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "Content-Type": content_type,
+            },
+            content=buffer,
+            timeout=10.0,
+        )
+    response.raise_for_status()

--- a/apps/api/src/multipart_uploads.py
+++ b/apps/api/src/multipart_uploads.py
@@ -35,7 +35,7 @@ import httpx
 from fastapi import UploadFile
 from PIL import Image, ImageOps, UnidentifiedImageError
 
-from . import uploads as legacy_uploads
+from . import gcs_client
 from .settings import settings
 
 logger = logging.getLogger(__name__)
@@ -185,8 +185,8 @@ def _strip_exif_and_resize(raw: bytes, content_type: str) -> bytes:
 
 
 async def _store_in_gcs(filename: str, body: bytes, content_type: str) -> None:
-    access_token = await legacy_uploads.get_gcp_access_token()
-    await legacy_uploads.upload_to_gcs(
+    access_token = await gcs_client.get_gcp_access_token()
+    await gcs_client.upload_to_gcs(
         bucket=settings.uploads_bucket or "",
         object_key=filename,
         buffer=body,

--- a/apps/api/src/uploads.py
+++ b/apps/api/src/uploads.py
@@ -1,6 +1,4 @@
 import asyncio
-import base64
-import hashlib
 import os
 import time
 from pathlib import Path
@@ -10,154 +8,24 @@ from uuid import uuid4
 import httpx
 from fastapi import UploadFile
 
+from .gcs_client import (
+    GCS_API_BASE,
+    _encode_rfc3986,
+    _fetch_metadata,
+    _generate_signed_url_v4,
+    get_gcp_access_token,
+    upload_to_gcs,
+)
 from .settings import settings
 
 MAX_FILE_SIZE_BYTES = 8 * 1024 * 1024
 ALLOWED_MIME_TYPES = {"image/jpeg", "image/png", "image/webp", "image/gif"}
 MAX_PHOTO_COUNT = 10
-GCS_API_BASE = "https://storage.googleapis.com"
 
 
 class SavedUpload(TypedDict, total=False):
     url: str
     filePath: str
-
-
-def _encode_rfc3986(value: str) -> str:
-    encoded = str(httpx.QueryParams({value: ""}))
-    return encoded.replace("=", "").replace("+", "%20").replace("%7E", "~")
-
-
-def _encode_path(object_key: str) -> str:
-    return "/".join(_encode_rfc3986(segment) for segment in object_key.split("/"))
-
-
-async def _fetch_metadata(pathname: str) -> str:
-    async with httpx.AsyncClient() as client:
-        response = await client.get(
-            f"http://metadata.google.internal/computeMetadata/v1/{pathname}",
-            headers={"Metadata-Flavor": "Google"},
-            timeout=3.0,
-        )
-    response.raise_for_status()
-    return response.text
-
-
-async def get_gcp_access_token() -> str:
-    async with httpx.AsyncClient() as client:
-        response = await client.get(
-            "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token",
-            headers={"Metadata-Flavor": "Google"},
-            timeout=3.0,
-        )
-    response.raise_for_status()
-    data = response.json()
-    token = data.get("access_token")
-    if not token:
-        raise RuntimeError("METADATA_TOKEN_MISSING")
-    return str(token)
-
-
-async def _sign_string_with_iam(string_to_sign: str, access_token: str, service_account_email: str) -> str:
-    body = {"payload": base64.b64encode(string_to_sign.encode("utf-8")).decode("utf-8")}
-    async with httpx.AsyncClient() as client:
-        response = await client.post(
-            f"https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{_encode_rfc3986(service_account_email)}:signBlob",
-            headers={
-                "Authorization": f"Bearer {access_token}",
-                "Content-Type": "application/json",
-            },
-            json=body,
-            timeout=5.0,
-        )
-    response.raise_for_status()
-    signed_blob = response.json().get("signedBlob")
-    if not signed_blob:
-        raise RuntimeError("SIGN_BLOB_MISSING")
-    return signed_blob
-
-
-async def _generate_signed_url_v4(
-    bucket: str,
-    object_key: str,
-    expires_in_seconds: int,
-    access_token: str,
-    service_account_email: str,
-    private_key: Optional[str] = None,
-) -> str:
-    now = time.gmtime()
-    datestamp = time.strftime("%Y%m%d", now)
-    timestamp = time.strftime("%Y%m%dT%H%M%SZ", now)
-    credential_scope = f"{datestamp}/auto/storage/goog4_request"
-    credential = f"{service_account_email}/{credential_scope}"
-
-    canonical_query = "&".join(
-        [
-            "X-Goog-Algorithm=GOOG4-RSA-SHA256",
-            f"X-Goog-Credential={_encode_rfc3986(credential)}",
-            f"X-Goog-Date={timestamp}",
-            f"X-Goog-Expires={expires_in_seconds}",
-            "X-Goog-SignedHeaders=host",
-        ]
-    )
-
-    canonical_uri = f"/{bucket}/{_encode_path(object_key)}"
-    canonical_request = "\n".join(
-        [
-            "GET",
-            canonical_uri,
-            canonical_query,
-            "host:storage.googleapis.com",
-            "",
-            "host",
-            "UNSIGNED-PAYLOAD",
-        ]
-    )
-
-    hash_hex = hashlib.sha256(canonical_request.encode("utf-8")).hexdigest()
-    string_to_sign = "\n".join(
-        [
-            "GOOG4-RSA-SHA256",
-            timestamp,
-            credential_scope,
-            hash_hex,
-        ]
-    )
-
-    if private_key:
-        import rsa  # type: ignore
-
-        key = rsa.PrivateKey.load_pkcs1(private_key.encode("utf-8"))
-        signature_bytes = rsa.sign(string_to_sign.encode("utf-8"), key, "SHA-256")
-        signature = signature_bytes.hex()
-    else:
-        signed_blob = await _sign_string_with_iam(string_to_sign, access_token, service_account_email)
-        signature = base64.b64decode(signed_blob).hex()
-
-    return f"{GCS_API_BASE}{canonical_uri}?{canonical_query}&X-Goog-Signature={signature}"
-
-
-async def upload_to_gcs(
-    bucket: str,
-    object_key: str,
-    buffer: bytes,
-    content_type: str,
-    access_token: str,
-) -> None:
-    upload_url = f"{GCS_API_BASE}/upload/storage/v1/b/{_encode_rfc3986(bucket)}/o"
-    params = {"uploadType": "media", "name": object_key}
-    async with httpx.AsyncClient() as client:
-        response = await client.post(
-            upload_url,
-            params=params,
-            headers={
-                "Authorization": f"Bearer {access_token}",
-                "Content-Type": content_type,
-            },
-            content=buffer,
-            timeout=10.0,
-        )
-    response.raise_for_status()
 
 
 async def save_photo_file(file: UploadFile) -> SavedUpload:

--- a/apps/api/tests/unit/test_multipart_uploads.py
+++ b/apps/api/tests/unit/test_multipart_uploads.py
@@ -202,10 +202,10 @@ async def test_gcs_happy_path_writes_via_legacy_helpers(monkeypatch, tmp_path):
         captured.update(kwargs)
 
     monkeypatch.setattr(
-        multipart_uploads.legacy_uploads, "get_gcp_access_token", fake_get_token
+        multipart_uploads.gcs_client, "get_gcp_access_token", fake_get_token
     )
     monkeypatch.setattr(
-        multipart_uploads.legacy_uploads, "upload_to_gcs", fake_upload_to_gcs
+        multipart_uploads.gcs_client, "upload_to_gcs", fake_upload_to_gcs
     )
 
     upload = _make_upload(_jpeg_bytes(800, 600), "ok.jpg", "image/jpeg")
@@ -241,9 +241,9 @@ async def test_gcs_failure_in_dev_falls_back_to_local_write(monkeypatch, tmp_pat
         return "fake-token"
 
     monkeypatch.setattr(
-        multipart_uploads.legacy_uploads, "get_gcp_access_token", fake_get_token
+        multipart_uploads.gcs_client, "get_gcp_access_token", fake_get_token
     )
-    monkeypatch.setattr(multipart_uploads.legacy_uploads, "upload_to_gcs", boom)
+    monkeypatch.setattr(multipart_uploads.gcs_client, "upload_to_gcs", boom)
 
     upload = _make_upload(_jpeg_bytes(400, 400), "ok.jpg", "image/jpeg")
 
@@ -268,9 +268,9 @@ async def test_gcs_failure_in_production_raises_storage_unavailable(monkeypatch)
         return "fake-token"
 
     monkeypatch.setattr(
-        multipart_uploads.legacy_uploads, "get_gcp_access_token", fake_get_token
+        multipart_uploads.gcs_client, "get_gcp_access_token", fake_get_token
     )
-    monkeypatch.setattr(multipart_uploads.legacy_uploads, "upload_to_gcs", boom)
+    monkeypatch.setattr(multipart_uploads.gcs_client, "upload_to_gcs", boom)
 
     upload = _make_upload(_jpeg_bytes(400, 400), "ok.jpg", "image/jpeg")
 

--- a/apps/api/tests/unit/test_uploads.py
+++ b/apps/api/tests/unit/test_uploads.py
@@ -461,7 +461,7 @@ class TestSavePhotoFile:
         with patch("src.uploads.settings") as mock_settings:
             mock_settings.uploads_bucket = "test-bucket"
 
-            with patch("src.gcs_client.get_gcp_access_token", side_effect=Exception("GCP Error")):
+            with patch("src.uploads.get_gcp_access_token", side_effect=Exception("GCP Error")):
                 with patch.object(Path, "mkdir"):
                     with patch.object(Path, "write_bytes"):
                         result = await save_photo_file(mock_file)
@@ -555,7 +555,7 @@ class TestDeleteUploads:
         with patch("src.uploads.settings") as mock_settings:
             mock_settings.uploads_bucket = "test-bucket"
 
-            with patch("src.gcs_client.get_gcp_access_token", side_effect=Exception("GCP Error")):
+            with patch("src.uploads.get_gcp_access_token", side_effect=Exception("GCP Error")):
                 with patch.object(Path, "unlink") as mock_unlink:
                     await delete_uploads(["/uploads/test.jpg"])
 

--- a/apps/api/tests/unit/test_uploads.py
+++ b/apps/api/tests/unit/test_uploads.py
@@ -5,15 +5,17 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 
-from src.uploads import (
-    MAX_FILE_SIZE_BYTES,
-    ALLOWED_MIME_TYPES,
-    MAX_PHOTO_COUNT,
+from src.gcs_client import (
     _fetch_metadata,
     get_gcp_access_token,
     _sign_string_with_iam,
     _generate_signed_url_v4,
     upload_to_gcs,
+)
+from src.uploads import (
+    MAX_FILE_SIZE_BYTES,
+    ALLOWED_MIME_TYPES,
+    MAX_PHOTO_COUNT,
     create_signed_url_resolver,
     get_signed_upload_url,
     save_photo_file,
@@ -48,7 +50,7 @@ class TestConstants:
 
 class TestEncodeRfc3986:
     """Test RFC3986 encoding helper.
-    
+
     Note: The _encode_rfc3986 function uses httpx.QueryParams which may have
     compatibility issues across versions. These tests verify the function exists
     and mock its behavior where needed.
@@ -56,19 +58,19 @@ class TestEncodeRfc3986:
 
     def test_function_exists(self):
         """Verify the function is importable."""
-        from src.uploads import _encode_rfc3986
+        from src.gcs_client import _encode_rfc3986
         assert callable(_encode_rfc3986)
 
 
 class TestEncodePath:
     """Test path encoding for GCS URLs.
-    
+
     Note: Uses _encode_rfc3986 internally which may have httpx version issues.
     """
 
     def test_function_exists(self):
         """Verify the function is importable."""
-        from src.uploads import _encode_path
+        from src.gcs_client import _encode_path
         assert callable(_encode_path)
 
 
@@ -85,7 +87,7 @@ class TestFetchMetadata:
         mock_response.text = "test-email@project.iam.gserviceaccount.com"
         mock_response.raise_for_status = MagicMock()
 
-        with patch("src.uploads.httpx.AsyncClient") as mock_client:
+        with patch("src.gcs_client.httpx.AsyncClient") as mock_client:
             mock_instance = AsyncMock()
             mock_instance.get = AsyncMock(return_value=mock_response)
             mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
@@ -102,7 +104,7 @@ class TestFetchMetadata:
             "Not Found", request=MagicMock(), response=MagicMock()
         )
 
-        with patch("src.uploads.httpx.AsyncClient") as mock_client:
+        with patch("src.gcs_client.httpx.AsyncClient") as mock_client:
             mock_instance = AsyncMock()
             mock_instance.get = AsyncMock(return_value=mock_response)
             mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
@@ -122,7 +124,7 @@ class TestGetGcpAccessToken:
         mock_response.json.return_value = {"access_token": "ya29.test-token"}
         mock_response.raise_for_status = MagicMock()
 
-        with patch("src.uploads.httpx.AsyncClient") as mock_client:
+        with patch("src.gcs_client.httpx.AsyncClient") as mock_client:
             mock_instance = AsyncMock()
             mock_instance.get = AsyncMock(return_value=mock_response)
             mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
@@ -138,7 +140,7 @@ class TestGetGcpAccessToken:
         mock_response.json.return_value = {}
         mock_response.raise_for_status = MagicMock()
 
-        with patch("src.uploads.httpx.AsyncClient") as mock_client:
+        with patch("src.gcs_client.httpx.AsyncClient") as mock_client:
             mock_instance = AsyncMock()
             mock_instance.get = AsyncMock(return_value=mock_response)
             mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
@@ -158,14 +160,14 @@ class TestSignStringWithIam:
         mock_response.json.return_value = {"signedBlob": "c2lnbmVkLWRhdGE="}
         mock_response.raise_for_status = MagicMock()
 
-        with patch("src.uploads.httpx.AsyncClient") as mock_client:
+        with patch("src.gcs_client.httpx.AsyncClient") as mock_client:
             mock_instance = AsyncMock()
             mock_instance.post = AsyncMock(return_value=mock_response)
             mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
             mock_instance.__aexit__ = AsyncMock(return_value=None)
             mock_client.return_value = mock_instance
 
-            with patch("src.uploads._encode_rfc3986", side_effect=lambda x: x):
+            with patch("src.gcs_client._encode_rfc3986", side_effect=lambda x: x):
                 result = await _sign_string_with_iam(
                     "string-to-sign",
                     "access-token",
@@ -179,14 +181,14 @@ class TestSignStringWithIam:
         mock_response.json.return_value = {}
         mock_response.raise_for_status = MagicMock()
 
-        with patch("src.uploads.httpx.AsyncClient") as mock_client:
+        with patch("src.gcs_client.httpx.AsyncClient") as mock_client:
             mock_instance = AsyncMock()
             mock_instance.post = AsyncMock(return_value=mock_response)
             mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
             mock_instance.__aexit__ = AsyncMock(return_value=None)
             mock_client.return_value = mock_instance
 
-            with patch("src.uploads._encode_rfc3986", side_effect=lambda x: x):
+            with patch("src.gcs_client._encode_rfc3986", side_effect=lambda x: x):
                 with pytest.raises(RuntimeError, match="SIGN_BLOB_MISSING"):
                     await _sign_string_with_iam(
                         "string-to-sign",
@@ -207,14 +209,14 @@ class TestUploadToGcs:
         mock_response = MagicMock()
         mock_response.raise_for_status = MagicMock()
 
-        with patch("src.uploads.httpx.AsyncClient") as mock_client:
+        with patch("src.gcs_client.httpx.AsyncClient") as mock_client:
             mock_instance = AsyncMock()
             mock_instance.post = AsyncMock(return_value=mock_response)
             mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
             mock_instance.__aexit__ = AsyncMock(return_value=None)
             mock_client.return_value = mock_instance
 
-            with patch("src.uploads._encode_rfc3986", side_effect=lambda x: x):
+            with patch("src.gcs_client._encode_rfc3986", side_effect=lambda x: x):
                 await upload_to_gcs(
                     bucket="test-bucket",
                     object_key="uploads/test.jpg",
@@ -237,12 +239,12 @@ class TestGenerateSignedUrlV4:
 
     @pytest.mark.asyncio
     async def test_generates_signed_url_with_iam(self):
-        with patch("src.uploads._sign_string_with_iam") as mock_sign:
+        with patch("src.gcs_client._sign_string_with_iam") as mock_sign:
             # Return base64 encoded signature
             mock_sign.return_value = "c2lnbmVkLWRhdGE="
 
-            with patch("src.uploads._encode_rfc3986", side_effect=lambda x: x.replace(" ", "%20")):
-                with patch("src.uploads._encode_path", side_effect=lambda x: x):
+            with patch("src.gcs_client._encode_rfc3986", side_effect=lambda x: x.replace(" ", "%20")):
+                with patch("src.gcs_client._encode_path", side_effect=lambda x: x):
                     result = await _generate_signed_url_v4(
                         bucket="test-bucket",
                         object_key="uploads/photo.jpg",
@@ -259,11 +261,11 @@ class TestGenerateSignedUrlV4:
 
     @pytest.mark.asyncio
     async def test_includes_expiry_parameter(self):
-        with patch("src.uploads._sign_string_with_iam") as mock_sign:
+        with patch("src.gcs_client._sign_string_with_iam") as mock_sign:
             mock_sign.return_value = "c2lnbmVkLWRhdGE="
 
-            with patch("src.uploads._encode_rfc3986", side_effect=lambda x: x.replace(" ", "%20")):
-                with patch("src.uploads._encode_path", side_effect=lambda x: x):
+            with patch("src.gcs_client._encode_rfc3986", side_effect=lambda x: x.replace(" ", "%20")):
+                with patch("src.gcs_client._encode_path", side_effect=lambda x: x):
                     result = await _generate_signed_url_v4(
                         bucket="test-bucket",
                         object_key="photo.jpg",
@@ -459,7 +461,7 @@ class TestSavePhotoFile:
         with patch("src.uploads.settings") as mock_settings:
             mock_settings.uploads_bucket = "test-bucket"
 
-            with patch("src.uploads.get_gcp_access_token", side_effect=Exception("GCP Error")):
+            with patch("src.gcs_client.get_gcp_access_token", side_effect=Exception("GCP Error")):
                 with patch.object(Path, "mkdir"):
                     with patch.object(Path, "write_bytes"):
                         result = await save_photo_file(mock_file)
@@ -533,8 +535,8 @@ class TestDeleteUploads:
             mock_settings.uploads_bucket = "test-bucket"
 
             with patch("src.uploads.get_gcp_access_token", return_value="token"):
-                with patch("src.uploads._encode_rfc3986", side_effect=lambda x: x):
-                    with patch("src.uploads.httpx.AsyncClient") as mock_client:
+                with patch("src.gcs_client._encode_rfc3986", side_effect=lambda x: x):
+                    with patch("src.gcs_client.httpx.AsyncClient") as mock_client:
                         mock_instance = AsyncMock()
                         mock_instance.delete = AsyncMock()
                         mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
@@ -553,7 +555,7 @@ class TestDeleteUploads:
         with patch("src.uploads.settings") as mock_settings:
             mock_settings.uploads_bucket = "test-bucket"
 
-            with patch("src.uploads.get_gcp_access_token", side_effect=Exception("GCP Error")):
+            with patch("src.gcs_client.get_gcp_access_token", side_effect=Exception("GCP Error")):
                 with patch.object(Path, "unlink") as mock_unlink:
                     await delete_uploads(["/uploads/test.jpg"])
 


### PR DESCRIPTION
## Summary

- Extracts all GCS plumbing from `src/uploads.py` into a new `src/gcs_client.py` module (`get_gcp_access_token`, `upload_to_gcs`, `_generate_signed_url_v4`, `_sign_string_with_iam`, `_fetch_metadata`, `_encode_rfc3986`, `_encode_path`, `GCS_API_BASE`)
- `uploads.py` re-exports those names so existing callers are unaffected; `multipart_uploads.py` now imports from `gcs_client` directly, eliminating the `legacy_uploads` coupling
- Test patch paths updated to match the new module boundaries (GCS-layer tests patch `src.gcs_client.*`; `save_photo_file`/`delete_uploads`/`get_signed_upload_url` tests continue to patch `src.uploads.*` since `uploads.py` holds those imported names)
- Pure refactor — OpenAPI snapshot unchanged, 193 unit tests pass

## Test plan

- [x] `pytest tests/unit/test_uploads.py tests/unit/test_multipart_uploads.py` — 57/57 passed
- [x] `pytest tests/unit/` — 193/193 passed
- [x] `python scripts/dump_openapi.py` — snapshot diff is empty (no contract change)
- [ ] CI green on push

Closes #195

🤖 Generated with [Claude Code](https://claude.ai/claude-code)