### PR TITLE
chore(api): fix wrong httpx patch target in test_deletes_from_gcs_when_bucket_configured

### DIFF
--- a/apps/api/tests/unit/test_uploads.py
+++ b/apps/api/tests/unit/test_uploads.py
@@ -535,7 +535,8 @@ class TestDeleteUploads:
             mock_settings.uploads_bucket = "test-bucket"
 
             with patch("src.uploads.get_gcp_access_token", return_value="token"):
-                with patch("src.gcs_client._encode_rfc3986", side_effect=lambda x: x):
+                # Patch where each name is used (uploads.py), not where it's defined.
+                with patch("src.uploads._encode_rfc3986", side_effect=lambda x: x):
                     with patch("src.uploads.httpx.AsyncClient") as mock_client:
                         mock_instance = AsyncMock()
                         mock_instance.delete = AsyncMock()

--- a/apps/api/tests/unit/test_uploads.py
+++ b/apps/api/tests/unit/test_uploads.py
@@ -536,7 +536,7 @@ class TestDeleteUploads:
 
             with patch("src.uploads.get_gcp_access_token", return_value="token"):
                 with patch("src.gcs_client._encode_rfc3986", side_effect=lambda x: x):
-                    with patch("src.gcs_client.httpx.AsyncClient") as mock_client:
+                    with patch("src.uploads.httpx.AsyncClient") as mock_client:
                         mock_instance = AsyncMock()
                         mock_instance.delete = AsyncMock()
                         mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)


### PR DESCRIPTION
Closes #227

## Summary
- `test_deletes_from_gcs_when_bucket_configured` was patching `src.gcs_client.httpx.AsyncClient` and `src.gcs_client._encode_rfc3986`, but both names are imported directly into `uploads.py` — so both patches were missing the actual call sites
- Correct targets are `src.uploads.httpx.AsyncClient` and `src.uploads._encode_rfc3986`
- Added a comment explaining the "patch where it's used, not where it's defined" rule to prevent the same regression

## Test plan
- [x] `pytest apps/api/tests/unit/test_uploads.py` — 47 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)